### PR TITLE
Splitting the main interface into multiple smaller ones

### DIFF
--- a/api.go
+++ b/api.go
@@ -491,26 +491,17 @@ func (c Client) makeTargetURL(bucketName, objectName, bucketLocation string, que
 // CloudStorageClient - Cloud Storage Client interface.
 type CloudStorageClient interface {
 	// Bucket Read/Write/Stat operations.
-	MakeBucket(bucketName string, cannedACL BucketACL, location string) error
-	BucketExists(bucketName string) error
-	RemoveBucket(bucketName string) error
-	SetBucketACL(bucketName string, cannedACL BucketACL) error
-	GetBucketACL(bucketName string) (BucketACL, error)
+	BucketOperator
+	BucketACLOperator
+	ObjectOperator
+	FileOperator
 
-	ListBuckets() ([]BucketInfo, error)
-	ListObjects(bucket, prefix string, recursive bool, doneCh <-chan struct{}) <-chan ObjectInfo
 	ListIncompleteUploads(bucket, prefix string, recursive bool, doneCh <-chan struct{}) <-chan ObjectMultipartInfo
 
 	// Object Read/Write/Stat operations.
-	GetObject(bucketName, objectName string) (reader *Object, err error)
-	PutObject(bucketName, objectName string, reader io.Reader, contentType string) (n int64, err error)
-	StatObject(bucketName, objectName string) (ObjectInfo, error)
-	RemoveObject(bucketName, objectName string) error
 	RemoveIncompleteUpload(bucketName, objectName string) error
 
 	// File to Object API.
-	FPutObject(bucketName, objectName, filePath, contentType string) (n int64, err error)
-	FGetObject(bucketName, objectName, filePath string) error
 
 	// PutObjectWithProgress for progress.
 	PutObjectWithProgress(bucketName, objectName string, reader io.Reader, contentType string, progress io.Reader) (n int64, err error)

--- a/bucket_acl_operator.go
+++ b/bucket_acl_operator.go
@@ -1,0 +1,6 @@
+package minio
+
+type BucketACLOperator interface {
+	SetBucketACL(bucketName string, cannedACL BucketACL) error
+	GetBucketACL(bucketName string) (BucketACL, error)
+}

--- a/bucket_operator.go
+++ b/bucket_operator.go
@@ -1,0 +1,13 @@
+package minio
+
+// BucketOperator provides operations on a bucket in the object storage system
+type BucketOperator interface {
+	// ListBuckets returns a slice of all the buckets in the object stora
+	ListBuckets() ([]BucketInfo, error)
+	// MakeBucket creates a new bucket with the given name and ACL
+	MakeBucket(bucketName string, cannedACL BucketACL, location string) error
+	// BucketExists returns nil if the bucket exists, error otherwise
+	BucketExists(bucketName string) error
+	// RemoveBucket removes the bucket with the given name. Any non-nil error means the bucket was not removed
+	RemoveBucket(bucketName string) error
+}

--- a/file_operator.go
+++ b/file_operator.go
@@ -1,0 +1,9 @@
+package minio
+
+// FileOperator provides functionality to do operations between local files and the remote object store
+type FileOperator interface {
+	// FPutObject transfers the data at filePath and the object at bucketName/objectName. Returns the number of bytes transferred, or an error if the file doesn't exist, the network I/O to the object storage system failed, or any other failure occurred
+	FPutObject(bucketName, objectName, filePath, contentType string) (n int64, err error)
+	// FGetObject gets the object at bucketName/objectName and writes it to filePath
+	FGetObject(bucketName, objectName, filePath string) error
+}

--- a/object_operator.go
+++ b/object_operator.go
@@ -1,0 +1,19 @@
+package minio
+
+import (
+	"io"
+)
+
+// ObjectOperator provides operations to interact with objects in the object store
+type ObjectOperator interface {
+	// ListObjects gets the object list and streams each object back in the returned channel. Objects may not be in order
+	ListObjects(bucket, prefix string, recursive bool, doneCh <-chan struct{}) <-chan ObjectInfo
+	// GetObject gets the specific object with the given name and returns it
+	GetObject(bucketName, objectName string) (reader *Object, err error)
+	// PutObject reads data from reader and puts it into bucketName/objectName
+	PutObject(bucketName, objectName string, reader io.Reader, contentType string) (n int64, err error)
+	// StatObject returns a valid ObjectInfo if the given bucketName/objectName exists, and an error otherwise
+	StatObject(bucketName, objectName string) (ObjectInfo, error)
+	// RemoveObject removes the object at bucketName/objectName. Any non-nil error means the object was not successfully removed
+	RemoveObject(bucketName, objectName string) error
+}


### PR DESCRIPTION
Having a single, all-encompassing interface is ok, but it’s often useful to pass around a smaller chunk of functionality, to reduce the surface area of functionality that a function gets access to. Additionally, passing smaller interfaces around makes it much easier to write unit tests.

This PR is a first try at splitting up the `CloudStorageClient` interface.

Note that the same tests fail here as on master (see https://github.com/minio/minio-go/issues/326).