### PR TITLE
Fix constants on 32 bit machines

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -20,19 +20,19 @@ package minio
 
 // minimumPartSize - minimum part size 5MiB per object after which
 // putObject behaves internally as multipart.
-var minimumPartSize int64 = 1024 * 1024 * 5
+const minimumPartSize = 1024 * 1024 * 5
 
 // maxParts - maximum parts for a single multipart session.
-var maxParts = int64(10000)
+const maxParts = 10000
 
 // maxPartSize - maximum part size 5GiB for a single multipart upload operation.
-var maxPartSize int64 = 1024 * 1024 * 1024 * 5
+const maxPartSize = 1024 * 1024 * 1024 * 5
 
 // maxSinglePutObjectSize - maximum size 5GiB of object per PUT operation.
-var maxSinglePutObjectSize = 1024 * 1024 * 1024 * 5
+const maxSinglePutObjectSize = 1024 * 1024 * 1024 * 5
 
 // maxMultipartPutObjectSize - maximum size 5TiB of object for Multipart operation.
-var maxMultipartPutObjectSize = 1024 * 1024 * 1024 * 1024 * 5
+const maxMultipartPutObjectSize = 1024 * 1024 * 1024 * 1024 * 5
 
 // optimalReadAtBufferSize - optimal buffer 5MiB used for reading through ReadAt operation.
-var optimalReadAtBufferSize = 1024 * 1024 * 5
+const optimalReadAtBufferSize = 1024 * 1024 * 5


### PR DESCRIPTION
This uses the Go keyword 'const' to really define the values as constants. Since constants in Go are not restricted by size, this allows compiling and using the library on 32 bit machines. For variables, int in the default type, so that on 32 bit machines at least maxSinglePutObjectSize and maxMultipartPutObjectSize overflow, and Go refuses to compile.

Example (before):

    $ GOARCH=386 go test -v
    # github.com/minio/minio-go
    ./constants.go:32: constant 5368709120 overflows int
    ./constants.go:35: constant 5497558138880 overflows int
    FAIL	github.com/minio/minio-go [build failed]
