### PR TITLE
retry: Enhance retry to support cases of restricted bucket policy.

### DIFF
--- a/api-error-response.go
+++ b/api-error-response.go
@@ -146,17 +146,6 @@ func httpRespToErrorResponse(resp *http.Response, bucketName, objectName string)
 			}
 		}
 	}
-
-	// AccessDenied without a signature mismatch code, usually means
-	// that the bucket policy has certain restrictions where some API
-	// operations are not allowed. Handle this case so that top level
-	// callers can interpret this easily and fall back if needed to a
-	// lower functionality call. Read each individual API specific
-	// code for such fallbacks.
-	if errResp.Code == "AccessDenied" && errResp.Message == "Access Denied" {
-		errResp.Code = "NotImplemented"
-		errResp.Message = "Operation is not allowed according to your bucket policy."
-	}
 	return errResp
 }
 

--- a/api-put-object-progress.go
+++ b/api-put-object-progress.go
@@ -91,7 +91,7 @@ func (c Client) PutObjectWithProgress(bucketName, objectName string, reader io.R
 		errResp := ToErrorResponse(err)
 		// Verify if multipart functionality is not available, if not
 		// fall back to single PutObject operation.
-		if errResp.Code == "NotImplemented" {
+		if errResp.Code == "AccessDenied" && errResp.Message == "Access Denied." {
 			// Verify if size of reader is greater than '5GiB'.
 			if size > maxSinglePutObjectSize {
 				return 0, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)


### PR DESCRIPTION
This is necessary if GetBucketLocation() is explicitly disabled
for a user policy, fallback to the errorResponse Region and attempt
the request again if necessary. - fixes #332

An example of one such policy

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "s3:ListAllMyBuckets",
            "Resource": "arn:aws:s3:::*"
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:GetObject",
                "s3:GetObjectAcl",
                "s3:GetObjectVersion",
                "s3:GetObjectVersionAcl",
                "s3:ListBucket"
            ],
            "Resource": [
                "arn:aws:s3:::jarjarbing",
                "arn:aws:s3:::jarjarbing/*"
            ]
        }
    ]
}
```

Clearly user with this policy can list objects on ``jarjarbing`` bucket. But
cannot possibly use our library in this case. This patch addresses this by
using the information returned in the error response and retry the request.