### PR TITLE
httpClient: Golang errorneously returnes EOF

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
     - Have test cases for the new code. If you have questions about how to do it, please ask in your pull request.
     - Run `go fmt`
     - Squash your commits into a single commit. `git rebase -i`. It's okay to force update your pull request.
-    - Make sure `go test -race ./...` and `go build` completes.
+    - Make sure `go test -short -race ./...` and `go build` completes.
 
 * Read [Effective Go](https://github.com/golang/go/wiki/CodeReviewComments) article from Golang project
     - `minio-go` project is strictly conformant with Golang style

--- a/api.go
+++ b/api.go
@@ -325,6 +325,12 @@ func (c Client) do(req *http.Request) (*http.Response, error) {
 	// execute the request.
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		// Handle this specifically for now until future Golang
+		// versions fix this issue properly.
+		urlErr, ok := err.(*url.Error)
+		if ok && strings.Contains(urlErr.Err.Error(), "EOF") {
+			return nil, fmt.Errorf("Connection closed by foreign host %s. Retry again.", urlErr.URL)
+		}
 		return resp, err
 	}
 	// If trace is enabled, dump http request and response.


### PR DESCRIPTION
    Following code results in EOF when a dummy server
    is running on port 9000, for example `php-fpm`.

    ```
    package main

    import (
        "fmt"
        "net/http"
    )

    func main() {
        resp, err := http.Get("http://localhost:9000")
        fmt.Println(resp, err)
    }
    ```
    ```
    $ go run test.go
    <nil> Get http://localhost:9000: EOF
    ```

    Lets handle this specially to provide a valid user message.