### PR TITLE
list: Fix listObjects to avoid large bufferred channels to facilitate…

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -77,7 +77,7 @@ func (c Client) ListBuckets() ([]BucketInfo, error) {
 //
 func (c Client) ListObjects(bucketName, objectPrefix string, recursive bool, doneCh <-chan struct{}) <-chan ObjectInfo {
 	// Allocate new list objects channel.
-	objectStatCh := make(chan ObjectInfo, 1000)
+	objectStatCh := make(chan ObjectInfo)
 	// Default listing is delimited at "/"
 	delimiter := "/"
 	if recursive {
@@ -254,7 +254,7 @@ func (c Client) ListIncompleteUploads(bucketName, objectPrefix string, recursive
 // listIncompleteUploads lists all incomplete uploads.
 func (c Client) listIncompleteUploads(bucketName, objectPrefix string, recursive, aggregateSize bool, doneCh <-chan struct{}) <-chan ObjectMultipartInfo {
 	// Allocate channel for multipart uploads.
-	objectMultipartStatCh := make(chan ObjectMultipartInfo, 1000)
+	objectMultipartStatCh := make(chan ObjectMultipartInfo)
 	// Delimiter is set to "/" by default.
 	delimiter := "/"
 	if recursive {

--- a/examples/s3/listobjects-N.go
+++ b/examples/s3/listobjects-N.go
@@ -1,0 +1,76 @@
+// +build ignore
+
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/minio/minio-go"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and my-prefixname
+	// are dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set insecure=true to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API copatibality (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", false)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// List 'N' number of objects from a bucket-name with a matching prefix.
+	listObjectsN := func(bucket, prefix string, recursive bool, N int) (objsInfo []minio.ObjectInfo, err error) {
+		// Create a done channel to control 'ListObjects' go routine.
+		doneCh := make(chan struct{}, 1)
+
+		// Free the channel upon return.
+		defer close(doneCh)
+
+		i := 1
+		for object := range s3Client.ListObjects(bucket, prefix, recursive, doneCh) {
+			if object.Err != nil {
+				return nil, object.Err
+			}
+			i++
+			// Verify if we have printed N objects.
+			if i == N {
+				// Indicate ListObjects go-routine to exit and stop
+				// feeding the objectInfo channel.
+				doneCh <- struct{}{}
+			}
+			objsInfo = append(objsInfo, object)
+		}
+		return objsInfo, nil
+	}
+
+	// List recursively first 100 entries for prefix 'my-prefixname'.
+	recursive := true
+	objsInfo, err := listObjectsN("my-bucketname", "my-prefixname", recursive, 100)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Print all the entries.
+	fmt.Println(objsInfo)
+}


### PR DESCRIPTION
… doneCh.

If we send 1000 bufferred entries simultaneously in bufferred channel, the
top level caller while using doneCh to limit the entries will have no way
to communicate back on how much a ListObjects should be listing the entries
for.

The usual scenario is when one wishes to only get N entires from ListObjects,
It is better for us to send 1 entry at a time so that as and when the
doneCh is called we exit the loop without accumulating more entries than
was needed.

Following program talks about how this issue can happen.
```
func testListBackets() {
    doneCh := make(chan struct{}, 1)
    defer close(doneCh)

    n := 0
    objectCh := s3cli.ListObjects("backet", "", true, doneCh)
    for object := range objectCh {
        if object.Err != nil {
            fmt.Println(object.Err)
            return
        }
        n++
        fmt.Println(n, object)
        if n == 14 {
            doneCh <- struct{}{}
        }
        // waiting here ........................................................
        fmt.Println(n) // Println does not print 14
    }
}
```

Here the program ends up printing 15th object as well even after doneCh indicating
the routine to exit.

Fixes #386