### PR TITLE
doc: More simplification

### DIFF
--- a/bucket-acl.go
+++ b/bucket-acl.go
@@ -16,10 +16,10 @@
 
 package minio
 
-// BucketACL - bucket level access control
+// BucketACL - bucket level access control.
 type BucketACL string
 
-// different types of ACL's currently supported for buckets
+// Different types of ACL's currently supported for buckets.
 const (
 	bucketPrivate       = BucketACL("private")
 	bucketReadOnly      = BucketACL("public-read")
@@ -27,7 +27,7 @@ const (
 	bucketAuthenticated = BucketACL("authenticated-read")
 )
 
-// String printer helper
+// Stringify acl.
 func (b BucketACL) String() string {
 	if string(b) == "" {
 		return "private"
@@ -35,7 +35,7 @@ func (b BucketACL) String() string {
 	return string(b)
 }
 
-// isValidBucketACL - is provided acl string supported
+// isValidBucketACL - is provided acl string supported.
 func (b BucketACL) isValidBucketACL() bool {
 	switch true {
 	case b.isPrivate():
@@ -54,22 +54,22 @@ func (b BucketACL) isValidBucketACL() bool {
 	}
 }
 
-// IsPrivate - is acl Private
+// isPrivate - is acl Private.
 func (b BucketACL) isPrivate() bool {
 	return b == bucketPrivate
 }
 
-// IsPublicRead - is acl PublicRead
+// isPublicRead - is acl PublicRead.
 func (b BucketACL) isReadOnly() bool {
 	return b == bucketReadOnly
 }
 
-// IsPublicReadWrite - is acl PublicReadWrite
+// isPublicReadWrite - is acl PublicReadWrite.
 func (b BucketACL) isPublic() bool {
 	return b == bucketPublic
 }
 
-// IsAuthenticated - is acl AuthenticatedRead
+// isAuthenticated - is acl AuthenticatedRead.
 func (b BucketACL) isAuthenticated() bool {
 	return b == bucketAuthenticated
 }

--- a/errors.go
+++ b/errors.go
@@ -49,17 +49,16 @@ type ErrorResponse struct {
 // ToErrorResponse returns parsed ErrorResponse struct, if input is nil or not ErrorResponse return value is nil
 // this fuction is useful when some one wants to dig deeper into the error structures over the network.
 //
-// for example:
+// For example:
 //
 //   import s3 "github.com/minio/minio-go"
 //   ...
 //   ...
-//   ..., err := s3.GetObject(...)
+//   reader, stat, err := s3.GetObject(...)
 //   if err != nil {
 //      resp := s3.ToErrorResponse(err)
 //      fmt.Println(resp.ToXML())
 //   }
-//   ...
 //   ...
 func ToErrorResponse(err error) *ErrorResponse {
 	switch err := err.(type) {

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,65 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"io"
+	"time"
+)
+
+// CloudStorageAPI - Cloud Storage API interface
+type CloudStorageAPI interface {
+	// Bucket Read/Write/Stat operations
+	BucketAPI
+
+	// Object Read/Write/Stat operations
+	ObjectAPI
+
+	// Presigned API
+	PresignedAPI
+}
+
+// BucketAPI - bucket specific Read/Write/Stat interface.
+type BucketAPI interface {
+	MakeBucket(bucket string, cannedACL BucketACL) error
+	BucketExists(bucket string) error
+	RemoveBucket(bucket string) error
+	SetBucketACL(bucket string, cannedACL BucketACL) error
+	GetBucketACL(bucket string) (BucketACL, error)
+
+	ListBuckets() <-chan BucketStatCh
+	ListObjects(bucket, prefix string, recursive bool) <-chan ObjectStatCh
+	ListIncompleteUploads(bucket, prefix string, recursive bool) <-chan ObjectMultipartStatCh
+}
+
+// ObjectAPI - object specific Read/Write/Stat interface.
+type ObjectAPI interface {
+	GetObject(bucket, object string) (io.ReadCloser, ObjectStat, error)
+	GetPartialObject(bucket, object string, offset, length int64) (io.ReadCloser, ObjectStat, error)
+	PutObject(bucket, object, contentType string, size int64, data io.Reader) error
+	StatObject(bucket, object string) (ObjectStat, error)
+	RemoveObject(bucket, object string) error
+
+	RemoveIncompleteUpload(bucket, object string) <-chan error
+}
+
+// PresignedAPI - Get/Put/Post.
+type PresignedAPI interface {
+	PresignedGetObject(bucket, object string, expires time.Duration) (string, error)
+	PresignedPutObject(bucket, object string, expires time.Duration) (string, error)
+	PresignedPostPolicy(*PostPolicy) (map[string]string, error)
+}


### PR DESCRIPTION
Move interface into its own file as CloudStorageAPI. Which captures
a minimal interface for all cloud storage clients.

Export the "minio.API" struct so that the internal methods are now
exposed and have their documentation listed out.

minio.API delegates methods to comply with CloudStorageAPI interface.