### PR TITLE
retry: Add doneCh to retry timer, to gracefully terminate the go-rout…

### DIFF
--- a/api.go
+++ b/api.go
@@ -419,10 +419,16 @@ func (c Client) executeMethod(method string, metadata requestMetadata) (res *htt
 		bodySeeker, isRetryable = metadata.contentBody.(io.Seeker)
 	}
 
+	// Create a done channel to control 'ListObjects' go routine.
+	doneCh := make(chan struct{}, 1)
+
+	// Indicate to our routine to exit cleanly upon return.
+	defer close(doneCh)
+
 	// Blank indentifier is kept here on purpose since 'range' without
 	// blank identifiers is only supported since go1.4
 	// https://golang.org/doc/go1.4#forrange.
-	for _ = range c.newRetryTimer(MaxRetry, time.Second, time.Second*30, MaxJitter) {
+	for _ = range c.newRetryTimer(MaxRetry, time.Second, time.Second*30, MaxJitter, doneCh) {
 		// Retry executes the following function body if request has an
 		// error until maxRetries have been exhausted, retry attempts are
 		// performed after waiting for a given period of time in a

--- a/retry.go
+++ b/retry.go
@@ -35,7 +35,7 @@ const NoJitter = 0.0
 
 // newRetryTimer creates a timer with exponentially increasing delays
 // until the maximum retry attempts are reached.
-func (c Client) newRetryTimer(maxRetry int, unit time.Duration, cap time.Duration, jitter float64) <-chan int {
+func (c Client) newRetryTimer(maxRetry int, unit time.Duration, cap time.Duration, jitter float64, doneCh chan struct{}) <-chan int {
 	attemptCh := make(chan int)
 
 	// computes the exponential backoff duration according to
@@ -63,7 +63,13 @@ func (c Client) newRetryTimer(maxRetry int, unit time.Duration, cap time.Duratio
 	go func() {
 		defer close(attemptCh)
 		for i := 0; i < maxRetry; i++ {
-			attemptCh <- i + 1 // Attempts start from 1.
+			select {
+			// Attempts start from 1.
+			case attemptCh <- i + 1:
+			case <-doneCh:
+				// Stop the routine.
+				return
+			}
 			time.Sleep(exponentialBackoffWait(i))
 		}
 	}()


### PR DESCRIPTION
…ine.

Without this fix the newRetryTimer() would be hung endlessly
forever crashing the program eventually. Add a done channel to
signal routine to exit cleanly.

Fixes #388