### PR TITLE
tracing: Add HTTP tracing.

### DIFF
--- a/api-get.go
+++ b/api-get.go
@@ -55,7 +55,7 @@ func (c Client) GetBucketACL(bucketName string) (BucketACL, error) {
 	}
 
 	// Initiate the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return "", err
@@ -340,7 +340,7 @@ func (c Client) getObject(bucketName, objectName string, offset, length int64) (
 		return nil, ObjectStat{}, err
 	}
 	// Execute the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return nil, ObjectStat{}, err
 	}

--- a/api-list.go
+++ b/api-list.go
@@ -39,7 +39,7 @@ func (c Client) ListBuckets() ([]BucketStat, error) {
 		return nil, err
 	}
 	// Initiate the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 		return listBucketResult{}, err
 	}
 	// Execute list buckets.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return listBucketResult{}, err
@@ -361,7 +361,7 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 		return listMultipartUploadsResult{}, err
 	}
 	// Execute list multipart uploads request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return listMultipartUploadsResult{}, err
@@ -466,7 +466,7 @@ func (c Client) listObjectPartsQuery(bucketName, objectName, uploadID string, pa
 		return listObjectPartsResult{}, err
 	}
 	// Exectue list object parts.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return listObjectPartsResult{}, err

--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -67,7 +67,7 @@ func (c Client) MakeBucket(bucketName string, acl BucketACL, location string) er
 	}
 
 	// Execute the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -201,7 +201,7 @@ func (c Client) SetBucketACL(bucketName string, acl BucketACL) error {
 	}
 
 	// Initiate the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return err

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -379,7 +379,7 @@ func (c Client) putObject(bucketName, objectName string, putObjMetadata putObjec
 		return ObjectStat{}, err
 	}
 	// Execute the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return ObjectStat{}, err
@@ -432,7 +432,7 @@ func (c Client) initiateMultipartUpload(bucketName, objectName, contentType stri
 		return initiateMultipartUploadResult{}, err
 	}
 	// Execute the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return initiateMultipartUploadResult{}, err
@@ -484,7 +484,7 @@ func (c Client) uploadPart(bucketName, objectName, uploadID string, uploadingPar
 		return objectPart{}, err
 	}
 	// Execute the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return objectPart{}, err
@@ -539,7 +539,7 @@ func (c Client) completeMultipartUpload(bucketName, objectName, uploadID string,
 	}
 
 	// Execute the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return completeMultipartUploadResult{}, err

--- a/api-remove.go
+++ b/api-remove.go
@@ -35,7 +35,7 @@ func (c Client) RemoveBucket(bucketName string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func (c Client) RemoveObject(bucketName, objectName string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -137,8 +137,9 @@ func (c Client) abortMultipartUpload(bucketName, objectName, uploadID string) er
 	if err != nil {
 		return err
 	}
+
 	// execute the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return err

--- a/api-stat.go
+++ b/api-stat.go
@@ -34,7 +34,7 @@ func (c Client) BucketExists(bucketName string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -63,7 +63,7 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectStat, error) {
 	if err != nil {
 		return ObjectStat{}, err
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return ObjectStat{}, err

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -82,7 +82,7 @@ func (c Client) getBucketLocation(bucketName string) (string, error) {
 	}
 
 	// Initiate the request.
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	defer closeResponse(resp)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Current implementation only dumps Request and Response
headers. In time this will print more information method and
method arguments.

Fixes #276