### PR TITLE
Access Policy: Policy Removal Fix

### DIFF
--- a/bucket-policy.go
+++ b/bucket-policy.go
@@ -207,9 +207,10 @@ func isBucketPolicyReadOnly(statements []Statement, bucketName string, objectPre
 // Removes read write bucket policy if found.
 func removeBucketPolicyStatementReadWrite(statements []Statement, bucketName string, objectPrefix string) []Statement {
 	var newStatements []Statement
+	var bucketResourceStatementRemoved bool
 	for _, statement := range statements {
 		for _, resource := range statement.Resources {
-			if resource == awsResourcePrefix+bucketName {
+			if resource == awsResourcePrefix+bucketName && !bucketResourceStatementRemoved {
 				var newActions []string
 				for _, action := range statement.Actions {
 					switch action {
@@ -219,6 +220,7 @@ func removeBucketPolicyStatementReadWrite(statements []Statement, bucketName str
 					newActions = append(newActions, action)
 				}
 				statement.Actions = newActions
+				bucketResourceStatementRemoved = true
 			} else if resource == awsResourcePrefix+bucketName+"/"+objectPrefix+"*" {
 				var newActions []string
 				for _, action := range statement.Actions {
@@ -241,9 +243,10 @@ func removeBucketPolicyStatementReadWrite(statements []Statement, bucketName str
 // Removes write only bucket policy if found.
 func removeBucketPolicyStatementWriteOnly(statements []Statement, bucketName string, objectPrefix string) []Statement {
 	var newStatements []Statement
+	var bucketResourceStatementRemoved bool
 	for _, statement := range statements {
 		for _, resource := range statement.Resources {
-			if resource == awsResourcePrefix+bucketName {
+			if resource == awsResourcePrefix+bucketName && !bucketResourceStatementRemoved {
 				var newActions []string
 				for _, action := range statement.Actions {
 					switch action {
@@ -253,6 +256,7 @@ func removeBucketPolicyStatementWriteOnly(statements []Statement, bucketName str
 					newActions = append(newActions, action)
 				}
 				statement.Actions = newActions
+				bucketResourceStatementRemoved = true
 			} else if resource == awsResourcePrefix+bucketName+"/"+objectPrefix+"*" {
 				var newActions []string
 				for _, action := range statement.Actions {
@@ -275,9 +279,10 @@ func removeBucketPolicyStatementWriteOnly(statements []Statement, bucketName str
 // Removes read only bucket policy if found.
 func removeBucketPolicyStatementReadOnly(statements []Statement, bucketName string, objectPrefix string) []Statement {
 	var newStatements []Statement
+	var bucketResourceStatementRemoved bool
 	for _, statement := range statements {
 		for _, resource := range statement.Resources {
-			if resource == awsResourcePrefix+bucketName {
+			if resource == awsResourcePrefix+bucketName && !bucketResourceStatementRemoved {
 				var newActions []string
 				for _, action := range statement.Actions {
 					switch action {
@@ -287,6 +292,7 @@ func removeBucketPolicyStatementReadOnly(statements []Statement, bucketName stri
 					newActions = append(newActions, action)
 				}
 				statement.Actions = newActions
+				bucketResourceStatementRemoved = true
 			} else if resource == awsResourcePrefix+bucketName+"/"+objectPrefix+"*" {
 				var newActions []string
 				for _, action := range statement.Actions {

--- a/bucket-policy_test.go
+++ b/bucket-policy_test.go
@@ -393,6 +393,7 @@ func TestRemoveBucketPolicyStatementReadOnly(t *testing.T) {
 	}{
 		{"my-bucket", "", []Statement{}, emptyStatement},
 		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", ""), emptyStatement},
+		{"my-bucket", "abc/", append(setReadOnlyStatement("my-bucket", "abc/"), setReadOnlyStatement("my-bucket", "def/")...), setReadOnlyStatement("my-bucket", "def/")},
 	}
 	for i, testCase := range testCases {
 		actualStatements := removeBucketPolicyStatementReadOnly(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)
@@ -414,6 +415,7 @@ func TestRemoveBucketPolicyStatementWriteOnly(t *testing.T) {
 	}{
 		{"my-bucket", "", []Statement{}, emptyStatement},
 		{"write-only-bucket", "", setWriteOnlyStatement("write-only-bucket", ""), emptyStatement},
+		{"my-bucket", "abc/", append(setWriteOnlyStatement("my-bucket", "abc/"), setWriteOnlyStatement("my-bucket", "def/")...), setWriteOnlyStatement("my-bucket", "def/")},
 	}
 	for i, testCase := range testCases {
 		actualStatements := removeBucketPolicyStatementWriteOnly(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)
@@ -435,6 +437,7 @@ func TestRemoveBucketPolicyStatementReadWrite(t *testing.T) {
 	}{
 		{"my-bucket", "", []Statement{}, emptyStatement},
 		{"read-write-bucket", "", setReadWriteStatement("read-write-bucket", ""), emptyStatement},
+		{"my-bucket", "abc/", append(setReadWriteStatement("my-bucket", "abc/"), setReadWriteStatement("my-bucket", "def/")...), setReadWriteStatement("my-bucket", "def/")},
 	}
 	for i, testCase := range testCases {
 		actualStatements := removeBucketPolicyStatementReadWrite(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)


### PR DESCRIPTION
Fixes: https://github.com/minio/minio-go/issues/406 (Bug in access policy removal)

* Added boolean in the remove policy functions to prevent the function from removing more than one Bucket Resource Statement.
* Test cases added to bucket-policy unit tests