### PR TITLE
api: CopyObject Etags are different from source.

### DIFF
--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -996,10 +996,6 @@ func TestCopyObjectV2(t *testing.T) {
 		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n",
 			objInfo.Size, objInfoCopy.Size)
 	}
-	if objInfo.ETag != objInfoCopy.ETag {
-		t.Fatalf("Error: ETags do not match, want %v, got %v\n",
-			objInfoCopy.ETag, objInfo.ETag)
-	}
 
 	// Remove all objects and buckets
 	err = c.RemoveObject(bucketName, objectName)

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -1025,10 +1025,6 @@ func TestCopyObject(t *testing.T) {
 		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n",
 			objInfo.Size, objInfoCopy.Size)
 	}
-	if objInfo.ETag != objInfoCopy.ETag {
-		t.Fatalf("Error: ETags do not match, want %v, got %v\n",
-			objInfoCopy.ETag, objInfo.ETag)
-	}
 
 	// Remove all objects and buckets
 	err = c.RemoveObject(bucketName, objectName)


### PR DESCRIPTION
We do not have to validate them.