### PR TITLE
Golang net/url behaves differently when url.Opaque is set handle it

### DIFF
--- a/api_handlers_test.go
+++ b/api_handlers_test.go
@@ -56,8 +56,19 @@ func (h bucketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case r.URL.Path == h.resource:
 			_, ok := r.URL.Query()["acl"]
 			if ok {
-				if r.Header.Get("x-amz-acl") != "public-read-write" {
+				switch r.Header.Get("x-amz-acl") {
+				case "public-read-write":
+					fallthrough
+				case "public-read":
+					fallthrough
+				case "private":
+					fallthrough
+				case "authenticated-read":
+					w.WriteHeader(http.StatusOK)
+					return
+				default:
 					w.WriteHeader(http.StatusNotImplemented)
+					return
 				}
 			}
 			w.WriteHeader(http.StatusOK)

--- a/request.go
+++ b/request.go
@@ -467,7 +467,7 @@ func (r *request) PreSignV4() (string, error) {
 		return "", errors.New("presign requires accesskey and secretkey")
 	}
 	r.SignV4()
-	return r.req.URL.String(), nil
+	return r.req.URL.Scheme + "://" + r.req.URL.Host + r.req.URL.Path + "?" + r.req.URL.RawQuery, nil
 }
 
 // SignV4 the request before Do(), in accordance with - http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html


### PR DESCRIPTION
url.Opaque once set url.String() by default just replies url.Opaque.

This is not an ideal scenario, since we need to know the full URL many times.