### PR TITLE
Fixed part size

### DIFF
--- a/api-put-object-common.go
+++ b/api-put-object-common.go
@@ -68,7 +68,7 @@ func shouldUploadPart(objPart objectPart, objectParts map[int]objectPart) bool {
 // NOTE: Assumption here is that for any object to be uploaded to any S3 compatible
 // object storage it will have the following parameters as constants.
 //
-//  maxPartsCount - 10000
+//  maxPartsCount - 1000000
 //  minPartSize - 5MiB
 //  maxMultipartPutObjectSize - 5TiB
 //

--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -341,14 +341,14 @@ func TestPartSize(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	if totalPartsCount != 9987 {
-		t.Fatalf("Error: expecting total parts count of 9987: got %v instead", totalPartsCount)
+	if totalPartsCount != 524288 {
+		t.Fatalf("Error: expecting total parts count of 524288: got %v instead", totalPartsCount)
 	}
-	if partSize != 550502400 {
-		t.Fatalf("Error: expecting part size of 550502400: got %v instead", partSize)
+	if partSize != 10485760 {
+		t.Fatalf("Error: expecting part size of 10485760: got %v instead", partSize)
 	}
-	if lastPartSize != 241172480 {
-		t.Fatalf("Error: expecting last part size of 241172480: got %v instead", lastPartSize)
+	if lastPartSize != 10485760 {
+		t.Fatalf("Error: expecting last part size of 10485760: got %v instead", lastPartSize)
 	}
 	totalPartsCount, partSize, lastPartSize, err = optimalPartInfo(5000000000)
 	if err != nil {
@@ -361,13 +361,26 @@ func TestPartSize(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
-	if totalPartsCount != 9987 {
-		t.Fatalf("Error: expecting total parts count of 9987: got %v instead", totalPartsCount)
+	if totalPartsCount != 524288 {
+		t.Fatalf("Error: expecting total parts count of 524288: got %v instead", totalPartsCount)
 	}
-	if partSize != 550502400 {
-		t.Fatalf("Error: expecting part size of 550502400: got %v instead", partSize)
+	if partSize != 10485760 {
+		t.Fatalf("Error: expecting part size of 10485760: got %v instead", partSize)
 	}
-	if lastPartSize != 241172480 {
-		t.Fatalf("Error: expecting last part size of 241172480: got %v instead", lastPartSize)
+	if lastPartSize != 10485760 {
+		t.Fatalf("Error: expectings last part size of 10485760: got %v instead", lastPartSize)
+	}
+	totalPartsCount, partSize, lastPartSize, err = optimalPartInfo(1073741824)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	if totalPartsCount != 205 {
+		t.Fatalf("Error: expecting total parts count of 205: got %v instead", totalPartsCount)
+	}
+	if partSize != 5242880 {
+		t.Fatalf("Error: expecting part size of 5242880: got %v instead", partSize)
+	}
+	if lastPartSize != 4194304 {
+		t.Fatalf("Error: expecting last part size of 4194304: got %v instead", lastPartSize)
 	}
 }

--- a/constants.go
+++ b/constants.go
@@ -23,7 +23,7 @@ package minio
 const minPartSize = 1024 * 1024 * 5
 
 // maxPartsCount - maximum number of parts for a single multipart session.
-const maxPartsCount = 10000
+const maxPartsCount = 1000000
 
 // maxPartSize - maximum part size 5GiB for a single multipart upload
 // operation.


### PR DESCRIPTION
With maxMultipartPutObjectSize set to 5TiB and dividing by maxPartsCount of 10000, you get 525mb chunks which... doesn't work for some providers who support s3. 

I believe intent was 5MiB chucks 