### PR TITLE
All keys and marker should be encoded properly

### DIFF
--- a/api-core.go
+++ b/api-core.go
@@ -266,10 +266,10 @@ func (a apiCore) listObjectsRequest(bucket, marker, prefix, delimiter string, ma
 	resourceQuery := func() (*string, error) {
 		switch {
 		case marker != "":
-			marker = fmt.Sprintf("&marker=%s", marker)
+			marker = fmt.Sprintf("&marker=%s", getURLEncodedPath(marker))
 			fallthrough
 		case prefix != "":
-			prefix = fmt.Sprintf("&prefix=%s", prefix)
+			prefix = fmt.Sprintf("&prefix=%s", getURLEncodedPath(prefix))
 			fallthrough
 		case delimiter != "":
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)

--- a/api-multipart-core.go
+++ b/api-multipart-core.go
@@ -34,13 +34,13 @@ func (a apiCore) listMultipartUploadsRequest(bucket, keymarker, uploadIDMarker, 
 	resourceQuery := func() (string, error) {
 		switch {
 		case keymarker != "":
-			keymarker = fmt.Sprintf("&key-marker=%s", keymarker)
+			keymarker = fmt.Sprintf("&key-marker=%s", getURLEncodedPath(keymarker))
 			fallthrough
 		case uploadIDMarker != "":
 			uploadIDMarker = fmt.Sprintf("&upload-id-marker=%s", uploadIDMarker)
 			fallthrough
 		case prefix != "":
-			prefix = fmt.Sprintf("&prefix=%s", prefix)
+			prefix = fmt.Sprintf("&prefix=%s", getURLEncodedPath(prefix))
 			fallthrough
 		case delimiter != "":
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)


### PR DESCRIPTION
A key not being encoded, leads to S3 sending same 1000 requests again and again.