### PR TITLE
client: endpointURL should be saved as string and parsed as needed.

### DIFF
--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -88,7 +88,10 @@ func (c Client) makeBucketRequest(bucketName string, location string) (*http.Req
 	// is the preferred method here. The final location of the
 	// 'bucket' is provided through XML LocationConstraint data with
 	// the request.
-	targetURL := *c.endpointURL
+	targetURL, err := url.Parse(c.endpointURL)
+	if err != nil {
+		return nil, err
+	}
 	targetURL.Path = "/" + bucketName + "/"
 
 	// get a new HTTP request for the method.

--- a/api-put-bucket_test.go
+++ b/api-put-bucket_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"testing"
 )
 
@@ -33,11 +34,14 @@ func TestMakeBucketRequest(t *testing.T) {
 	// Used for asserting with the actual request generated.
 	createExpectedRequest := func(c *Client, bucketName string, location string, req *http.Request) (*http.Request, error) {
 
-		targetURL := *c.endpointURL
+		targetURL, err := url.Parse(c.endpointURL)
+		if err != nil {
+			return nil, err
+		}
 		targetURL.Path = "/" + bucketName + "/"
 
 		// get a new HTTP request for the method.
-		req, err := http.NewRequest("PUT", targetURL.String(), nil)
+		req, err = http.NewRequest("PUT", targetURL.String(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/api.go
+++ b/api.go
@@ -53,7 +53,7 @@ type Client struct {
 		appName    string
 		appVersion string
 	}
-	endpointURL *url.URL
+	endpointURL string
 
 	// Needs allocation.
 	httpClient     *http.Client
@@ -164,7 +164,7 @@ func privateNew(endpoint, accessKeyID, secretAccessKey string, secure bool) (*Cl
 	}
 
 	// Save endpoint URL, user agent for future uses.
-	clnt.endpointURL = endpointURL
+	clnt.endpointURL = endpointURL.String()
 
 	// Instantiate http client and bucket location cache.
 	clnt.httpClient = &http.Client{
@@ -621,14 +621,18 @@ func (c Client) setUserAgent(req *http.Request) {
 // makeTargetURL make a new target url.
 func (c Client) makeTargetURL(bucketName, objectName, bucketLocation string, queryValues url.Values) (*url.URL, error) {
 	// Save host.
-	host := c.endpointURL.Host
+	url, err := url.Parse(c.endpointURL)
+	if err != nil {
+		return nil, err
+	}
+	host := url.Host
 	// For Amazon S3 endpoint, try to fetch location based endpoint.
 	if isAmazonEndpoint(c.endpointURL) {
 		// Fetch new host based on the bucket location.
 		host = getS3Endpoint(bucketLocation)
 	}
 	// Save scheme.
-	scheme := c.endpointURL.Scheme
+	scheme := url.Scheme
 
 	urlStr := scheme + "://" + host + "/"
 	// Make URL only if bucketName is available, otherwise use the

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -147,7 +147,10 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 	urlValues.Set("location", "")
 
 	// Set get bucket location always as path style.
-	targetURL := c.endpointURL
+	targetURL, err := url.Parse(c.endpointURL)
+	if err != nil {
+		return nil, err
+	}
 	targetURL.Path = path.Join(bucketName, "") + "/"
 	targetURL.RawQuery = urlValues.Encode()
 

--- a/bucket-cache_test.go
+++ b/bucket-cache_test.go
@@ -70,12 +70,15 @@ func TestGetBucketLocationRequest(t *testing.T) {
 		urlValues.Set("location", "")
 
 		// Set get bucket location always as path style.
-		targetURL := c.endpointURL
+		targetURL, err := url.Parse(c.endpointURL)
+		if err != nil {
+			return nil, err
+		}
 		targetURL.Path = path.Join(bucketName, "") + "/"
 		targetURL.RawQuery = urlValues.Encode()
 
 		// Get a new HTTP request for the method.
-		req, err := http.NewRequest("GET", targetURL.String(), nil)
+		req, err = http.NewRequest("GET", targetURL.String(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -111,9 +111,9 @@ func TestIsValidEndpointURL(t *testing.T) {
 		// Flag indicating whether the test is expected to pass or not.
 		shouldPass bool
 	}{
-		{"", nil, true},
+		{"", fmt.Errorf("Endpoint url cannot be empty."), false},
 		{"/", nil, true},
-		{"https://s3.amazonaws.com", nil, true},
+		{"https://s3.am1;4205;0cazonaws.com", nil, true},
 		{"https://s3.cn-north-1.amazonaws.com.cn", nil, true},
 		{"https://s3.amazonaws.com/", nil, true},
 		{"https://storage.googleapis.com/", nil, true},
@@ -125,11 +125,7 @@ func TestIsValidEndpointURL(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		endPoint, e := url.Parse(testCase.url)
-		if e != nil {
-			t.Fatalf("Test %d: Fatal err \"%s\"", i+1, e.Error())
-		}
-		err := isValidEndpointURL(endPoint)
+		err := isValidEndpointURL(testCase.url)
 		if err != nil && testCase.shouldPass {
 			t.Errorf("Test %d: Expected to pass, but failed with: <ERROR> %s", i+1, err.Error())
 		}
@@ -187,11 +183,7 @@ func TestIsVirtualHostSupported(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		endPoint, e := url.Parse(testCase.url)
-		if e != nil {
-			t.Fatalf("Test %d: Fatal err \"%s\"", i+1, e.Error())
-		}
-		result := isVirtualHostSupported(endPoint, testCase.bucket)
+		result := isVirtualHostSupported(testCase.url, testCase.bucket)
 		if testCase.result != result {
 			t.Errorf("Test %d: Expected isVirtualHostSupported to be '%v' for input url \"%s\" and bucket \"%s\", but found it to be '%v' instead", i+1, testCase.result, testCase.url, testCase.bucket, result)
 		}
@@ -220,11 +212,7 @@ func TestIsAmazonEndpoint(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		endPoint, e := url.Parse(testCase.url)
-		if e != nil {
-			t.Fatalf("Test %d: Fatal err \"%s\"", i+1, e.Error())
-		}
-		result := isAmazonEndpoint(endPoint)
+		result := isAmazonEndpoint(testCase.url)
 		if testCase.result != result {
 			t.Errorf("Test %d: Expected isAmazonEndpoint to be '%v' for input \"%s\", but found it to be '%v' instead", i+1, testCase.result, testCase.url, result)
 		}
@@ -255,11 +243,7 @@ func TestIsAmazonChinaEndpoint(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		endPoint, e := url.Parse(testCase.url)
-		if e != nil {
-			t.Fatalf("Test %d: Fatal err \"%s\"", i+1, e.Error())
-		}
-		result := isAmazonChinaEndpoint(endPoint)
+		result := isAmazonChinaEndpoint(testCase.url)
 		if testCase.result != result {
 			t.Errorf("Test %d: Expected isAmazonEndpoint to be '%v' for input \"%s\", but found it to be '%v' instead", i+1, testCase.result, testCase.url, result)
 		}
@@ -288,11 +272,7 @@ func TestIsGoogleEndpoint(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		endPoint, e := url.Parse(testCase.url)
-		if e != nil {
-			t.Fatalf("Test %d: Fatal err \"%s\"", i+1, e.Error())
-		}
-		result := isGoogleEndpoint(endPoint)
+		result := isGoogleEndpoint(testCase.url)
 		if testCase.result != result {
 			t.Errorf("Test %d: Expected isGoogleEndpoint to be '%v' for input \"%s\", but found it to be '%v' instead", i+1, testCase.result, testCase.url, result)
 		}


### PR DESCRIPTION
This fix is needed to avoid the problems of passing down mutating pointers.
