### PR TITLE
Do not sort requestList in each call and add an unit test to check if it is already correctly sorted

### DIFF
--- a/request-signature-v2.go
+++ b/request-signature-v2.go
@@ -235,7 +235,8 @@ func writeCanonicalizedHeaders(buf *bytes.Buffer, req http.Request) {
 	}
 }
 
-// Must be sorted:
+// The following list is already sorted and should always be, otherwise we could
+// have signature-related issues
 var resourceList = []string{
 	"acl",
 	"location",
@@ -243,13 +244,13 @@ var resourceList = []string{
 	"notification",
 	"partNumber",
 	"policy",
-	"response-content-type",
-	"response-content-language",
-	"response-expires",
+	"requestPayment",
 	"response-cache-control",
 	"response-content-disposition",
 	"response-content-encoding",
-	"requestPayment",
+	"response-content-language",
+	"response-content-type",
+	"response-expires",
 	"torrent",
 	"uploadId",
 	"uploads",
@@ -271,7 +272,6 @@ func writeCanonicalizedResource(buf *bytes.Buffer, req http.Request) {
 	path := encodeURL2Path(requestURL)
 	buf.WriteString(path)
 
-	sort.Strings(resourceList)
 	if requestURL.RawQuery != "" {
 		var n int
 		vals, _ := url.ParseQuery(requestURL.RawQuery)

--- a/request-signature-v2_test.go
+++ b/request-signature-v2_test.go
@@ -1,0 +1,35 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"sort"
+	"testing"
+)
+
+// Tests for 'func TestResourceListSorting(t *testing.T)'.
+func TestResourceListSorting(t *testing.T) {
+	sortedResourceList := make([]string, len(resourceList))
+	copy(sortedResourceList, resourceList)
+	sort.Strings(sortedResourceList)
+	for i := 0; i < len(resourceList); i++ {
+		if resourceList[i] != sortedResourceList[i] {
+			t.Errorf("Expected resourceList[%d] = \"%s\", resourceList is not correctly sorted.", i, sortedResourceList[i])
+			break
+		}
+	}
+}


### PR DESCRIPTION
An optimization which corrects this bug https://github.com/minio/minio-go/issues/375 (concurrent routines trying to sort resourceList)