### PR TITLE
http/Client: Add a sensible 30sec timeout to wait for response.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,9 @@
     - Have test cases for the new code. If you have questions about how to do it, please ask in your pull request.
     - Run `go fmt`
     - Squash your commits into a single commit. `git rebase -i`. It's okay to force update your pull request.
-    - Make sure `go test -short -race ./...` and `go build` completes.
+    - Make sure `go test -race ./...` and `go build` completes.
+      NOTE: go test runs functional tests and requires you to have a AWS S3 account. Set them as environment variables
+      ``ACCESS_KEY`` and ``SECRET_KEY``. To run shorter version of the tests please use ``go test -short -race ./...``
 
 * Read [Effective Go](https://github.com/golang/go/wiki/CodeReviewComments) article from Golang project
     - `minio-go` project is strictly conformant with Golang style

--- a/api.go
+++ b/api.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // Client implements Amazon S3 compatible methods.
@@ -137,7 +138,14 @@ func privateNew(endpoint, accessKeyID, secretAccessKey string, insecure bool) (*
 	clnt.endpointURL = endpointURL
 
 	// Instantiate http client and bucket location cache.
-	clnt.httpClient = &http.Client{}
+	clnt.httpClient = &http.Client{
+		// Setting a sensible time out of 30secs to wait for response
+		// headers. Request is pro-actively cancelled after 30secs
+		// with no response.
+		Timeout:   30 * time.Second,
+		Transport: http.DefaultTransport,
+	}
+
 	clnt.bucketLocCache = newBucketLocationCache()
 
 	// Return.

--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -1017,7 +1017,13 @@ func TestFunctionalV2(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		// Setting a sensible time out of 30secs to wait for response
+		// headers. Request is pro-actively cancelled after 30secs
+		// with no response.
+		Timeout:   30 * time.Second,
+		Transport: http.DefaultTransport,
+	}
 	resp, err = httpClient.Do(req)
 	if err != nil {
 		t.Fatal("Error: ", err)

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -1045,7 +1045,13 @@ func TestFunctional(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		// Setting a sensible time out of 30secs to wait for response
+		// headers. Request is pro-actively cancelled after 30secs
+		// with no response.
+		Timeout:   30 * time.Second,
+		Transport: http.DefaultTransport,
+	}
 	resp, err = httpClient.Do(req)
 	if err != nil {
 		t.Fatal("Error: ", err)


### PR DESCRIPTION
If client does not receive a response for 30secs, the request
is cancelled pro-actively.