### PR TITLE
queryEncode: Do not encode query multiple times.

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -188,11 +188,11 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 	urlValues := make(url.Values)
 	// Set object prefix.
 	if objectPrefix != "" {
-		urlValues.Set("prefix", urlEncodePath(objectPrefix))
+		urlValues.Set("prefix", objectPrefix)
 	}
 	// Set object marker.
 	if objectMarker != "" {
-		urlValues.Set("marker", urlEncodePath(objectMarker))
+		urlValues.Set("marker", objectMarker)
 	}
 	// Set delimiter.
 	if delimiter != "" {
@@ -366,7 +366,7 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 	urlValues.Set("uploads", "")
 	// Set object key marker.
 	if keyMarker != "" {
-		urlValues.Set("key-marker", urlEncodePath(keyMarker))
+		urlValues.Set("key-marker", keyMarker)
 	}
 	// Set upload id marker.
 	if uploadIDMarker != "" {
@@ -374,7 +374,7 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 	}
 	// Set prefix marker.
 	if prefix != "" {
-		urlValues.Set("prefix", urlEncodePath(prefix))
+		urlValues.Set("prefix", prefix)
 	}
 	// Set delimiter.
 	if delimiter != "" {

--- a/api.go
+++ b/api.go
@@ -478,7 +478,7 @@ func (c Client) makeTargetURL(bucketName, objectName, bucketLocation string, que
 	}
 	// If there are any query values, add them to the end.
 	if len(queryValues) > 0 {
-		urlStr = urlStr + "?" + queryValues.Encode()
+		urlStr = urlStr + "?" + queryEncode(queryValues)
 	}
 	u, err := url.Parse(urlStr)
 	if err != nil {

--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -397,6 +397,22 @@ func TestPartSize(t *testing.T) {
 	}
 }
 
+// Tests query values to URL encoding.
+func TestQueryURLEncoding(t *testing.T) {
+	urlValues := make(url.Values)
+	urlValues.Set("prefix", "test@1123")
+	urlValues.Set("delimiter", "/")
+	urlValues.Set("marker", "%%%@$$$")
+
+	queryStr := queryEncode(urlValues)
+	if !strings.Contains(queryStr, "test%401123") {
+		t.Fatalf("Error: @ should be encoded as %s, invalid query string %s", "test%401123", queryStr)
+	}
+	if !strings.Contains(queryStr, "%25%25%25%40%24%24%24") {
+		t.Fatalf("Error: %s should be encoded as %s, invalid query string %s", "%%%@$$$", "%25%25%25%40%24%24%24", queryStr)
+	}
+}
+
 // Tests url encoding.
 func TestURLEncoding(t *testing.T) {
 	type urlStrings struct {

--- a/utils.go
+++ b/utils.go
@@ -17,6 +17,7 @@
 package minio
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -27,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -262,6 +264,31 @@ func isValidObjectPrefix(objectPrefix string) error {
 		return ErrInvalidObjectPrefix("Object prefix with non UTF-8 strings are not supported.")
 	}
 	return nil
+}
+
+// queryEncode - encodes query values in their URL encoded form.
+func queryEncode(v url.Values) string {
+	if v == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vs := v[k]
+		prefix := urlEncodePath(k) + "="
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
+			buf.WriteString(urlEncodePath(v))
+		}
+	}
+	return buf.String()
 }
 
 // urlEncodePath encode the strings from UTF-8 byte representations to HTML hex escape sequences


### PR DESCRIPTION
Multiple encodings on URLs lead to invalid queries to be made
against s3. Handle this by implementing a custom Encode() function.

This is necessary, we have to custom encode characters like '++'
which are erroneously encoded by url.ParseQuery() as space characters
which in turn become '%20' instead the server would be expecting it
to be '%25'

This in turn also fixes - https://github.com/minio/mc/issues/1591