### PR TITLE
api: Implement CopyObject API

### DIFF
--- a/api-put-object-copy.go
+++ b/api-put-object-copy.go
@@ -1,0 +1,54 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import "net/http"
+
+// CopyObject - copy a source object into a new object with the provided name in the provided bucket
+func (c Client) CopyObject(bucketName, objectName string, xAmzHeaders http.Header) (copyObjectResult, error) {
+	// Input validation.
+	if err := isValidBucketName(bucketName); err != nil {
+		return copyObjectResult{}, err
+	}
+	if err := isValidObjectName(objectName); err != nil {
+		return copyObjectResult{}, err
+	}
+
+	// Execute PUT on objectName.
+	resp, err := c.executeMethod("PUT", requestMetadata{
+		bucketName:   bucketName,
+		objectName:   objectName,
+		customHeader: xAmzHeaders,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return copyObjectResult{}, err
+	}
+	if resp != nil {
+		if resp.StatusCode != http.StatusOK {
+			return copyObjectResult{}, httpRespToErrorResponse(resp, bucketName, objectName)
+		}
+	}
+
+	// Decode copy response on success.
+	copyObjectResult := copyObjectResult{}
+	err = xmlDecoder(resp.Body, &copyObjectResult)
+	if err != nil {
+		return copyObjectResult, err
+	}
+	return copyObjectResult, nil
+}

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -96,6 +96,12 @@ type initiator struct {
 	DisplayName string
 }
 
+// copyObjectResult container for copy object response.
+type copyObjectResult struct {
+	ETag         string
+	LastModified string // time string format "2006-01-02T15:04:05.000Z"
+}
+
 // objectPart container for particular part of an object.
 type objectPart struct {
 	// Part number identifies the part.

--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -744,6 +745,133 @@ func TestGetObjectReadAtFunctionalV2(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+}
+
+// Tests copy object
+func TestCopyObjectV2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping functional tests for short runs")
+	}
+	// Seed random based on current time.
+	rand.Seed(time.Now().Unix())
+
+	// Instantiate new minio client object
+	c, err := minio.NewV2(
+		"s3.amazonaws.com",
+		os.Getenv("ACCESS_KEY"),
+		os.Getenv("SECRET_KEY"),
+		false,
+	)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Enable tracing, write to stderr.
+	// c.TraceOn(os.Stderr)
+
+	// Set user agent.
+	c.SetAppInfo("Minio-go-FunctionalTest", "0.1.0")
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()))
+
+	// Make a new bucket in 'us-east-1' (source bucket).
+	err = c.MakeBucket(bucketName, "us-east-1")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName)
+	}
+
+	// Make a new bucket in 'us-east-1' (destination bucket).
+	err = c.MakeBucket(bucketName+"-copy", "us-east-1")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName+"-copy")
+	}
+
+	// Generate data more than 32K
+	buf := make([]byte, rand.Intn(1<<20)+32*1024)
+
+	_, err = io.ReadFull(crand.Reader, buf)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Save the data
+	objectName := randString(60, rand.NewSource(time.Now().UnixNano()))
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), "binary/octet-stream")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName)
+	}
+
+	if n != int64(len(buf)) {
+		t.Fatalf("Error: number of bytes does not match want %v, got %v",
+			len(buf), n)
+	}
+
+	// Make headers for the copy.
+	xAmzHeaders := make(http.Header)
+	xAmzHeaders.Set("x-amz-copy-source", bucketName+"/"+objectName)
+
+	// Perform the Copy
+	res, err := c.CopyObject(bucketName+"-copy", objectName+"-copy", xAmzHeaders)
+	if err != nil {
+		t.Fatal("Error:", err, bucketName+"-copy", objectName+"-copy")
+	}
+
+	// Source object
+	reader, err := c.GetObject(bucketName, objectName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	// Destination object
+	readerCopy, err := c.GetObject(bucketName+"-copy", objectName+"-copy")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	// Check the various fields of source object against destination object.
+	objInfo, err := reader.Stat()
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	objInfoCopy, err := readerCopy.Stat()
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if objInfo.Size != objInfoCopy.Size {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n",
+			objInfo.Size, objInfoCopy.Size)
+	}
+	if objInfo.ETag != objInfoCopy.ETag {
+		t.Fatalf("Error: ETags do not match, want %v, got %v\n",
+			objInfoCopy.ETag, objInfo.ETag)
+	}
+	// Trim double quotes from copyObjectResult ETag field to compare
+	copyObjectETag := strings.TrimPrefix(res.ETag, "\"")
+	copyObjectETag = strings.TrimSuffix(copyObjectETag, "\"")
+	if copyObjectETag != objInfo.ETag {
+		t.Fatalf("Error: ETags do not match, want %v, got %v\n",
+			objInfo.ETag, copyObjectETag)
+	}
+
+	// Remove all objects and buckets
+	err = c.RemoveObject(bucketName, objectName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = c.RemoveObject(bucketName+"-copy", objectName+"-copy")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = c.RemoveBucket(bucketName + "-copy")
 	if err != nil {
 		t.Fatal("Error:", err)
 	}

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -773,6 +774,133 @@ func TestGetObjectReadAtFunctional(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+}
+
+// Tests copy object
+func TestCopyObject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping functional tests for short runs")
+	}
+	// Seed random based on current time.
+	rand.Seed(time.Now().Unix())
+
+	// Instantiate new minio client object
+	c, err := minio.NewV2(
+		"s3.amazonaws.com",
+		os.Getenv("ACCESS_KEY"),
+		os.Getenv("SECRET_KEY"),
+		false,
+	)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Enable tracing, write to stderr.
+	// c.TraceOn(os.Stderr)
+
+	// Set user agent.
+	c.SetAppInfo("Minio-go-FunctionalTest", "0.1.0")
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()))
+
+	// Make a new bucket in 'us-east-1' (source bucket).
+	err = c.MakeBucket(bucketName, "us-east-1")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName)
+	}
+
+	// Make a new bucket in 'us-east-1' (destination bucket).
+	err = c.MakeBucket(bucketName+"-copy", "us-east-1")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName+"-copy")
+	}
+
+	// Generate data more than 32K
+	buf := make([]byte, rand.Intn(1<<20)+32*1024)
+
+	_, err = io.ReadFull(crand.Reader, buf)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Save the data
+	objectName := randString(60, rand.NewSource(time.Now().UnixNano()))
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), "binary/octet-stream")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName)
+	}
+
+	if n != int64(len(buf)) {
+		t.Fatalf("Error: number of bytes does not match want %v, got %v",
+			len(buf), n)
+	}
+
+	// Make headers for the copy.
+	xAmzHeaders := make(http.Header)
+	xAmzHeaders.Set("x-amz-copy-source", bucketName+"/"+objectName)
+
+	// Perform the Copy
+	res, err := c.CopyObject(bucketName+"-copy", objectName+"-copy", xAmzHeaders)
+	if err != nil {
+		t.Fatal("Error:", err, bucketName+"-copy", objectName+"-copy")
+	}
+
+	// Source object
+	reader, err := c.GetObject(bucketName, objectName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	// Destination object
+	readerCopy, err := c.GetObject(bucketName+"-copy", objectName+"-copy")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	// Check the various fields of source object against destination object.
+	objInfo, err := reader.Stat()
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	objInfoCopy, err := readerCopy.Stat()
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if objInfo.Size != objInfoCopy.Size {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n",
+			objInfo.Size, objInfoCopy.Size)
+	}
+	if objInfo.ETag != objInfoCopy.ETag {
+		t.Fatalf("Error: ETags do not match, want %v, got %v\n",
+			objInfoCopy.ETag, objInfo.ETag)
+	}
+	// Trim double quotes from copyObjectResult ETag field to compare
+	copyObjectETag := strings.TrimPrefix(res.ETag, "\"")
+	copyObjectETag = strings.TrimSuffix(copyObjectETag, "\"")
+	if copyObjectETag != objInfo.ETag {
+		t.Fatalf("Error: ETags do not match, want %v, got %v\n",
+			objInfo.ETag, copyObjectETag)
+	}
+
+	// Remove all objects and buckets
+	err = c.RemoveObject(bucketName, objectName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = c.RemoveObject(bucketName+"-copy", objectName+"-copy")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = c.RemoveBucket(bucketName + "-copy")
 	if err != nil {
 		t.Fatal("Error:", err)
 	}


### PR DESCRIPTION
api is implemented in api-put-object-copy.go

tests are included in both api_functional_v2_test.go and api_functional_v4_test.go as TestCopyObjectV2 and TestCopyObject respectively.

Let me know if you would rather the tests only be included in the TestFunctional functions...or if there is anything else that needs to be changed