### PR TITLE
FPutObject: Implement automatic detection of mime-type if not provided

### DIFF
--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"os"
+	"path/filepath"
 	"sort"
 )
 
@@ -55,6 +57,14 @@ func (c Client) FPutObject(bucketName, objectName, filePath, contentType string)
 	// Check for largest object size allowed.
 	if fileSize > int64(maxMultipartPutObjectSize) {
 		return 0, ErrEntityTooLarge(fileSize, maxMultipartPutObjectSize, bucketName, objectName)
+	}
+
+	// Set contentType based on filepath extension if not given or default
+	// value of "binary/octet-stream" if the extension has no associated type.
+	if contentType == "" {
+		if contentType = mime.TypeByExtension(filepath.Ext(filePath)); contentType == "" {
+			contentType = "application/octet-stream"
+		}
 	}
 
 	// NOTE: Google Cloud Storage multipart Put is not compatible with Amazon S3 APIs.

--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -341,6 +341,154 @@ func TestResumablePutObjectV2(t *testing.T) {
 
 }
 
+// Tests FPutObject hidden contentType setting
+func TestFPutObjectV2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping functional tests for short runs")
+	}
+
+	// Seed random based on current time.
+	rand.Seed(time.Now().Unix())
+
+	// Instantiate new minio client object.
+	c, err := minio.NewV2(
+		"s3.amazonaws.com",
+		os.Getenv("ACCESS_KEY"),
+		os.Getenv("SECRET_KEY"),
+		false,
+	)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Enable tracing, write to stderr.
+	// c.TraceOn(os.Stderr)
+
+	// Set user agent.
+	c.SetAppInfo("Minio-go-FunctionalTest", "0.1.0")
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()))
+
+	// Make a new bucket.
+	err = c.MakeBucket(bucketName, "us-east-1")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName)
+	}
+
+	// Make a temp file with 11*1024*1024 bytes of data.
+	file, err := ioutil.TempFile(os.TempDir(), "FPutObjectTest")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	n, err := io.CopyN(file, crand.Reader, 11*1024*1024)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Close the file pro-actively for windows.
+	err = file.Close()
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Set base object name
+	objectName := bucketName + "FPutObject"
+
+	// Perform standard FPutObject with contentType provided (Expecting application/octet-stream)
+	n, err = c.FPutObject(bucketName, objectName+"-standard", file.Name(), "application/octet-stream")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Perform FPutObject with no contentType provided (Expecting application/octet-stream)
+	n, err = c.FPutObject(bucketName, objectName+"-Octet", file.Name(), "")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Add extension to temp file name
+	fileName := file.Name()
+	err = os.Rename(file.Name(), fileName+".gtar")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Perform FPutObject with no contentType provided (Expecting application/x-gtar)
+	n, err = c.FPutObject(bucketName, objectName+"-GTar", fileName+".gtar", "")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Check headers
+	rStandard, err := c.StatObject(bucketName, objectName+"-standard")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName+"-standard")
+	}
+	if rStandard.ContentType != "application/octet-stream" {
+		t.Fatalf("Error: Content-Type headers mismatched, want %v, got %v\n",
+			"application/octet-stream", rStandard.ContentType)
+	}
+
+	rOctet, err := c.StatObject(bucketName, objectName+"-Octet")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName+"-Octet")
+	}
+	if rOctet.ContentType != "application/octet-stream" {
+		t.Fatalf("Error: Content-Type headers mismatched, want %v, got %v\n",
+			"application/octet-stream", rStandard.ContentType)
+	}
+
+	rGTar, err := c.StatObject(bucketName, objectName+"-GTar")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName+"-GTar")
+	}
+	if rGTar.ContentType != "application/x-gtar" {
+		t.Fatalf("Error: Content-Type headers mismatched, want %v, got %v\n",
+			"application/x-gtar", rStandard.ContentType)
+	}
+
+	// Remove all objects and bucket and temp file
+	err = c.RemoveObject(bucketName, objectName+"-standard")
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+
+	err = c.RemoveObject(bucketName, objectName+"-Octet")
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+
+	err = c.RemoveObject(bucketName, objectName+"-GTar")
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+
+	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = os.Remove(fileName + ".gtar")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+}
+
 // Tests resumable file based put object multipart upload.
 func TestResumableFPutObjectV2(t *testing.T) {
 	if testing.Short() {

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -498,6 +498,154 @@ func TestResumableFPutObject(t *testing.T) {
 	}
 }
 
+// Tests FPutObject hidden contentType setting
+func TestFPutObject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping functional tests for short runs")
+	}
+
+	// Seed random based on current time.
+	rand.Seed(time.Now().Unix())
+
+	// Instantiate new minio client object.
+	c, err := minio.New(
+		"s3.amazonaws.com",
+		os.Getenv("ACCESS_KEY"),
+		os.Getenv("SECRET_KEY"),
+		false,
+	)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Enable tracing, write to stderr.
+	// c.TraceOn(os.Stderr)
+
+	// Set user agent.
+	c.SetAppInfo("Minio-go-FunctionalTest", "0.1.0")
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()))
+
+	// Make a new bucket.
+	err = c.MakeBucket(bucketName, "us-east-1")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName)
+	}
+
+	// Make a temp file with 11*1024*1024 bytes of data.
+	file, err := ioutil.TempFile(os.TempDir(), "FPutObjectTest")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	n, err := io.CopyN(file, crand.Reader, 11*1024*1024)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Close the file pro-actively for windows.
+	err = file.Close()
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Set base object name
+	objectName := bucketName + "FPutObject"
+
+	// Perform standard FPutObject with contentType provided (Expecting application/octet-stream)
+	n, err = c.FPutObject(bucketName, objectName+"-standard", file.Name(), "application/octet-stream")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Perform FPutObject with no contentType provided (Expecting application/octet-stream)
+	n, err = c.FPutObject(bucketName, objectName+"-Octet", file.Name(), "")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Add extension to temp file name
+	fileName := file.Name()
+	err = os.Rename(file.Name(), fileName+".gtar")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Perform FPutObject with no contentType provided (Expecting application/x-gtar)
+	n, err = c.FPutObject(bucketName, objectName+"-GTar", fileName+".gtar", "")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if n != int64(11*1024*1024) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", 11*1024*1024, n)
+	}
+
+	// Check headers
+	rStandard, err := c.StatObject(bucketName, objectName+"-standard")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName+"-standard")
+	}
+	if rStandard.ContentType != "application/octet-stream" {
+		t.Fatalf("Error: Content-Type headers mismatched, want %v, got %v\n",
+			"application/octet-stream", rStandard.ContentType)
+	}
+
+	rOctet, err := c.StatObject(bucketName, objectName+"-Octet")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName+"-Octet")
+	}
+	if rOctet.ContentType != "application/octet-stream" {
+		t.Fatalf("Error: Content-Type headers mismatched, want %v, got %v\n",
+			"application/octet-stream", rStandard.ContentType)
+	}
+
+	rGTar, err := c.StatObject(bucketName, objectName+"-GTar")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName+"-GTar")
+	}
+	if rGTar.ContentType != "application/x-gtar" {
+		t.Fatalf("Error: Content-Type headers mismatched, want %v, got %v\n",
+			"application/x-gtar", rStandard.ContentType)
+	}
+
+	// Remove all objects and bucket and temp file
+	err = c.RemoveObject(bucketName, objectName+"-standard")
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+
+	err = c.RemoveObject(bucketName, objectName+"-Octet")
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+
+	err = c.RemoveObject(bucketName, objectName+"-GTar")
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+
+	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	err = os.Remove(fileName + ".gtar")
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+}
+
 // Tests get object ReaderSeeker interface methods.
 func TestGetObjectReadSeekFunctional(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
This patch allows for automatic detection of mime-type if it is not provided in the contentType field, and sets it to the default "application/octet-stream" if the automatic detection is unable to find a suitable mime-type.

New tests FPutObject and FPutObjectV2 have been added in api_functional_tests_v4 and api_functional_tests_v2 respectively. 