### PR TITLE
Added retry handling for some standard retryable http status codes.

### DIFF
--- a/api.go
+++ b/api.go
@@ -454,6 +454,11 @@ func (c Client) executeMethod(method string, metadata requestMetadata) (res *htt
 			}
 		}
 
+		// Verify if http status code is retryable.
+		if isHTTPStatusRetryable(res.StatusCode) {
+			continue // Retry.
+		}
+
 		// For errors verify if its retryable otherwise fail quickly.
 		errResponse := ToErrorResponse(httpRespToErrorResponse(res, metadata.bucketName, metadata.objectName))
 		// Bucket region if set in error response, we can retry the

--- a/retry.go
+++ b/retry.go
@@ -18,6 +18,7 @@ package minio
 
 import (
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -46,7 +47,6 @@ func (c Client) newRetryTimer(maxRetry int, unit time.Duration, cap time.Duratio
 		}
 		if jitter > MaxJitter {
 			jitter = MaxJitter
-
 		}
 
 		//sleep = random_between(0, min(cap, base * 2 ** attempt))
@@ -93,6 +93,18 @@ func isS3CodeRetryable(s3Code string) bool {
 	case "RequestLimitExceeded", "RequestThrottled", "InternalError":
 		fallthrough
 	case "ExpiredToken", "ExpiredTokenException":
+		return true
+	}
+	return false
+}
+
+// isHTTPStatusRetryable - is HTTP error code retryable.
+func isHTTPStatusRetryable(status int) bool {
+	switch status {
+	case 429, // http.StatusTooManyRequests is not part of the Go 1.5 library, yet
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable:
 		return true
 	}
 	return false


### PR DESCRIPTION
The status codes that are definitely retryable according to the
documentation:

500 and 503 for AWS
(http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html)

429, 500, 502 and 503 for Google cloud storage
(https://cloud.google.com/storage/docs/json_api/v1/status-codes)

502 and 503 for Azure
(https://msdn.microsoft.com/en-us/library/system.net.httpstatuscode(VS.80).aspx)

I decided to retry on the superset of these codes.