### PR TITLE
putObjectReadAt: Always upload parts in order.

### DIFF
--- a/api-put-object-common.go
+++ b/api-put-object-common.go
@@ -43,6 +43,24 @@ func isReadAt(reader io.Reader) (ok bool) {
 	return
 }
 
+// shouldUploadPart - verify if part should be uploaded.
+func shouldUploadPart(objPart objectPart, objectParts map[int]objectPart) bool {
+	// If part not found should upload the part.
+	uploadedPart, found := objectParts[objPart.PartNumber]
+	if !found {
+		return true
+	}
+	// if size mismatches should upload the part.
+	if objPart.Size != uploadedPart.Size {
+		return true
+	}
+	// if md5sum mismatches should upload the part.
+	if objPart.ETag == uploadedPart.ETag {
+		return true
+	}
+	return false
+}
+
 // optimalPartInfo - calculate the optimal part info for a given
 // object size.
 //

--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -171,8 +171,8 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 			return 0, err
 		}
 
-		// Verify if part was not uploaded.
-		if !isPartUploaded(objectPart{
+		// Verify if part should be uploaded.
+		if shouldUploadPart(objectPart{
 			ETag:       hex.EncodeToString(md5Sum),
 			PartNumber: partNumber,
 			Size:       prtSize,

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -123,8 +123,8 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 			}
 		}
 
-		// Verify if part was not uploaded.
-		if !isPartUploaded(objectPart{
+		// Verify if part should be uploaded.
+		if shouldUploadPart(objectPart{
 			ETag:       hex.EncodeToString(md5Sum),
 			PartNumber: partNumber,
 			Size:       prtSize,

--- a/utils.go
+++ b/utils.go
@@ -52,19 +52,6 @@ func sumHMAC(key []byte, data []byte) []byte {
 	return hash.Sum(nil)
 }
 
-// isPartUploaded - true if part is already uploaded.
-func isPartUploaded(objPart objectPart, objectParts map[int]objectPart) (isUploaded bool) {
-	uploadedPart, isUploaded := objectParts[objPart.PartNumber]
-	// if size mismatches part should be uploaded.
-	if objPart.Size != uploadedPart.Size {
-		isUploaded = false
-	}
-	if isUploaded {
-		isUploaded = (objPart.ETag == uploadedPart.ETag)
-	}
-	return
-}
-
 // getEndpointURL - construct a new endpoint.
 func getEndpointURL(endpoint string, inSecure bool) (*url.URL, error) {
 	if strings.Contains(endpoint, ":") {


### PR DESCRIPTION
This change also reduces the chance of significant random i/o on the source.
