### PR TITLE
api: Change PresignedPostPolicy to return back proper URL

### DIFF
--- a/API.md
+++ b/API.md
@@ -446,7 +446,7 @@ if err != nil {
 ### Presigned operations
 ---------------------------------------
 <a name="PresignedGetObject">
-#### PresignedGetObject(bucketName, objectName string, expiry time.Duration, reqParams url.Values) error
+#### PresignedGetObject(bucketName, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error)
 Generate a presigned URL for GET.
 
 __Parameters__
@@ -471,7 +471,7 @@ if err != nil {
 
 ---------------------------------------
 <a name="PresignedPutObject">
-#### PresignedPutObject(bucketName string, objectName string, expiry time.Duration) (string, error)
+#### PresignedPutObject(bucketName string, objectName string, expiry time.Duration) (*url.URL, error)
 Generate a presigned URL for PUT.
 <blockquote>
 NOTE: you can upload to S3 only with specified object name.
@@ -494,7 +494,7 @@ if err != nil {
 
 ---------------------------------------
 <a name="PresignedPostPolicy">
-#### PresignedPostPolicy(policy PostPolicy) (map[string]string, error)
+#### PresignedPostPolicy(policy PostPolicy) (*url.URL, map[string]string, error)
 PresignedPostPolicy we can provide policies specifying conditions restricting
 what you want to allow in a POST request, such as bucket name where objects can be
 uploaded, key name prefixes that you want to allow for the object being created and more.
@@ -517,7 +517,7 @@ policy.SetContentLengthRange(1024, 1024*1024)
 ```
 Get the POST form key/value object:
 ```go
-formData, err := s3Client.PresignedPostPolicy(policy)
+url, formData, err := s3Client.PresignedPostPolicy(policy)
 if err != nil {
     fmt.Println(err)
     return
@@ -531,5 +531,5 @@ for k, v := range m {
     fmt.Printf("-F %s=%s ", k, v)
 }
 fmt.Printf("-F file=@/etc/bash.bashrc ")
-fmt.Printf("https://my-bucketname.s3.amazonaws.com\n")
+fmt.Printf("%s\n", url)
 ```

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ func main() {
 * [FGetObject(bucketName, objectName, filePath) error](examples/s3/fgetobject.go)
 
 ### Presigned Operations.
-* [PresignedGetObject(bucketName, objectName, time.Duration, url.Values) (string, error)](examples/s3/presignedgetobject.go)
-* [PresignedPutObject(bucketName, objectName, time.Duration) (string, error)](examples/s3/presignedputobject.go)
-* [PresignedPostPolicy(NewPostPolicy()) (map[string]string, error)](examples/s3/presignedpostpolicy.go)
+* [PresignedGetObject(bucketName, objectName, time.Duration, url.Values) (*url.URL, error)](examples/s3/presignedgetobject.go)
+* [PresignedPutObject(bucketName, objectName, time.Duration) (*url.URL, error)](examples/s3/presignedputobject.go)
+* [PresignedPostPolicy(NewPostPolicy()) (*url.URL, map[string]string, error)](examples/s3/presignedpostpolicy.go)
 
 ### Bucket Policy Operations.
 * [SetBucketPolicy(bucketName, objectPrefix, BucketPolicy) error](examples/s3/setbucketpolicy.go)

--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -1184,7 +1184,7 @@ func TestFunctionalV2(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 	// Verify if presigned url works.
-	resp, err := http.Get(presignedGetURL)
+	resp, err := http.Get(presignedGetURL.String())
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
@@ -1208,7 +1208,7 @@ func TestFunctionalV2(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 	// Verify if presigned url works.
-	resp, err = http.Get(presignedGetURL)
+	resp, err = http.Get(presignedGetURL.String())
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
@@ -1236,7 +1236,7 @@ func TestFunctionalV2(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	req, err := http.NewRequest("PUT", presignedPutURL, bytes.NewReader(buf))
+	req, err := http.NewRequest("PUT", presignedPutURL.String(), bytes.NewReader(buf))
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -1256,7 +1256,7 @@ func TestFunctional(t *testing.T) {
 	}
 
 	// Verify if presigned url works.
-	resp, err := http.Get(presignedGetURL)
+	resp, err := http.Get(presignedGetURL.String())
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
@@ -1279,7 +1279,7 @@ func TestFunctional(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 	// Verify if presigned url works.
-	resp, err = http.Get(presignedGetURL)
+	resp, err = http.Get(presignedGetURL.String())
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
@@ -1306,7 +1306,7 @@ func TestFunctional(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	req, err := http.NewRequest("PUT", presignedPutURL, bytes.NewReader(buf))
+	req, err := http.NewRequest("PUT", presignedPutURL.String(), bytes.NewReader(buf))
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}

--- a/examples/s3/presignedpostpolicy.go
+++ b/examples/s3/presignedpostpolicy.go
@@ -43,15 +43,17 @@ func main() {
 	policy := minio.NewPostPolicy()
 	policy.SetBucket("my-bucketname")
 	policy.SetKey("my-objectname")
-	policy.SetExpires(time.Now().UTC().AddDate(0, 0, 10)) // expires in 10 days
-	m, err := s3Client.PresignedPostPolicy(policy)
+	// Expires in 10 days.
+	policy.SetExpires(time.Now().UTC().AddDate(0, 0, 10))
+	// Returns form data for POST form request.
+	url, formData, err := s3Client.PresignedPostPolicy(policy)
 	if err != nil {
 		log.Fatalln(err)
 	}
 	fmt.Printf("curl ")
-	for k, v := range m {
+	for k, v := range formData {
 		fmt.Printf("-F %s=%s ", k, v)
 	}
 	fmt.Printf("-F file=@/etc/bash.bashrc ")
-	fmt.Printf("https://my-bucketname.s3.amazonaws.com\n")
+	fmt.Printf("%s\n", url)
 }


### PR DESCRIPTION
The reason to do this is because bucket names can be in
various different regions and for users it becomes convenient
if we return back the proper endpoint which can be safely used
without worrying about virtual host style or path style.

We have enough information to provide a proper URL, this is also
consistent with other Presigned operations as it would be an
expected behavior.