### PR TITLE
error: Change AmzBucketRegion to 'Region' so that we can decode XML v…

### DIFF
--- a/api-error-response.go
+++ b/api-error-response.go
@@ -47,7 +47,7 @@ type ErrorResponse struct {
 
 	// Region where the bucket is located. This header is returned
 	// only in HEAD bucket and ListObjects response.
-	AmzBucketRegion string
+	Region string
 }
 
 // ToErrorResponse - Returns parsed ErrorResponse struct from body and
@@ -98,51 +98,51 @@ func httpRespToErrorResponse(resp *http.Response, bucketName, objectName string)
 		case http.StatusNotFound:
 			if objectName == "" {
 				errResp = ErrorResponse{
-					Code:            "NoSuchBucket",
-					Message:         "The specified bucket does not exist.",
-					BucketName:      bucketName,
-					RequestID:       resp.Header.Get("x-amz-request-id"),
-					HostID:          resp.Header.Get("x-amz-id-2"),
-					AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+					Code:       "NoSuchBucket",
+					Message:    "The specified bucket does not exist.",
+					BucketName: bucketName,
+					RequestID:  resp.Header.Get("x-amz-request-id"),
+					HostID:     resp.Header.Get("x-amz-id-2"),
+					Region:     resp.Header.Get("x-amz-bucket-region"),
 				}
 			} else {
 				errResp = ErrorResponse{
-					Code:            "NoSuchKey",
-					Message:         "The specified key does not exist.",
-					BucketName:      bucketName,
-					Key:             objectName,
-					RequestID:       resp.Header.Get("x-amz-request-id"),
-					HostID:          resp.Header.Get("x-amz-id-2"),
-					AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+					Code:       "NoSuchKey",
+					Message:    "The specified key does not exist.",
+					BucketName: bucketName,
+					Key:        objectName,
+					RequestID:  resp.Header.Get("x-amz-request-id"),
+					HostID:     resp.Header.Get("x-amz-id-2"),
+					Region:     resp.Header.Get("x-amz-bucket-region"),
 				}
 			}
 		case http.StatusForbidden:
 			errResp = ErrorResponse{
-				Code:            "AccessDenied",
-				Message:         "Access Denied.",
-				BucketName:      bucketName,
-				Key:             objectName,
-				RequestID:       resp.Header.Get("x-amz-request-id"),
-				HostID:          resp.Header.Get("x-amz-id-2"),
-				AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+				Code:       "AccessDenied",
+				Message:    "Access Denied.",
+				BucketName: bucketName,
+				Key:        objectName,
+				RequestID:  resp.Header.Get("x-amz-request-id"),
+				HostID:     resp.Header.Get("x-amz-id-2"),
+				Region:     resp.Header.Get("x-amz-bucket-region"),
 			}
 		case http.StatusConflict:
 			errResp = ErrorResponse{
-				Code:            "Conflict",
-				Message:         "Bucket not empty.",
-				BucketName:      bucketName,
-				RequestID:       resp.Header.Get("x-amz-request-id"),
-				HostID:          resp.Header.Get("x-amz-id-2"),
-				AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+				Code:       "Conflict",
+				Message:    "Bucket not empty.",
+				BucketName: bucketName,
+				RequestID:  resp.Header.Get("x-amz-request-id"),
+				HostID:     resp.Header.Get("x-amz-id-2"),
+				Region:     resp.Header.Get("x-amz-bucket-region"),
 			}
 		default:
 			errResp = ErrorResponse{
-				Code:            resp.Status,
-				Message:         resp.Status,
-				BucketName:      bucketName,
-				RequestID:       resp.Header.Get("x-amz-request-id"),
-				HostID:          resp.Header.Get("x-amz-id-2"),
-				AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+				Code:       resp.Status,
+				Message:    resp.Status,
+				BucketName: bucketName,
+				RequestID:  resp.Header.Get("x-amz-request-id"),
+				HostID:     resp.Header.Get("x-amz-id-2"),
+				Region:     resp.Header.Get("x-amz-bucket-region"),
 			}
 		}
 	}

--- a/api-get.go
+++ b/api-get.go
@@ -83,12 +83,12 @@ func (c Client) GetBucketACL(bucketName string) (BucketACL, error) {
 	if !isGoogleEndpoint(c.endpointURL) {
 		if policy.AccessControlList.Grant == nil {
 			errorResponse := ErrorResponse{
-				Code:            "InternalError",
-				Message:         "Access control Grant list is empty. " + reportIssue,
-				BucketName:      bucketName,
-				RequestID:       resp.Header.Get("x-amz-request-id"),
-				HostID:          resp.Header.Get("x-amz-id-2"),
-				AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+				Code:       "InternalError",
+				Message:    "Access control Grant list is empty. " + reportIssue,
+				BucketName: bucketName,
+				RequestID:  resp.Header.Get("x-amz-request-id"),
+				HostID:     resp.Header.Get("x-amz-id-2"),
+				Region:     resp.Header.Get("x-amz-bucket-region"),
 			}
 			return "", errorResponse
 		}
@@ -513,11 +513,11 @@ func (c Client) getObject(bucketName, objectName string, offset, length int64) (
 	if err != nil {
 		msg := "Last-Modified time format not recognized. " + reportIssue
 		return nil, ObjectInfo{}, ErrorResponse{
-			Code:            "InternalError",
-			Message:         msg,
-			RequestID:       resp.Header.Get("x-amz-request-id"),
-			HostID:          resp.Header.Get("x-amz-id-2"),
-			AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+			Code:      "InternalError",
+			Message:   msg,
+			RequestID: resp.Header.Get("x-amz-request-id"),
+			HostID:    resp.Header.Get("x-amz-id-2"),
+			Region:    resp.Header.Get("x-amz-bucket-region"),
 		}
 	}
 	// Get content-type.

--- a/api-remove.go
+++ b/api-remove.go
@@ -149,13 +149,13 @@ func (c Client) abortMultipartUpload(bucketName, objectName, uploadID string) er
 				// This is needed specifically for abort and it cannot
 				// be converged into default case.
 				errorResponse = ErrorResponse{
-					Code:            "NoSuchUpload",
-					Message:         "The specified multipart upload does not exist.",
-					BucketName:      bucketName,
-					Key:             objectName,
-					RequestID:       resp.Header.Get("x-amz-request-id"),
-					HostID:          resp.Header.Get("x-amz-id-2"),
-					AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+					Code:       "NoSuchUpload",
+					Message:    "The specified multipart upload does not exist.",
+					BucketName: bucketName,
+					Key:        objectName,
+					RequestID:  resp.Header.Get("x-amz-request-id"),
+					HostID:     resp.Header.Get("x-amz-id-2"),
+					Region:     resp.Header.Get("x-amz-bucket-region"),
 				}
 			default:
 				return httpRespToErrorResponse(resp, bucketName, objectName)

--- a/api-stat.go
+++ b/api-stat.go
@@ -87,26 +87,26 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
 	if err != nil {
 		return ObjectInfo{}, ErrorResponse{
-			Code:            "InternalError",
-			Message:         "Content-Length is invalid. " + reportIssue,
-			BucketName:      bucketName,
-			Key:             objectName,
-			RequestID:       resp.Header.Get("x-amz-request-id"),
-			HostID:          resp.Header.Get("x-amz-id-2"),
-			AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+			Code:       "InternalError",
+			Message:    "Content-Length is invalid. " + reportIssue,
+			BucketName: bucketName,
+			Key:        objectName,
+			RequestID:  resp.Header.Get("x-amz-request-id"),
+			HostID:     resp.Header.Get("x-amz-id-2"),
+			Region:     resp.Header.Get("x-amz-bucket-region"),
 		}
 	}
 	// Parse Last-Modified has http time format.
 	date, err := time.Parse(http.TimeFormat, resp.Header.Get("Last-Modified"))
 	if err != nil {
 		return ObjectInfo{}, ErrorResponse{
-			Code:            "InternalError",
-			Message:         "Last-Modified time format is invalid. " + reportIssue,
-			BucketName:      bucketName,
-			Key:             objectName,
-			RequestID:       resp.Header.Get("x-amz-request-id"),
-			HostID:          resp.Header.Get("x-amz-id-2"),
-			AmzBucketRegion: resp.Header.Get("x-amz-bucket-region"),
+			Code:       "InternalError",
+			Message:    "Last-Modified time format is invalid. " + reportIssue,
+			BucketName: bucketName,
+			Key:        objectName,
+			RequestID:  resp.Header.Get("x-amz-request-id"),
+			HostID:     resp.Header.Get("x-amz-id-2"),
+			Region:     resp.Header.Get("x-amz-bucket-region"),
 		}
 	}
 	// Fetch content type if any present.

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"sync"
 )
 
@@ -127,7 +127,7 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 
 	// Set get bucket location always as path style.
 	targetURL := c.endpointURL
-	targetURL.Path = filepath.Join(bucketName, "") + "/"
+	targetURL.Path = path.Join(bucketName, "") + "/"
 	targetURL.RawQuery = urlValues.Encode()
 
 	// Get a new HTTP request for the method.


### PR DESCRIPTION
…alue too.

Error xml sent by AWS S3 can have a Region field as well. Keep it same name
to avoid problems decoding it.