### PR TITLE
userAgent: Rename SetUserAgent to SetAppInfo.

### DIFF
--- a/api-definitions.go
+++ b/api-definitions.go
@@ -39,6 +39,7 @@ type ObjectStat struct {
 	Size         int64
 	ContentType  string
 
+	// Owner name.
 	Owner struct {
 		DisplayName string
 		ID          string

--- a/api_handlers_test.go
+++ b/api_handlers_test.go
@@ -16,15 +16,27 @@
 
 package minio_test
 
-// bucketHandler is an http.Handler that verifies bucket responses and validates incoming requests
 import (
 	"bytes"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
+type userAgentHandler struct{}
+
+func (h userAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Verify if new user agents are set for the same client.
+	if strings.Contains(r.Header.Get("User-Agent"), "minio-gc") {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+// bucketHandler is an http.Handler that verifies bucket responses and validates incoming requests
 type bucketHandler struct {
 	resource string
 }

--- a/api_private_test.go
+++ b/api_private_test.go
@@ -16,10 +16,7 @@
 
 package minio
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestSignature(t *testing.T) {
 	conf := new(Config)
@@ -51,14 +48,6 @@ func TestACLTypes(t *testing.T) {
 		if BucketACL(acl).isValidBucketACL() != ok {
 			t.Fatal("Error")
 		}
-	}
-}
-
-func TestUserAgent(t *testing.T) {
-	conf := new(Config)
-	conf.SetUserAgent("minio", "1.0", "amd64")
-	if !strings.Contains(conf.userAgent, "minio") {
-		t.Fatalf("Error")
 	}
 }
 

--- a/interface.go
+++ b/interface.go
@@ -46,4 +46,7 @@ type CloudStorageAPI interface {
 	PresignedGetObject(bucket, object string, expires time.Duration) (string, error)
 	PresignedPutObject(bucket, object string, expires time.Duration) (string, error)
 	PresignedPostPolicy(*PostPolicy) (map[string]string, error)
+
+	// Client level
+	SetAppInfo(appName, appVersion string, comments ...string)
 }


### PR DESCRIPTION
- remove racy style boolean variable verification, use sync.Once
  to SetAppInfo only once.
- SetpAppInfo now part of API rather than Config just like other libraries.

Fixes #242