### PR TITLE
putObject: using buffer.Bytes() causes memory copy. Avoid it.

### DIFF
--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -124,7 +124,7 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 		var reader io.Reader
 		// Update progress reader appropriately to the latest offset
 		// as we read from the source.
-		reader = newHook(bytes.NewReader(tmpBuffer.Bytes()), progress)
+		reader = newHook(tmpBuffer, progress)
 
 		// Verify if part should be uploaded.
 		if shouldUploadPart(objectPart{

--- a/api-put-object-readat.go
+++ b/api-put-object-readat.go
@@ -155,7 +155,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 		var reader io.Reader
 		// Update progress reader appropriately to the latest offset
 		// as we read from the source.
-		reader = newHook(bytes.NewReader(tmpBuffer.Bytes()), progress)
+		reader = newHook(tmpBuffer, progress)
 
 		// Proceed to upload the part.
 		var objPart objectPart


### PR DESCRIPTION
In Current code it was done so that we could create a Seeker, so that
if the request fails we could retry with the same body buffer.

But memory allocation doubles for example in case of uploading a
1GB file a maximum size of 550MB buffer in case of putObjectStream()
leads to 1GB usage this is bad for tiny distros and embedded systems.

Ideally it would have preferred if bytes.NewBuffer() gave us a Seeker()
too, but we will fix that with our own implementation.