### PR TITLE
Do not compute payload sha256 with https endpoint

### DIFF
--- a/api-put-object-common.go
+++ b/api-put-object-common.go
@@ -17,8 +17,6 @@
 package minio
 
 import (
-	"crypto/md5"
-	"crypto/sha256"
 	"fmt"
 	"hash"
 	"io"
@@ -101,15 +99,10 @@ func optimalPartInfo(objectSize int64) (totalPartsCount int, partSize int64, las
 //
 // Stages reads from offsets into the buffer, if buffer is nil it is
 // initialized to optimalBufferSize.
-func (c Client) hashCopyBuffer(writer io.Writer, reader io.ReaderAt, buf []byte) (md5Sum, sha256Sum []byte, size int64, err error) {
-	// MD5 and SHA256 hasher.
-	var hashMD5, hashSHA256 hash.Hash
-	// MD5 and SHA256 hasher.
-	hashMD5 = md5.New()
-	hashWriter := io.MultiWriter(writer, hashMD5)
-	if c.signature.isV4() {
-		hashSHA256 = sha256.New()
-		hashWriter = io.MultiWriter(writer, hashMD5, hashSHA256)
+func hashCopyBuffer(hashAlgorithms map[string]hash.Hash, hashSums map[string][]byte, writer io.Writer, reader io.ReaderAt, buf []byte) (size int64, err error) {
+	hashWriter := writer
+	for _, v := range hashAlgorithms {
+		hashWriter = io.MultiWriter(hashWriter, v)
 	}
 
 	// Buffer is nil, initialize.
@@ -126,15 +119,15 @@ func (c Client) hashCopyBuffer(writer io.Writer, reader io.ReaderAt, buf []byte)
 		readAtSize, rerr := reader.ReadAt(buf, readAtOffset)
 		if rerr != nil {
 			if rerr != io.EOF {
-				return nil, nil, 0, rerr
+				return 0, rerr
 			}
 		}
 		writeSize, werr := hashWriter.Write(buf[:readAtSize])
 		if werr != nil {
-			return nil, nil, 0, werr
+			return 0, werr
 		}
 		if readAtSize != writeSize {
-			return nil, nil, 0, fmt.Errorf("Read size was not completely written to writer. wanted %d, got %d - %s", readAtSize, writeSize, reportIssue)
+			return 0, fmt.Errorf("Read size was not completely written to writer. wanted %d, got %d - %s", readAtSize, writeSize, reportIssue)
 		}
 		readAtOffset += int64(writeSize)
 		size += int64(writeSize)
@@ -143,52 +136,17 @@ func (c Client) hashCopyBuffer(writer io.Writer, reader io.ReaderAt, buf []byte)
 		}
 	}
 
-	// Finalize md5 sum and sha256 sum.
-	md5Sum = hashMD5.Sum(nil)
-	if c.signature.isV4() {
-		sha256Sum = hashSHA256.Sum(nil)
+	for k, v := range hashAlgorithms {
+		hashSums[k] = v.Sum(nil)
 	}
-	return md5Sum, sha256Sum, size, err
+	return size, err
 }
 
-// hashCopy is identical to hashCopyN except that it doesn't take
-// any size argument.
-func (c Client) hashCopy(writer io.Writer, reader io.Reader) (md5Sum, sha256Sum []byte, size int64, err error) {
-	// MD5 and SHA256 hasher.
-	var hashMD5, hashSHA256 hash.Hash
-	// MD5 and SHA256 hasher.
-	hashMD5 = md5.New()
-	hashWriter := io.MultiWriter(writer, hashMD5)
-	if c.signature.isV4() {
-		hashSHA256 = sha256.New()
-		hashWriter = io.MultiWriter(writer, hashMD5, hashSHA256)
-	}
-
-	// Using copyBuffer to copy in large buffers, default buffer
-	// for io.Copy of 32KiB is too small.
-	size, err = io.Copy(hashWriter, reader)
-	if err != nil {
-		return nil, nil, 0, err
-	}
-
-	// Finalize md5 sum and sha256 sum.
-	md5Sum = hashMD5.Sum(nil)
-	if c.signature.isV4() {
-		sha256Sum = hashSHA256.Sum(nil)
-	}
-	return md5Sum, sha256Sum, size, err
-}
-
-// hashCopyN - Calculates Md5sum and SHA256sum for up to partSize amount of bytes.
-func (c Client) hashCopyN(writer io.Writer, reader io.Reader, partSize int64) (md5Sum, sha256Sum []byte, size int64, err error) {
-	// MD5 and SHA256 hasher.
-	var hashMD5, hashSHA256 hash.Hash
-	// MD5 and SHA256 hasher.
-	hashMD5 = md5.New()
-	hashWriter := io.MultiWriter(writer, hashMD5)
-	if c.signature.isV4() {
-		hashSHA256 = sha256.New()
-		hashWriter = io.MultiWriter(writer, hashMD5, hashSHA256)
+// hashCopyN - Calculates chosen hashes up to partSize amount of bytes.
+func hashCopyN(hashAlgorithms map[string]hash.Hash, hashSums map[string][]byte, writer io.Writer, reader io.Reader, partSize int64) (size int64, err error) {
+	hashWriter := writer
+	for _, v := range hashAlgorithms {
+		hashWriter = io.MultiWriter(hashWriter, v)
 	}
 
 	// Copies to input at writer.
@@ -196,16 +154,14 @@ func (c Client) hashCopyN(writer io.Writer, reader io.Reader, partSize int64) (m
 	if err != nil {
 		// If not EOF return error right here.
 		if err != io.EOF {
-			return nil, nil, 0, err
+			return 0, err
 		}
 	}
 
-	// Finalize md5shum and sha256 sum.
-	md5Sum = hashMD5.Sum(nil)
-	if c.signature.isV4() {
-		sha256Sum = hashSHA256.Sum(nil)
+	for k, v := range hashAlgorithms {
+		hashSums[k] = v.Sum(nil)
 	}
-	return md5Sum, sha256Sum, size, err
+	return size, err
 }
 
 // getUploadID - fetch upload id if already present for an object name
@@ -243,33 +199,26 @@ func (c Client) getUploadID(bucketName, objectName, contentType string) (uploadI
 	return uploadID, isNew, nil
 }
 
-// computeHash - Calculates MD5 and SHA256 for an input read Seeker.
-func (c Client) computeHash(reader io.ReadSeeker) (md5Sum, sha256Sum []byte, size int64, err error) {
-	// MD5 and SHA256 hasher.
-	var hashMD5, hashSHA256 hash.Hash
-	// MD5 and SHA256 hasher.
-	hashMD5 = md5.New()
-	hashWriter := io.MultiWriter(hashMD5)
-	if c.signature.isV4() {
-		hashSHA256 = sha256.New()
-		hashWriter = io.MultiWriter(hashMD5, hashSHA256)
+// computeHash - Calculates hashes for an input read Seeker.
+func computeHash(hashAlgorithms map[string]hash.Hash, hashSums map[string][]byte, reader io.ReadSeeker) (size int64, err error) {
+	var hashWriter io.Writer
+	for _, v := range hashAlgorithms {
+		hashWriter = io.MultiWriter(v)
 	}
 
 	// If no buffer is provided, no need to allocate just use io.Copy.
 	size, err = io.Copy(hashWriter, reader)
 	if err != nil {
-		return nil, nil, 0, err
+		return 0, err
 	}
 
 	// Seek back reader to the beginning location.
 	if _, err := reader.Seek(0, 0); err != nil {
-		return nil, nil, 0, err
+		return 0, err
 	}
 
-	// Finalize md5shum and sha256 sum.
-	md5Sum = hashMD5.Sum(nil)
-	if c.signature.isV4() {
-		sha256Sum = hashSHA256.Sum(nil)
+	for k, v := range hashAlgorithms {
+		hashSums[k] = v.Sum(nil)
 	}
-	return md5Sum, sha256Sum, size, nil
+	return size, nil
 }

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -18,8 +18,11 @@ package minio
 
 import (
 	"bytes"
+	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
+	"hash"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -112,9 +115,18 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 	tmpBuffer := new(bytes.Buffer)
 
 	for partNumber <= totalPartsCount {
-		// Calculates MD5 and SHA256 sum while copying partSize bytes
-		// into tmpBuffer.
-		md5Sum, sha256Sum, prtSize, rErr := c.hashCopyN(tmpBuffer, reader, partSize)
+
+		// Choose hash algorithms to be calculated by hashCopyN, avoid sha256
+		// with non-v4 signature request or HTTPS connection
+		hashSums := make(map[string][]byte)
+		hashAlgos := make(map[string]hash.Hash)
+		hashAlgos["md5"] = md5.New()
+		if c.signature.isV4() && !c.secure {
+			hashAlgos["sha256"] = sha256.New()
+		}
+
+		// Calculates hash sums while copying partSize bytes into tmpBuffer.
+		prtSize, rErr := hashCopyN(hashAlgos, hashSums, tmpBuffer, reader, partSize)
 		if rErr != nil {
 			if rErr != io.EOF {
 				return 0, rErr
@@ -128,13 +140,13 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 
 		// Verify if part should be uploaded.
 		if shouldUploadPart(objectPart{
-			ETag:       hex.EncodeToString(md5Sum),
+			ETag:       hex.EncodeToString(hashSums["md5"]),
 			PartNumber: partNumber,
 			Size:       prtSize,
 		}, partsInfo) {
 			// Proceed to upload the part.
 			var objPart objectPart
-			objPart, err = c.uploadPart(bucketName, objectName, uploadID, reader, partNumber, md5Sum, sha256Sum, prtSize)
+			objPart, err = c.uploadPart(bucketName, objectName, uploadID, reader, partNumber, hashSums["md5"], hashSums["sha256"], prtSize)
 			if err != nil {
 				// Reset the temporary buffer upon any error.
 				tmpBuffer.Reset()

--- a/api.go
+++ b/api.go
@@ -55,6 +55,9 @@ type Client struct {
 	}
 	endpointURL string
 
+	// Indicate whether we are using https or not
+	secure bool
+
 	// Needs allocation.
 	httpClient     *http.Client
 	bucketLocCache *bucketLocationCache
@@ -162,6 +165,9 @@ func privateNew(endpoint, accessKeyID, secretAccessKey string, secure bool) (*Cl
 	if clnt.accessKeyID == "" || clnt.secretAccessKey == "" {
 		clnt.anonymous = true
 	}
+
+	// Remember whether we are using https or not
+	clnt.secure = secure
 
 	// Save endpoint URL, user agent for future uses.
 	clnt.endpointURL = endpointURL.String()
@@ -583,10 +589,15 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 		// set sha256 sum for signature calculation only with
 		// signature version '4'.
 		if c.signature.isV4() {
-			req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(sum256([]byte{})))
-			if metadata.contentSHA256Bytes != nil {
-				req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(metadata.contentSHA256Bytes))
+			shaHeader := "UNSIGNED-PAYLOAD"
+			if !c.secure {
+				if metadata.contentSHA256Bytes == nil {
+					shaHeader = hex.EncodeToString(sum256([]byte{}))
+				} else {
+					shaHeader = hex.EncodeToString(metadata.contentSHA256Bytes)
+				}
 			}
+			req.Header.Set("X-Amz-Content-Sha256", shaHeader)
 		}
 	}
 


### PR DESCRIPTION
Fixes #428 

It would be better to make the layer responsible for putting objects chooses what hash algorithms should be computed