### PR TITLE
Remove host from url.Opaque

### DIFF
--- a/request.go
+++ b/request.go
@@ -159,9 +159,9 @@ func httpNewRequest(method, urlStr string, body io.Reader) (*http.Request, error
 		if err != nil {
 			return nil, err
 		}
-		uEncoded.Opaque = "//" + uEncoded.Host + separator + bucketName + separator + encodedObjectName
+		uEncoded.Opaque = separator + bucketName + separator + encodedObjectName
 	} else {
-		uEncoded.Opaque = "//" + uEncoded.Host + separator + bucketName
+		uEncoded.Opaque = separator + bucketName
 	}
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {
@@ -417,12 +417,9 @@ func (r *request) getSignedHeaders() string {
 func (r *request) getCanonicalRequest(hashedPayload string) string {
 	r.req.URL.RawQuery = strings.Replace(r.req.URL.Query().Encode(), "+", "%20", -1)
 
-	// get path URI from Opaque
-	uri := strings.Join(strings.Split(r.req.URL.Opaque, "/")[3:], "/")
-
 	canonicalRequest := strings.Join([]string{
 		r.req.Method,
-		"/" + uri,
+		r.req.URL.Opaque,
 		r.req.URL.RawQuery,
 		r.getCanonicalHeaders(),
 		r.getSignedHeaders(),


### PR DESCRIPTION
## Summary
This addresses #167 

## Analysis
The `Opaque` in the `URL` structure ultimately lead to the issue in #167, which had the request not just allowing unicode urls (the expected result), but also not scrubbing -anything-... including the host info (unexpected).

While RFC 2616 allows this ( see http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2 )the result affects openstack's conservative swift3 middleware. The middleware seems to identify and parse the parts of the url correctly, but otherwise doesn't know how to treat the scheme and host details in the URI and fails rather than guess (after all, the middleware doesn't even know that the host details are its own).

## Regressions
This should work fine, because the .Host field in the http.Request had ought to keep special characters (In fact, I think Url.Opaque only exists for avoiding fanciness in the Request URI), however, care should be taken all the same. If a future version of http messes with 'Host', I'm thinking the only real solution would be to dig even deeper into the Url object.

## Notes
I've already run go test on this, however I haven't been able to run the test suite for mc due to gopkg.in/check.v1 not being vendored in.

Should I also make a PR to minio/mc for adding the check.v1 to vendor?