### PR TITLE
retry: Retry requests for errors like network EOF.

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -19,6 +19,8 @@ package minio
 import (
 	"math/rand"
 	"net"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -56,6 +58,12 @@ func isNetErrorRetryable(err error) bool {
 	switch err.(type) {
 	case *net.DNSError, *net.OpError, net.UnknownNetworkError:
 		return true
+	case *url.Error:
+		// For a URL error, where it replies back "connection closed"
+		// retry again.
+		if strings.Contains(err.Error(), "Connection closed by foreign host") {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Type case happens when s3 abruptly closes connection, in case
of PUT object.

Error is in this form

```api_functional_v4_test.go:372: Error: Put https://fdjxy04buj2a56wlb9tmj6gxuqy4ub.s3.amazonaws.com/fdjxy04buj2a56wlb9tmj6gxuqy4ub-resumable?partNumber=1&uploadId=6Yz7myPIr_nSlN3.0irMydXIl3zIdfTbJheoRv2I4YfU8MEIW667guCHo9LLMBv1Av1ymUQAAjwLGfK_IJbXFHCx0n9CX_Eg325UlBvUg2paBQ_Wrr8ZoTyMEojAFDX7: Connection closed by foreign host https://fdjxy04buj2a56wlb9tmj6gxuqy4ub.s3.amazonaws.com/fdjxy04buj2a56wlb9tmj6gxuqy4ub-resumable?partNumber=1&uploadId=6Yz7myPIr_nSlN3.0irMydXIl3zIdfTbJheoRv2I4YfU8MEIW667guCHo9LLMBv1Av1ymUQAAjwLGfK_IJbXFHCx0n9CX_Eg325UlBvUg2paBQ_Wrr8ZoTyMEojAFDX7. Retry again.```

We verify the error string and retry again.