### PR TITLE
Revert "remove: remove incomplete shouldn't fail ob object being null"

### DIFF
--- a/api.go
+++ b/api.go
@@ -1070,6 +1070,10 @@ func (a API) removeIncompleteUploadInRoutine(bucket, object string, errorCh chan
 		errorCh <- err
 		return
 	}
+	if err := invalidObjectError(object); err != nil {
+		errorCh <- err
+		return
+	}
 	listMultipartUplResult, err := a.listMultipartUploads(bucket, "", "", object, "", 1000)
 	if err != nil {
 		errorCh <- err


### PR DESCRIPTION
This reverts commit 1d0c5cb797dbc09ba55027e89dca852f9a847df7.