### PR TITLE
Closing the http response.Body (ReadCloser) after close during GetObject.

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -59,6 +59,9 @@ func (c Client) GetObject(bucketName, objectName string) (*Object, error) {
 			select {
 			// When the done channel is closed exit our routine.
 			case <-doneCh:
+				// Close the http response body before returning.
+				// This ends the connection with the server.
+				httpReader.Close()
 				return
 			// Request message.
 			case req := <-reqCh:


### PR DESCRIPTION
Exposed during https://github.com/minio/minio/issues/1800 . The response Body was not closed after `r.Close()` was called in api-v4-functional tests. That's why the call to `Remove` was blocked till server terminated the connection with a timeout.  