### PR TITLE
api: Add new API ListenBucketNotification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ The full API Reference is available here.
 
 * [`SetBucketNotification`](https://docs.minio.io/docs/golang-client-api-reference#SetBucketNotification)
 * [`GetBucketNotification`](https://docs.minio.io/docs/golang-client-api-reference#GetBucketNotification)
-* [`DeleteBucketNotification`](https://docs.minio.io/docs/golang-client-api-reference#DeleteBucketNotification)
+* [`RemoveAllBucketNotification`](https://docs.minio.io/docs/golang-client-api-reference#RemoveAllBucketNotification)
+* [`ListenBucketNotification`](https://docs.minio.io/docs/golang-client-api-reference#ListenBucketNotification) (Minio Extension)
 
 ### API Reference : File Object Operations
 
@@ -194,7 +195,7 @@ The full API Reference is available here.
 * [setbucketnotification.go](https://github.com/minio/minio-go/blob/master/examples/s3/setbucketnotification.go)
 * [getbucketnotification.go](https://github.com/minio/minio-go/blob/master/examples/s3/getbucketnotification.go)
 * [deletebucketnotification.go](https://github.com/minio/minio-go/blob/master/examples/s3/deletebucketnotification.go)
- 
+* [listenbucketnotification.go](https://github.com/minio/minio-go/blob/master/examples/s3/listenbucketnotification.go) (Minio Extension)
 
 #### Full Examples : File Object Operations
 

--- a/api-notification.go
+++ b/api-notification.go
@@ -17,6 +17,8 @@
 package minio
 
 import (
+	"bufio"
+	"encoding/json"
 	"net/http"
 	"net/url"
 )
@@ -36,7 +38,6 @@ func (c Client) GetBucketNotification(bucketName string) (bucketNotification Buc
 
 // Request server for notification rules.
 func (c Client) getBucketNotification(bucketName string) (BucketNotification, error) {
-
 	urlValues := make(url.Values)
 	urlValues.Set("notification", "")
 
@@ -66,4 +67,122 @@ func processBucketNotificationResponse(bucketName string, resp *http.Response) (
 		return BucketNotification{}, err
 	}
 	return bucketNotification, nil
+}
+
+// Indentity represents the user id, this is a compliance field.
+type identity struct {
+	PrincipalID string `json:"principalId"`
+}
+
+// Notification event bucket metadata.
+type bucketMeta struct {
+	Name          string   `json:"name"`
+	OwnerIdentity identity `json:"ownerIdentity"`
+	ARN           string   `json:"arn"`
+}
+
+// Notification event object metadata.
+type objectMeta struct {
+	Key       string `json:"key"`
+	Size      int64  `json:"size,omitempty"`
+	ETag      string `json:"eTag,omitempty"`
+	VersionID string `json:"versionId,omitempty"`
+	Sequencer string `json:"sequencer"`
+}
+
+// Notification event server specific metadata.
+type eventMeta struct {
+	SchemaVersion   string     `json:"s3SchemaVersion"`
+	ConfigurationID string     `json:"configurationId"`
+	Bucket          bucketMeta `json:"bucket"`
+	Object          objectMeta `json:"object"`
+}
+
+// NotificationEvent represents an Amazon an S3 bucket notification event.
+type NotificationEvent struct {
+	EventVersion      string            `json:"eventVersion"`
+	EventSource       string            `json:"eventSource"`
+	AwsRegion         string            `json:"awsRegion"`
+	EventTime         string            `json:"eventTime"`
+	EventName         string            `json:"eventName"`
+	UserIdentity      identity          `json:"userIdentity"`
+	RequestParameters map[string]string `json:"requestParameters"`
+	ResponseElements  map[string]string `json:"responseElements"`
+	S3                eventMeta         `json:"s3"`
+}
+
+// NotificationInfo - represents the collection of notification events, additionally
+// also reports errors if any while listening on bucket notifications.
+type NotificationInfo struct {
+	Records []NotificationEvent
+	Err     error
+}
+
+// ListenBucketNotification - listen on bucket notifications.
+func (c Client) ListenBucketNotification(bucketName string, accountArn Arn, doneCh <-chan struct{}) <-chan NotificationInfo {
+	notificationInfoCh := make(chan NotificationInfo, 1)
+	// Only success, start a routine to start reading line by line.
+	go func(notificationInfoCh chan<- NotificationInfo) {
+		defer close(notificationInfoCh)
+
+		if err := isValidBucketName(bucketName); err != nil {
+			notificationInfoCh <- NotificationInfo{
+				Err: err,
+			}
+			return
+		}
+
+		urlValues := make(url.Values)
+		urlValues.Set("notificationARN", accountArn.String())
+
+		// Execute GET on bucket to list objects.
+		resp, err := c.executeMethod("GET", requestMetadata{
+			bucketName:  bucketName,
+			queryValues: urlValues,
+		})
+		if err != nil {
+			notificationInfoCh <- NotificationInfo{
+				Err: err,
+			}
+			return
+		}
+
+		// Validate http response, upon error return quickly.
+		if resp.StatusCode != http.StatusOK {
+			errResponse := httpRespToErrorResponse(resp, bucketName, "")
+			notificationInfoCh <- NotificationInfo{
+				Err: errResponse,
+			}
+			return
+		}
+
+		// Initialize a new bufio scanner, to read line by line.
+		bio := bufio.NewScanner(resp.Body)
+
+		// Close the response body.
+		defer resp.Body.Close()
+
+		// Unmarshal each line, returns marshalled values.
+		for bio.Scan() {
+			var notificationInfo NotificationInfo
+			buf := bio.Bytes()
+			if err = json.Unmarshal(buf, &notificationInfo); err != nil {
+				notificationInfoCh <- NotificationInfo{
+					Err: err,
+				}
+				return
+			}
+			// Send notifications on channel only if there are events received.
+			if len(notificationInfo.Records) > 0 {
+				select {
+				case notificationInfoCh <- notificationInfo:
+				case <-doneCh:
+					return
+				}
+			}
+		}
+	}(notificationInfoCh)
+
+	// Returns the notification info channel, for caller to start reading from.
+	return notificationInfoCh
 }

--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -309,7 +309,7 @@ func (c Client) SetBucketNotification(bucketName string, bucketNotification Buck
 	return nil
 }
 
-// DeleteBucketNotification - Remove bucket notification clears all previously specified config
-func (c Client) DeleteBucketNotification(bucketName string) error {
+// RemoveAllBucketNotification - Remove bucket notification clears all previously specified config
+func (c Client) RemoveAllBucketNotification(bucketName string) error {
 	return c.SetBucketNotification(bucketName, BucketNotification{})
 }

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -1483,7 +1483,7 @@ func TestBucketNotification(t *testing.T) {
 		t.Fatal("Error: cannot get the suffix")
 	}
 
-	err = c.DeleteBucketNotification(bucketName)
+	err = c.RemoveAllBucketNotification(bucketName)
 	if err != nil {
 		t.Fatal("Error: cannot delete bucket notification")
 	}

--- a/docs/API.md
+++ b/docs/API.md
@@ -48,7 +48,7 @@ func main() {
         s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", ssl)
         if err != nil {
                 fmt.Println(err)
-                return            
+                return
         }
 }
 
@@ -60,8 +60,8 @@ func main() {
 |[`ListBuckets`](#ListBuckets)   |[`PutObject`](#PutObject)   |[`PresignedPutObject`](#PresignedPutObject)   | [`GetBucketPolicy`](#GetBucketPolicy)  |
 |[`BucketExists`](#BucketExists)   |[`CopyObject`](#CopyObject)   |[`PresignedPostPolicy`](#PresignedPostPolicy)   | [`SetBucketNotification`](#SetBucketNotification)   |
 | [`RemoveBucket`](#RemoveBucket)  |[`StatObject`](#StatObject)   |   |  [`GetBucketNotification`](#GetBucketNotification)  |
-|[`ListObjects`](#ListObjects)   |[`RemoveObject`](#RemoveObject)   |   |   [`DeleteBucketNotification`](#DeleteBucketNotification)  |
-|[`ListObjectsV2`](#ListObjectsV2) | [`RemoveIncompleteUpload`](#RemoveIncompleteUpload)  |   |   |
+|[`ListObjects`](#ListObjects)   |[`RemoveObject`](#RemoveObject)   |   |  [`RemoveAllBucketNotification`](#RemoveAllBucketNotification)  |
+|[`ListObjectsV2`](#ListObjectsV2) | [`RemoveIncompleteUpload`](#RemoveIncompleteUpload)  |   |  [`ListenBucketNotification`](#ListenBucketNotification)  |
 |[`ListIncompleteUploads`](#ListIncompleteUploads) |[`FPutObject`](#FPutObject)   |   |   |
 |   | [`FGetObject`](#FGetObject)  |   |   |
 
@@ -167,7 +167,7 @@ Lists all buckets.
 
  __Example__
 
- 
+
  ```go
 
  buckets, err := minioClient.ListBuckets()
@@ -177,7 +177,7 @@ if err != nil {
 }
 for _, bucket := range buckets {
   fmt.Println(bucket)
-}  
+}
 
  ```
 
@@ -245,7 +245,7 @@ __Parameters__
 |`bucketName`  | _string_  |name of the bucket.   |
 | `objectPrefix` |_string_   | the prefix of the objects that should be listed. |
 | `recursive`  | _bool_  |`true` indicates recursive style listing and `false` indicates directory style listing delimited by '/'.  |
-|`doneCh`  | _chan struct{}_ | Set this value to 'true' to enable secure (HTTPS) access.  |
+|`doneCh`  | _chan struct{}_ | A message on this channel signals the end of the ListObjects loop.  |
 
 
 __Return Value__
@@ -302,7 +302,7 @@ for object := range objectCh {
 <a name="ListObjectsV2"></a>
 ### ListObjectsV2(bucketName string, prefix string, recursive bool, doneCh chan struct{}) <-chan ObjectInfo
 
-Lists objects in a bucket using the recommanded listing API v2 
+Lists objects in a bucket using the recommanded listing API v2
 
 __Parameters__
 
@@ -312,7 +312,7 @@ __Parameters__
 |`bucketName`  | _string_  |name of the bucket.   |
 | `objectPrefix` |_string_   | the prefix of the objects that should be listed. |
 | `recursive`  | _bool_  |`true` indicates recursive style listing and `false` indicates directory style listing delimited by '/'.  |
-|`doneCh`  | _chan struct{}_ | Set this value to 'true' to enable secure (HTTPS) access.  |
+|`doneCh`  | _chan struct{}_ | A message on this channel signals the end of the underlying Go routine.  |
 
 
 __Return Value__
@@ -379,7 +379,7 @@ __Parameters__
 |`bucketName`  | _string_  |name of the bucket.   |
 | `prefix` |_string_   | prefix of the object names that are partially uploaded |
 | `recursive`  | _bool_  |`true` indicates recursive style listing and `false` indicates directory style listing delimited by '/'.  |
-|`doneCh`  | _chan struct{}_ | Set this value to 'true' to enable secure (HTTPS) access.  |
+|`doneCh`  | _chan struct{}_ | A message on this channel signals the end of the underlying Go routine.  |
 
 
 __Return Value__
@@ -511,7 +511,7 @@ if err != nil {
 ```
 
 <a name="PutObject"></a>
-### PutObject(bucketName string, objectName string, reader io.Reader, contentType string) (n int, err error) 
+### PutObject(bucketName string, objectName string, reader io.Reader, contentType string) (n int, err error)
 
 Uploads an object.
 
@@ -602,7 +602,7 @@ if err != nil {
 <a name="FPutObject"></a>
 ### FPutObject(bucketName string, objectName string, filePath string, contentType string) error
 
-Uploads contents from a file to objectName. 
+Uploads contents from a file to objectName.
 
 
 __Parameters__
@@ -680,7 +680,7 @@ __Return Value__
 
   __Example__
 
-  
+
 ```go
 
 objInfo, err := minioClient.StatObject("mybucket", "photo.jpg")
@@ -787,7 +787,7 @@ if err != nil {
 Generates a presigned URL for HTTP PUT operations. Browsers/Mobile clients may point to this URL to upload objects directly to a bucket even if it is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The default expiry is set to 7 days.
 
 NOTE: you can upload to S3 only with specified object name.
- 
+
 
 
 __Parameters__
@@ -905,7 +905,7 @@ __Parameters__
             </td>
             <td> <i> BucketPolicy </i> </td>
             <td>
-            <ul>policy can be <br/> 
+            <ul>policy can be <br/>
             <li> <i>BucketPolicyNone</i>,</li>
             <li> <i>BucketPolicyReadOnly</i>,</li>
             <li> <i>BucketPolicyReadWrite</i>,</li>
@@ -990,7 +990,7 @@ __Return Values__
 
 |Param   |Type   |Description   |
 |:---|:---| :---|
-|`bucketNotification`  | _BucketNotification_ |structure which holds all notification configurations|
+|`bucketNotification`  | _BucketNotification_ | Object which holds all notification configurations|
 |`err` | _error_  |standard error  |
 
 __Example__
@@ -1018,7 +1018,7 @@ __Parameters__
 |Param   |Type   |Description   |
 |:---|:---| :---|
 |`bucketName`  | _string_  |name of the bucket.   |
-|`bucketNotification`  | _BucketNotification_  |bucket notification.   |
+|`bucketNotification`  | _BucketNotification_  |Represents bucket notification configuration.   |
 
 __Return Values__
 
@@ -1031,22 +1031,23 @@ __Example__
 
 
 ```go
-topicArn := NewArn("aws", "s3", "us-east-1", "804605494417", "PhotoUpdate")
+lambdaArn := minio.NewArn("minio", "lambda", "us-east-1", "1", "lambda")
 
-topicConfig := NewNotificationConfig(topicArn)
-topicConfig.AddEvents(ObjectCreatedAll, ObjectRemovedAll)
-topicConfig.AddFilterSuffix(".jpg")
+lambdaConfig := minio.NewNotificationConfig(lambdaArn)
+lambdaConfig.AddEvents(ObjectCreatedAll, ObjectRemovedAll)
+lambdaConfig.AddFilterPrefix("photos/")
+lambdaConfig.AddFilterSuffix(".jpg")
 
 bucketNotification := BucketNotification{}
-bucetNotification.AddTopic(topicConfig)
+bucetNotification.AddLambda(lambdaConfig)
 err := c.SetBucketNotification(bucketName, bucketNotification)
 if err != nil {
 	fmt.Println("Cannot set the bucket notification: " + err)
 }
 ```
 
-<a name="DeleteBucketNotification"></a>
-### DeleteBucketNotification(bucketName string) error
+<a name="RemoveAllBucketNotification"></a>
+### RemoveAllBucketNotification(bucketName string) error
 
 Remove all configured bucket notifications on a bucket.
 
@@ -1068,9 +1069,68 @@ __Example__
 
 
 ```go
-err := c.DeleteBucketNotification(bucketName)
+err := c.RemoveAllBucketNotification(bucketName)
 if err != nil {
 	fmt.Println("Cannot remove bucket notifications.")
+}
+```
+
+<a name="ListenBucketNotification"></a>
+### ListenBucketNotification(bucketName string, arn Arn, doneCh chan<- struct{}) <-chan NotificationInfo
+
+ListenBucketNotification API receives bucket notification events through the
+notification channel. The returned notification channel has two fields
+'Records' and 'Err'.
+
+- 'Records' holds the notifications received from the server.
+- 'Err' indicates any error while processing the received notifications.
+
+NOTE: Notification channel is closed at the first occurrence of an error.
+
+__Parameters__
+
+
+|Param   |Type   |Description   |
+|:---|:---| :---|
+|`bucketName`  | _string_  | Bucket to listen notifications from.   |
+|`arn`  | _string_ | Unique resource to listen notifications for.  |
+|`doneCh`  | _chan struct{}_ | A message on this channel ends the ListenBucketNotification loop.  |
+
+__Return Values__
+
+
+|Param   |Type   |Description   |
+|:---|:---| :---|
+|`chan NotificationInfo` | _chan_ | Read channel for all notificatons on bucket. |
+|`NotificationInfo` | _object_ | Notification object represents events info. |
+|`notificationInfo.Records` | _[]NotificationEvent_ | Collection of notification events. |
+|`notificationInfo.Err` | _error_ | Carries any error occurred during the operation. |
+
+
+__Example__
+
+
+```go
+
+// Create a done channel to control 'ListenBucketNotification' go routine.
+doneCh := make(chan struct{})
+
+// Indicate a background go-routine to exit cleanly upon return.
+defer close(doneCh)
+
+// Notification account ARN, variable fields to note here are:
+//  - region
+//  - account-id
+// Account id here is the same which was choosen during SetBucketNotification.
+lambdaARN := minio.NewArn("minio", "lambda", "us-east-1", "1", "lambda")
+
+// Listen for bucket notifications on "mybucket" filtered by account ARN "arn:minio:lambda:us-east-1:1:lambda".
+for notificationInfo := range s3Client.ListenBucketNotification("mybucket", lambdaARN, doneCh) {
+	if notificationInfo.Err != nil {
+		fmt.Println(notificationInfo.Err)
+                return
+	}
+	fmt.Println(notificationInfo)
 }
 ```
 
@@ -1078,22 +1138,3 @@ if err != nil {
 ## 6. Explore Further
 
 - [Build your own Go Music Player App example](https://docs.minio.io/docs/go-music-player-app)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/examples/minio/listenbucketnotification.go
+++ b/examples/minio/listenbucketnotification.go
@@ -1,0 +1,59 @@
+// +build ignore
+
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio-go"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	minioClient, err := minio.New("play.minio.io:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// s3Client.TraceOn(os.Stderr)
+
+	// Create a done channel to control 'ListenBucketNotification' go routine.
+	doneCh := make(chan struct{})
+
+	// Indicate to our routine to exit cleanly upon return.
+	defer close(doneCh)
+
+	// Account ARN.
+	accountARN := minio.NewArn("minio", "lambda", "us-east-1", "1", "lambda")
+
+	// Listen for bucket notifications on "mybucket" filtered by account ARN "arn:minio:sqs:us-east-1:1:minio".
+	for notificationInfo := range minioClient.ListenBucketNotification("YOUR-BUCKETNAME", accountARN, doneCh) {
+		if notificationInfo.Err != nil {
+			log.Fatalln(notificationInfo.Err)
+		}
+		log.Println(notificationInfo)
+	}
+}

--- a/examples/s3/removeallbucketnotification.go
+++ b/examples/s3/removeallbucketnotification.go
@@ -40,7 +40,7 @@ func main() {
 
 	// s3Client.TraceOn(os.Stderr)
 
-	err = s3Client.DeleteBucketNotification("my-bucketname")
+	err = s3Client.RemoveAllBucketNotification("my-bucketname")
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
ListenBucketNotification API receives bucket notification events through the
notification channel. The returned notification channel has two fields
'Records' and 'Err'.

- 'Records' holds the notifications received from the server.
- 'Err' indicates any error while processing the received notifications.

NOTE: Notification channel is closed at the first occurrence of an error.