### PR TITLE
Fix typo in initial example in API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -14,7 +14,7 @@ import (
 func main() {
     secure := true // Make HTTPS requests by default.
     s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", secure)
-    if err !!= nil {
+    if err != nil {
         fmt.Println(err)
         return
     }


### PR DESCRIPTION
Very small typo fix for `API.md`.