### PR TITLE
retry: Fill region even for http.StatusForbidden to try the request a…

### DIFF
--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -74,7 +74,7 @@ func (c Client) MakeBucket(bucketName string, acl BucketACL, location string) er
 		}
 	}
 
-	// Save the location into cache on a successfull makeBucket response.
+	// Save the location into cache on a successful makeBucket response.
 	c.bucketLocCache.Set(bucketName, location)
 
 	// Return.


### PR DESCRIPTION
…gain.

This fixes the restic issue with

> The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.

When bucket policy has certain restrictions regarding get bucket location.

Fixes #332