### PR TITLE
Access Policy: Fixed misleading error response when same policy set twice

### DIFF
--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -176,10 +176,19 @@ func (c Client) SetBucketPolicy(bucketName string, objectPrefix string, bucketPo
 	}
 	statements = append(statements, generatedStatements...)
 
-	// No change in the statements indicates an attempt of setting 'none' on a prefix
-	// which doesn't have a pre-existing policy.
+	// No change in the statements indicates either an attempt of setting 'none'
+	// on a prefix which doesn't have a pre-existing policy, or setting a policy
+	// on a prefix which already has the same policy.
 	if reflect.DeepEqual(policy.Statements, statements) {
-		return ErrNoSuchBucketPolicy(fmt.Sprintf("No policy exists on %s/%s", bucketName, objectPrefix))
+		// If policy being set is 'none' return an error, otherwise return nil to
+		// prevent the unnecessary request from being sent
+		var err error
+		if bucketPolicy == BucketPolicyNone {
+			err = ErrNoSuchBucketPolicy(fmt.Sprintf("No policy exists on %s/%s", bucketName, objectPrefix))
+		} else {
+			err = nil
+		}
+		return err
 	}
 
 	policy.Statements = statements


### PR DESCRIPTION
Fixes: https://github.com/minio/minio-go/issues/429

* When same policy is set twice on same prefix, return directly with nil error
 response(without sending a request to server).