### PR TITLE
Access Policy: Resource Matching

### DIFF
--- a/bucket-policy.go
+++ b/bucket-policy.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // maximum supported access policy size.
@@ -149,7 +150,7 @@ func isBucketPolicyReadWrite(statements []Statement, bucketName string, objectPr
 					commonActions = true
 					continue
 				}
-			} else if resource == awsResourcePrefix+bucketName+"/"+objectPrefix+"*" {
+			} else if resourceMatch(resource, awsResourcePrefix+bucketName+"/"+objectPrefix) {
 				if subsetActions(readWriteObjectActions, statement.Actions) {
 					readWrite = true
 				}
@@ -171,7 +172,7 @@ func isBucketPolicyWriteOnly(statements []Statement, bucketName string, objectPr
 					commonActions = true
 					continue
 				}
-			} else if resource == awsResourcePrefix+bucketName+"/"+objectPrefix+"*" {
+			} else if resourceMatch(resource, awsResourcePrefix+bucketName+"/"+objectPrefix) {
 				if subsetActions(writeOnlyObjectActions, statement.Actions) {
 					writeOnly = true
 				}
@@ -193,7 +194,7 @@ func isBucketPolicyReadOnly(statements []Statement, bucketName string, objectPre
 					commonActions = true
 					continue
 				}
-			} else if resource == awsResourcePrefix+bucketName+"/"+objectPrefix+"*" {
+			} else if resourceMatch(resource, awsResourcePrefix+bucketName+"/"+objectPrefix) {
 				if subsetActions(readOnlyObjectActions, statement.Actions) {
 					readOnly = true
 					break
@@ -313,15 +314,30 @@ func removeBucketPolicyStatementReadOnly(statements []Statement, bucketName stri
 
 // Remove bucket policies based on the type.
 func removeBucketPolicyStatement(statements []Statement, bucketName string, objectPrefix string) []Statement {
-	// Verify type of policy to be removed.
-	if isBucketPolicyReadWrite(statements, bucketName, objectPrefix) {
-		statements = removeBucketPolicyStatementReadWrite(statements, bucketName, objectPrefix)
-	} else if isBucketPolicyWriteOnly(statements, bucketName, objectPrefix) {
-		statements = removeBucketPolicyStatementWriteOnly(statements, bucketName, objectPrefix)
-	} else if isBucketPolicyReadOnly(statements, bucketName, objectPrefix) {
-		statements = removeBucketPolicyStatementReadOnly(statements, bucketName, objectPrefix)
+	// Verify that a policy is defined on the object prefix, otherwise do not remove the policy
+	if isPolicyDefinedForObjectPrefix(statements, bucketName, objectPrefix) {
+		// Verify type of policy to be removed.
+		if isBucketPolicyReadWrite(statements, bucketName, objectPrefix) {
+			statements = removeBucketPolicyStatementReadWrite(statements, bucketName, objectPrefix)
+		} else if isBucketPolicyWriteOnly(statements, bucketName, objectPrefix) {
+			statements = removeBucketPolicyStatementWriteOnly(statements, bucketName, objectPrefix)
+		} else if isBucketPolicyReadOnly(statements, bucketName, objectPrefix) {
+			statements = removeBucketPolicyStatementReadOnly(statements, bucketName, objectPrefix)
+		}
 	}
 	return statements
+}
+
+// Checks if an access policiy is defined for the given object prefix
+func isPolicyDefinedForObjectPrefix(statements []Statement, bucketName string, objectPrefix string) bool {
+	for _, statement := range statements {
+		for _, resource := range statement.Resources {
+			if resource == awsResourcePrefix+bucketName+"/"+objectPrefix+"*" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Unmarshals bucket policy byte array into a structured bucket access policy.
@@ -491,4 +507,31 @@ func setWriteOnlyStatement(bucketName, objectPrefix string) []Statement {
 	// Save the write only policy.
 	statements = append(statements, bucketResourceStatement, objectResourceStatement)
 	return statements
+}
+
+// Match function matches wild cards in 'pattern' for resource.
+func resourceMatch(pattern, resource string) bool {
+	if pattern == "" {
+		return resource == pattern
+	}
+	if pattern == "*" {
+		return true
+	}
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return resource == pattern
+	}
+	tGlob := strings.HasSuffix(pattern, "*")
+	end := len(parts) - 1
+	if !strings.HasPrefix(resource, parts[0]) {
+		return false
+	}
+	for i := 1; i < end; i++ {
+		if !strings.Contains(resource, parts[i]) {
+			return false
+		}
+		idx := strings.Index(resource, parts[i]) + len(parts[i])
+		resource = resource[idx:]
+	}
+	return tGlob || strings.HasSuffix(resource, parts[end])
 }

--- a/bucket-policy_test.go
+++ b/bucket-policy_test.go
@@ -361,22 +361,52 @@ func TestUnMarshalBucketPolicyUntyped(t *testing.T) {
 	}
 }
 
-// Tests validate removal of policy statement from the list of statements.
-func TestRemoveBucketPolicyStatement(t *testing.T) {
+// Tests validate whether access policy is defined for the given object prefix
+func TestIsPolicyDefinedForObjectPrefix(t *testing.T) {
 	testCases := []struct {
 		bucketName      string
 		objectPrefix    string
 		inputStatements []Statement
+		expectedResult  bool
 	}{
-		{"my-bucket", "", []Statement{}},
-		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", "")},
-		{"write-only-bucket", "", setWriteOnlyStatement("write-only-bucket", "")},
-		{"read-write-bucket", "", setReadWriteStatement("read-write-bucket", "")},
+		{"my-bucket", "abc/", setReadOnlyStatement("my-bucket", "abc/"), true},
+		{"my-bucket", "abc/", setReadOnlyStatement("my-bucket", "ab/"), false},
+		{"my-bucket", "abc/", setReadOnlyStatement("my-bucket", "abcde"), false},
+		{"my-bucket", "abc/", setReadOnlyStatement("my-bucket", "abc/de"), false},
+		{"my-bucket", "abc", setReadOnlyStatement("my-bucket", "abc"), true},
+		{"bucket", "", setReadOnlyStatement("bucket", "abc/"), false},
+	}
+	for i, testCase := range testCases {
+		actualResult := isPolicyDefinedForObjectPrefix(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)
+		if actualResult != testCase.expectedResult {
+			t.Errorf("Test %d: Expected isPolicyDefinedForObjectPrefix to '%v', but instead found '%v'", i+1, testCase.expectedResult, actualResult)
+		}
+	}
+}
+
+// Tests validate removal of policy statement from the list of statements.
+func TestRemoveBucketPolicyStatement(t *testing.T) {
+	var emptyStatement []Statement
+	testCases := []struct {
+		bucketName         string
+		objectPrefix       string
+		inputStatements    []Statement
+		expectedStatements []Statement
+	}{
+		{"my-bucket", "", nil, emptyStatement},
+		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", ""), emptyStatement},
+		{"write-only-bucket", "", setWriteOnlyStatement("write-only-bucket", ""), emptyStatement},
+		{"read-write-bucket", "", setReadWriteStatement("read-write-bucket", ""), emptyStatement},
+		{"my-bucket", "abcd", setReadOnlyStatement("my-bucket", "abc"), setReadOnlyStatement("my-bucket", "abc")},
+		{"my-bucket", "abc/de", setReadOnlyStatement("my-bucket", "abc/"), setReadOnlyStatement("my-bucket", "abc/")},
+		{"my-bucket", "abcd", setWriteOnlyStatement("my-bucket", "abc"), setWriteOnlyStatement("my-bucket", "abc")},
+		{"my-bucket", "abc/de", setWriteOnlyStatement("my-bucket", "abc/"), setWriteOnlyStatement("my-bucket", "abc/")},
+		{"my-bucket", "abcd", setReadWriteStatement("my-bucket", "abc"), setReadWriteStatement("my-bucket", "abc")},
+		{"my-bucket", "abc/de", setReadWriteStatement("my-bucket", "abc/"), setReadWriteStatement("my-bucket", "abc/")},
 	}
 	for i, testCase := range testCases {
 		actualStatements := removeBucketPolicyStatement(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)
-		// empty statement is expected after the invocation of removeBucketPolicyStatement().
-		if len(actualStatements) != 0 {
+		if !reflect.DeepEqual(testCase.expectedStatements, actualStatements) {
 			t.Errorf("Test %d: The expected statements from resource statement generator doesn't match the actual statements", i+1)
 		}
 	}
@@ -393,6 +423,7 @@ func TestRemoveBucketPolicyStatementReadOnly(t *testing.T) {
 	}{
 		{"my-bucket", "", []Statement{}, emptyStatement},
 		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", ""), emptyStatement},
+		{"read-only-bucket", "abc/", setReadOnlyStatement("read-only-bucket", "abc/"), emptyStatement},
 		{"my-bucket", "abc/", append(setReadOnlyStatement("my-bucket", "abc/"), setReadOnlyStatement("my-bucket", "def/")...), setReadOnlyStatement("my-bucket", "def/")},
 	}
 	for i, testCase := range testCases {
@@ -415,6 +446,7 @@ func TestRemoveBucketPolicyStatementWriteOnly(t *testing.T) {
 	}{
 		{"my-bucket", "", []Statement{}, emptyStatement},
 		{"write-only-bucket", "", setWriteOnlyStatement("write-only-bucket", ""), emptyStatement},
+		{"write-only-bucket", "abc/", setWriteOnlyStatement("write-only-bucket", "abc/"), emptyStatement},
 		{"my-bucket", "abc/", append(setWriteOnlyStatement("my-bucket", "abc/"), setWriteOnlyStatement("my-bucket", "def/")...), setWriteOnlyStatement("my-bucket", "def/")},
 	}
 	for i, testCase := range testCases {
@@ -437,6 +469,7 @@ func TestRemoveBucketPolicyStatementReadWrite(t *testing.T) {
 	}{
 		{"my-bucket", "", []Statement{}, emptyStatement},
 		{"read-write-bucket", "", setReadWriteStatement("read-write-bucket", ""), emptyStatement},
+		{"read-write-bucket", "abc/", setReadWriteStatement("read-write-bucket", "abc/"), emptyStatement},
 		{"my-bucket", "abc/", append(setReadWriteStatement("my-bucket", "abc/"), setReadWriteStatement("my-bucket", "def/")...), setReadWriteStatement("my-bucket", "def/")},
 	}
 	for i, testCase := range testCases {
@@ -444,6 +477,62 @@ func TestRemoveBucketPolicyStatementReadWrite(t *testing.T) {
 		// empty statement is expected after the invocation of removeBucketPolicyStatement().
 		if !reflect.DeepEqual(testCase.expectedStatements, actualStatements) {
 			t.Errorf("Test %d: Expected policy statements doesn't match the actual one", i+1)
+		}
+	}
+}
+
+// Tests validate Bucket policy resource matcher.
+func TestBucketPolicyResourceMatch(t *testing.T) {
+
+	// generates\ statement with given resource..
+	generateStatement := func(resource string) Statement {
+		statement := Statement{}
+		statement.Resources = []string{resource}
+		return statement
+	}
+
+	// generates resource prefix.
+	generateResource := func(bucketName, objectName string) string {
+		return awsResourcePrefix + bucketName + "/" + objectName
+	}
+
+	testCases := []struct {
+		resourceToMatch       string
+		statement             Statement
+		expectedResourceMatch bool
+	}{
+		// Test case 1-4.
+		// Policy with resource ending with bucket/* allows access to all objects inside the given bucket.
+		{generateResource("minio-bucket", ""), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/*")), true},
+		{generateResource("minio-bucket", ""), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/*")), true},
+		{generateResource("minio-bucket", ""), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/*")), true},
+		{generateResource("minio-bucket", ""), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/*")), true},
+		// Test case - 5.
+		// Policy with resource ending with bucket/oo* should not allow access to bucket/output.txt.
+		{generateResource("minio-bucket", "output.txt"), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/oo*")), false},
+		// Test case - 6.
+		// Policy with resource ending with bucket/oo* should allow access to bucket/ootput.txt.
+		{generateResource("minio-bucket", "ootput.txt"), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/oo*")), true},
+		// Test case - 7.
+		// Policy with resource ending with bucket/oo* allows access to all subfolders starting with "oo" inside given bucket.
+		{generateResource("minio-bucket", "oop-bucket/my-file"), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/oo*")), true},
+		// Test case - 8.
+		{generateResource("minio-bucket", "Asia/India/1.pjg"), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/Asia/Japan/*")), false},
+		// Test case - 9.
+		{generateResource("minio-bucket", "Asia/India/1.pjg"), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix, "minio-bucket"+"/Asia/Japan/*")), false},
+		// Test case - 10.
+		// Proves that the name space is flat.
+		{generateResource("minio-bucket", "Africa/Bihar/India/design_info.doc/Bihar"), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix,
+			"minio-bucket"+"/*/India/*/Bihar")), true},
+		// Test case - 11.
+		// Proves that the name space is flat.
+		{generateResource("minio-bucket", "Asia/China/India/States/Bihar/output.txt"), generateStatement(fmt.Sprintf("%s%s", awsResourcePrefix,
+			"minio-bucket"+"/*/India/*/Bihar/*")), true},
+	}
+	for i, testCase := range testCases {
+		actualResourceMatch := resourceMatch(testCase.statement.Resources[0], testCase.resourceToMatch)
+		if testCase.expectedResourceMatch != actualResourceMatch {
+			t.Errorf("Test %d: Expected Resource match to be `%v`, but instead found it to be `%v`", i+1, testCase.expectedResourceMatch, actualResourceMatch)
 		}
 	}
 }
@@ -461,6 +550,11 @@ func TestIsBucketPolicyReadOnly(t *testing.T) {
 		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", ""), true},
 		{"write-only-bucket", "", setWriteOnlyStatement("write-only-bucket", ""), false},
 		{"read-write-bucket", "", setReadWriteStatement("read-write-bucket", ""), true},
+		{"my-bucket", "abc", setReadOnlyStatement("my-bucket", ""), true},
+		{"my-bucket", "abc", setReadOnlyStatement("my-bucket", "abc"), true},
+		{"my-bucket", "abcde", setReadOnlyStatement("my-bucket", "abc"), true},
+		{"my-bucket", "abc/d", setReadOnlyStatement("my-bucket", "abc/"), true},
+		{"my-bucket", "abc", setWriteOnlyStatement("my-bucket", ""), false},
 	}
 	for i, testCase := range testCases {
 		actualResult := isBucketPolicyReadOnly(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)
@@ -484,6 +578,10 @@ func TestIsBucketPolicyReadWrite(t *testing.T) {
 		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", ""), false},
 		{"write-only-bucket", "", setWriteOnlyStatement("write-only-bucket", ""), false},
 		{"read-write-bucket", "", setReadWriteStatement("read-write-bucket", ""), true},
+		{"my-bucket", "abc", setReadWriteStatement("my-bucket", ""), true},
+		{"my-bucket", "abc", setReadWriteStatement("my-bucket", "abc"), true},
+		{"my-bucket", "abcde", setReadWriteStatement("my-bucket", "abc"), true},
+		{"my-bucket", "abc/d", setReadWriteStatement("my-bucket", "abc/"), true},
 	}
 	for i, testCase := range testCases {
 		actualResult := isBucketPolicyReadWrite(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)
@@ -507,6 +605,11 @@ func TestIsBucketPolicyWriteOnly(t *testing.T) {
 		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", ""), false},
 		{"write-only-bucket", "", setWriteOnlyStatement("write-only-bucket", ""), true},
 		{"read-write-bucket", "", setReadWriteStatement("read-write-bucket", ""), true},
+		{"my-bucket", "abc", setWriteOnlyStatement("my-bucket", ""), true},
+		{"my-bucket", "abc", setWriteOnlyStatement("my-bucket", "abc"), true},
+		{"my-bucket", "abcde", setWriteOnlyStatement("my-bucket", "abc"), true},
+		{"my-bucket", "abc/d", setWriteOnlyStatement("my-bucket", "abc/"), true},
+		{"my-bucket", "abc", setReadOnlyStatement("my-bucket", ""), false},
 	}
 	for i, testCase := range testCases {
 		actualResult := isBucketPolicyWriteOnly(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)


### PR DESCRIPTION
Fixes: https://github.com/minio/minio-go/issues/409

* Included the resource match function (from minio server). Literal string equality -> matching resource pattern using resourceMatch function.
* Unit tests added for resourceMatch (taken from minio server) and isPolicyDefinedForObjectPrefix (newly added function)
* Test cases associated with matching and the changes added.