### PR TITLE
minio-go: Go API cleanup.

### DIFF
--- a/parts-manager.go
+++ b/parts-manager.go
@@ -23,8 +23,8 @@ import (
 	"io"
 )
 
-// partsManager reads from io.Reader, partitions data into individual partMetadata{}, backed by a
-// temporary file which deletes itself upon Close().
+// partsManager reads from io.Reader, partitions data into individual *partMetadata{}*.
+// backed by a temporary file which purges itself upon Close().
 //
 // This method runs until an EOF or an error occurs. Before returning, the channel is always closed.
 func partsManager(reader io.Reader, partSize int64, isEnableSha256Sum bool) <-chan partMetadata {

--- a/post-policy.go
+++ b/post-policy.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// expirationDateFormat date format for expiration key in json policy
+// expirationDateFormat date format for expiration key in json policy.
 const expirationDateFormat = "2006-01-02T15:04:05.999Z"
 
 // policyCondition explanation: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
@@ -33,15 +33,15 @@ type PostPolicy struct {
 	conditions []policyCondition // collection of different policy conditions.
 	// contentLengthRange minimum and maximum allowable size for the uploaded content.
 	contentLengthRange struct {
-		min int
-		max int
+		min int64
+		max int64
 	}
 
-	// Post form data
+	// Post form data.
 	formData map[string]string
 }
 
-// NewPostPolicy instantiate new post policy
+// NewPostPolicy instantiate new post policy.
 func NewPostPolicy() *PostPolicy {
 	p := &PostPolicy{}
 	p.conditions = make([]policyCondition, 0)
@@ -49,7 +49,7 @@ func NewPostPolicy() *PostPolicy {
 	return p
 }
 
-// SetExpires expiration time
+// SetExpires expiration time.
 func (p *PostPolicy) SetExpires(t time.Time) error {
 	if t.IsZero() {
 		return errors.New("No expiry time set.")
@@ -58,7 +58,7 @@ func (p *PostPolicy) SetExpires(t time.Time) error {
 	return nil
 }
 
-// SetKey Object name
+// SetKey Object name.
 func (p *PostPolicy) SetKey(key string) error {
 	if strings.TrimSpace(key) == "" || key == "" {
 		return errors.New("Object name is not specified.")
@@ -75,7 +75,7 @@ func (p *PostPolicy) SetKey(key string) error {
 	return nil
 }
 
-// SetKeyStartsWith Object name that can start with
+// SetKeyStartsWith Object name that can start with.
 func (p *PostPolicy) SetKeyStartsWith(keyStartsWith string) error {
 	if strings.TrimSpace(keyStartsWith) == "" || keyStartsWith == "" {
 		return errors.New("Object prefix is not specified.")
@@ -92,24 +92,24 @@ func (p *PostPolicy) SetKeyStartsWith(keyStartsWith string) error {
 	return nil
 }
 
-// SetBucket bucket name
-func (p *PostPolicy) SetBucket(bucket string) error {
-	if strings.TrimSpace(bucket) == "" || bucket == "" {
+// SetBucket bucket name.
+func (p *PostPolicy) SetBucket(bucketName string) error {
+	if strings.TrimSpace(bucketName) == "" || bucketName == "" {
 		return errors.New("Bucket name is not specified.")
 	}
 	policyCond := policyCondition{
 		matchType: "eq",
 		condition: "$bucket",
-		value:     bucket,
+		value:     bucketName,
 	}
 	if err := p.addNewPolicy(policyCond); err != nil {
 		return err
 	}
-	p.formData["bucket"] = bucket
+	p.formData["bucket"] = bucketName
 	return nil
 }
 
-// SetContentType content-type
+// SetContentType content-type.
 func (p *PostPolicy) SetContentType(contentType string) error {
 	if strings.TrimSpace(contentType) == "" || contentType == "" {
 		return errors.New("No content type specified.")
@@ -126,23 +126,23 @@ func (p *PostPolicy) SetContentType(contentType string) error {
 	return nil
 }
 
-// SetContentLength - set new min and max content length condition
-func (p *PostPolicy) SetContentLength(min, max int) error {
+// SetContentLengthRange - set new min and max content length condition.
+func (p *PostPolicy) SetContentLengthRange(min, max int64) error {
 	if min > max {
-		return errors.New("Content length minimum-limit is larger than maximum-limit.")
+		return errors.New("minimum limit is larger than maximum limit")
 	}
 	if min < 0 {
-		return errors.New("Content length minimum-limit is negative.")
+		return errors.New("minimum limit cannot be negative")
 	}
 	if max < 0 {
-		return errors.New("Content length maximum-limit is negative")
+		return errors.New("maximum limit cannot be negative")
 	}
 	p.contentLengthRange.min = min
 	p.contentLengthRange.max = max
 	return nil
 }
 
-// addNewPolicy - internal helper to validate adding new policies
+// addNewPolicy - internal helper to validate adding new policies.
 func (p *PostPolicy) addNewPolicy(policyCond policyCondition) error {
 	if policyCond.matchType == "" || policyCond.condition == "" || policyCond.value == "" {
 		return errors.New("Policy fields empty.")
@@ -151,12 +151,12 @@ func (p *PostPolicy) addNewPolicy(policyCond policyCondition) error {
 	return nil
 }
 
-// Stringer interface for printing in pretty manner
+// Stringer interface for printing in pretty manner.
 func (p PostPolicy) String() string {
 	return string(p.marshalJSON())
 }
 
-// marshalJSON provides Marshalled JSON
+// marshalJSON provides Marshalled JSON.
 func (p PostPolicy) marshalJSON() []byte {
 	expirationStr := `"expiration":"` + p.expiration.Format(expirationDateFormat) + `"`
 	var conditionsStr string
@@ -178,7 +178,7 @@ func (p PostPolicy) marshalJSON() []byte {
 	return []byte(retStr)
 }
 
-// base64 produces base64 of PostPolicy's Marshalled json
+// base64 produces base64 of PostPolicy's Marshalled json.
 func (p PostPolicy) base64() string {
 	return base64.StdEncoding.EncodeToString(p.marshalJSON())
 }

--- a/request-signature-v2.go
+++ b/request-signature-v2.go
@@ -34,8 +34,9 @@ import (
 // PreSignV2 - presign the request in following style.
 // https://${S3_BUCKET}.s3.amazonaws.com/${S3_OBJECT}?AWSAccessKeyId=${S3_ACCESS_KEY}&Expires=${TIMESTAMP}&Signature=${SIGNATURE}
 func (r *Request) PreSignV2() (string, error) {
+	// if config is anonymous then presigning cannot be achieved, throw an error.
 	if r.config.isAnonymous() {
-		return "", errors.New("presigning cannot be done with anonymous credentials")
+		return "", errors.New("Presigning cannot be achieved with anonymous credentials")
 	}
 	d := time.Now().UTC()
 	// Add date if not present

--- a/request.go
+++ b/request.go
@@ -198,8 +198,9 @@ func (op *operation) getRequestURL(config Config) (url string) {
 	return
 }
 
+// newPresignedRequest - provides a new instance of *Request* for presign operations.
 func newPresignedRequest(op *operation, config *Config, expires int64) (*Request, error) {
-	// if no method default to POST
+	// if no method default to POST.
 	method := op.HTTPMethod
 	if method == "" {
 		method = "POST"
@@ -207,16 +208,16 @@ func newPresignedRequest(op *operation, config *Config, expires int64) (*Request
 
 	u := op.getRequestURL(*config)
 
-	// get a new HTTP request, for the requested method
+	// get a new HTTP request, for the requested method.
 	req, err := http.NewRequest(method, u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	// set UserAgent
+	// set UserAgent.
 	req.Header.Set("User-Agent", config.userAgent)
 
-	// save for subsequent use
+	// save for subsequent use.
 	r := new(Request)
 	r.config = config
 	r.expires = expires
@@ -225,25 +226,25 @@ func newPresignedRequest(op *operation, config *Config, expires int64) (*Request
 	return r, nil
 }
 
-// newRequest - instantiate a new request
+// newRequest - provides a new instance of *Request*.
 func newRequest(op *operation, config *Config, metadata requestMetadata) (*Request, error) {
-	// if no method default to POST
+	// if no method default to POST.
 	method := op.HTTPMethod
 	if method == "" {
 		method = "POST"
 	}
 
 	u := op.getRequestURL(*config)
-	// get a new HTTP request, for the requested method
+	// get a new HTTP request, for the requested method.
 	req, err := http.NewRequest(method, u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	// set UserAgent
+	// set UserAgent.
 	req.Header.Set("User-Agent", config.userAgent)
 
-	// add body
+	// add body.
 	switch {
 	case metadata.body == nil:
 		req.Body = nil
@@ -251,7 +252,7 @@ func newRequest(op *operation, config *Config, metadata requestMetadata) (*Reque
 		req.Body = metadata.body
 	}
 
-	// save for subsequent use
+	// save for subsequent use.
 	r := new(Request)
 	r.config = config
 	r.req = req
@@ -273,7 +274,7 @@ func newRequest(op *operation, config *Config, metadata requestMetadata) (*Reque
 			r.Set("X-Amz-Content-Sha256", hex.EncodeToString(metadata.sha256PayloadBytes))
 		}
 	}
-	// set md5Sum for in transit corruption detection.
+	// set md5Sum for content protection.
 	if metadata.md5SumPayloadBytes != nil {
 		r.Set("Content-MD5", base64.StdEncoding.EncodeToString(metadata.md5SumPayloadBytes))
 	}

--- a/s3-api-errors.go
+++ b/s3-api-errors.go
@@ -22,24 +22,24 @@ import "net/http"
 //
 // For path style requests on buckets with wrong endpoint s3 returns back a
 // generic error. Following block of code tries to make this meaningful for
-// the user by fetching the proper endpoint. Additionally also sets AmzBucketRegion.
-func (a s3API) handleStatusMovedPermanently(resp *http.Response, bucket, object string) ErrorResponse {
+// the user by fetching the proper endpoint. Additionally it also sets AmzBucketRegion.
+func (a s3API) handleStatusMovedPermanently(resp *http.Response, bucketName, objectName string) ErrorResponse {
 	errorResponse := ErrorResponse{
 		Code:            "PermanentRedirect",
 		RequestID:       resp.Header.Get("x-amz-request-id"),
 		HostID:          resp.Header.Get("x-amz-id-2"),
 		AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
 	}
-	errorResponse.Resource = separator + bucket
-	if object != "" {
-		errorResponse.Resource = separator + bucket + separator + object
+	errorResponse.Resource = separator + bucketName
+	if objectName != "" {
+		errorResponse.Resource = separator + bucketName + separator + objectName
 	}
 	var endPoint string
 	if errorResponse.AmzBucketRegion != "" {
 		region := errorResponse.AmzBucketRegion
 		endPoint = getEndpoint(region)
 	} else {
-		region, err := a.getBucketLocation(bucket)
+		region, err := a.getBucketLocation(bucketName)
 		if err != nil {
 			return *ToErrorResponse(err)
 		}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,58 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// isValidBucketName - verify bucket name in accordance with
+//  - http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
+func isValidBucketName(bucketName string) bool {
+	if strings.TrimSpace(bucketName) == "" {
+		return false
+	}
+	if len(bucketName) < 3 || len(bucketName) > 63 {
+		return false
+	}
+	if bucketName[0] == '.' || bucketName[len(bucketName)-1] == '.' {
+		return false
+	}
+	if match, _ := regexp.MatchString("\\.\\.", bucketName); match == true {
+		return false
+	}
+	// We don't support bucketNames with '.' in them
+	match, _ := regexp.MatchString("^[a-zA-Z][a-zA-Z0-9\\-]+[a-zA-Z0-9]$", bucketName)
+	return match
+}
+
+// isValidObjectName - verify object name in accordance with
+//   - http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+func isValidObjectName(objectName string) bool {
+	if strings.TrimSpace(objectName) == "" {
+		return false
+	}
+	if len(objectName) > 1024 || len(objectName) == 0 {
+		return false
+	}
+	if !utf8.ValidString(objectName) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
- change post policy api from SetContentLength --> SetContentLengthRange.
  max and min are int64.
- maxConcurrentQueue now is based on number of CPUs-1.
- define new argument validation errors
  ErrInvalidBucketName, ErrInvalidObjectName, ErrInvalidArgument.

Fixes #244 