### PR TITLE
pkg: add set package

### DIFF
--- a/api-get-policy.go
+++ b/api-get-policy.go
@@ -17,11 +17,11 @@
 package minio
 
 import (
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"sort"
 )
 
 // GetBucketPolicy - get bucket policy at a given path.
@@ -79,14 +79,8 @@ func processBucketPolicyResponse(bucketName string, resp *http.Response) (Bucket
 	if err != nil {
 		return BucketAccessPolicy{}, err
 	}
-	policy, err := unMarshalBucketPolicy(bucketPolicyBuf)
-	if err != nil {
-		return BucketAccessPolicy{}, err
-	}
-	// Sort the policy actions and resources for convenience.
-	for _, statement := range policy.Statements {
-		sort.Strings(statement.Actions)
-		sort.Strings(statement.Resources)
-	}
-	return policy, nil
+
+	policy := BucketAccessPolicy{}
+	err = json.Unmarshal(bucketPolicyBuf, &policy)
+	return policy, err
 }

--- a/bucket-policy_test.go
+++ b/bucket-policy_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/minio/minio-go/pkg/set"
 )
 
 // Validates bucket policy string.
@@ -45,32 +47,6 @@ func TestIsValidBucketPolicy(t *testing.T) {
 			t.Errorf("Test %d: Expected IsValidBucket policy to be '%v' for policy \"%s\", but instead found it to be '%v'", i+1, testCase.expectedResult, testCase.inputPolicy, actualResult)
 		}
 	}
-}
-
-// Tests whether first array is completly contained in second array.
-func TestSubsetActions(t *testing.T) {
-	testCases := []struct {
-		firstArray  []string
-		secondArray []string
-
-		expectedResult bool
-	}{
-		{[]string{"aaa", "bbb"}, []string{"ccc", "bbb"}, false},
-		{[]string{"aaa", "bbb"}, []string{"aaa", "ccc"}, false},
-		{[]string{"aaa", "bbb"}, []string{"aaa", "bbb"}, true},
-		{[]string{"aaa", "bbb"}, []string{"aaa", "bbb", "ccc"}, true},
-		{[]string{"aaa", "bbb", "aaa"}, []string{"aaa", "bbb", "ccc"}, false},
-		{[]string{"aaa", "bbb", "aaa"}, []string{"aaa", "bbb", "bbb", "aaa"}, true},
-		{[]string{"aaa", "bbb", "aaa"}, []string{"aaa", "bbb"}, false},
-		{[]string{"aaa", "bbb", "aaa"}, []string{"aaa", "bbb", "aaa", "bbb", "ccc"}, true},
-	}
-	for i, testCase := range testCases {
-		actualResult := subsetActions(testCase.firstArray, testCase.secondArray)
-		if testCase.expectedResult != actualResult {
-			t.Errorf("Test %d: First array '%v' is not contained in second array '%v'", i+1, testCase.firstArray, testCase.secondArray)
-		}
-	}
-
 }
 
 // Tests validate Bucket Policy type identifier.
@@ -145,13 +121,13 @@ func TestsetReadOnlyStatement(t *testing.T) {
 		statements := []Statement{}
 
 		bucketResourceStatement.Effect = "Allow"
-		bucketResourceStatement.Principal.AWS = []string{"*"}
-		bucketResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName)}
-		bucketResourceStatement.Actions = readOnlyBucketActions
+		bucketResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		bucketResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName)
+		bucketResourceStatement.Actions = set.CreateStringSet(readOnlyBucketActions...)
 		bucketListResourceStatement.Effect = "Allow"
-		bucketListResourceStatement.Principal.AWS = []string{"*"}
-		bucketListResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName)}
-		bucketListResourceStatement.Actions = []string{"s3:ListBucket"}
+		bucketListResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		bucketListResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName)
+		bucketListResourceStatement.Actions = set.CreateStringSet("s3:ListBucket")
 		if objectPrefix != "" {
 			bucketListResourceStatement.Conditions = map[string]map[string]string{
 				"StringEquals": {
@@ -160,9 +136,9 @@ func TestsetReadOnlyStatement(t *testing.T) {
 			}
 		}
 		objectResourceStatement.Effect = "Allow"
-		objectResourceStatement.Principal.AWS = []string{"*"}
-		objectResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName+"/"+objectPrefix+"*")}
-		objectResourceStatement.Actions = readOnlyObjectActions
+		objectResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		objectResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName + "/" + objectPrefix + "*")
+		objectResourceStatement.Actions = set.CreateStringSet(readOnlyObjectActions...)
 		// Save the read only policy.
 		statements = append(statements, *bucketResourceStatement, *bucketListResourceStatement, *objectResourceStatement)
 		return statements
@@ -197,13 +173,13 @@ func TestsetWriteOnlyStatement(t *testing.T) {
 		statements := []Statement{}
 		// Write only policy.
 		bucketResourceStatement.Effect = "Allow"
-		bucketResourceStatement.Principal.AWS = []string{"*"}
-		bucketResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName)}
-		bucketResourceStatement.Actions = writeOnlyBucketActions
+		bucketResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		bucketResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName)
+		bucketResourceStatement.Actions = set.CreateStringSet(writeOnlyBucketActions...)
 		objectResourceStatement.Effect = "Allow"
-		objectResourceStatement.Principal.AWS = []string{"*"}
-		objectResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName+"/"+objectPrefix+"*")}
-		objectResourceStatement.Actions = writeOnlyObjectActions
+		objectResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		objectResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName + "/" + objectPrefix + "*")
+		objectResourceStatement.Actions = set.CreateStringSet(writeOnlyObjectActions...)
 		// Save the write only policy.
 		statements = append(statements, *bucketResourceStatement, *objectResourceStatement)
 		return statements
@@ -238,13 +214,13 @@ func TestsetReadWriteStatement(t *testing.T) {
 		statements := []Statement{}
 
 		bucketResourceStatement.Effect = "Allow"
-		bucketResourceStatement.Principal.AWS = []string{"*"}
-		bucketResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName)}
-		bucketResourceStatement.Actions = readWriteBucketActions
+		bucketResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		bucketResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName)
+		bucketResourceStatement.Actions = set.CreateStringSet(readWriteBucketActions...)
 		bucketListResourceStatement.Effect = "Allow"
-		bucketListResourceStatement.Principal.AWS = []string{"*"}
-		bucketListResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName)}
-		bucketListResourceStatement.Actions = []string{"s3:ListBucket"}
+		bucketListResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		bucketListResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName)
+		bucketListResourceStatement.Actions = set.CreateStringSet("s3:ListBucket")
 		if objectPrefix != "" {
 			bucketListResourceStatement.Conditions = map[string]map[string]string{
 				"StringEquals": {
@@ -253,9 +229,9 @@ func TestsetReadWriteStatement(t *testing.T) {
 			}
 		}
 		objectResourceStatement.Effect = "Allow"
-		objectResourceStatement.Principal.AWS = []string{"*"}
-		objectResourceStatement.Resources = []string{fmt.Sprintf("%s%s", awsResourcePrefix, bucketName+"/"+objectPrefix+"*")}
-		objectResourceStatement.Actions = readWriteObjectActions
+		objectResourceStatement.Principal.AWS = set.CreateStringSet("*")
+		objectResourceStatement.Resources = set.CreateStringSet(awsResourcePrefix + bucketName + "/" + objectPrefix + "*")
+		objectResourceStatement.Actions = set.CreateStringSet(readWriteObjectActions...)
 		// Save the read write policy.
 		statements = append(statements, *bucketResourceStatement, *bucketListResourceStatement, *objectResourceStatement)
 		return statements
@@ -309,7 +285,8 @@ func TestUnMarshalBucketPolicy(t *testing.T) {
 		if e != nil {
 			t.Fatalf("Test %d: Couldn't Marshal bucket policy", i+1)
 		}
-		actualAccessPolicy, err := unMarshalBucketPolicy(inputPolicyBytes)
+		actualAccessPolicy := BucketAccessPolicy{}
+		err := json.Unmarshal(inputPolicyBytes, &actualAccessPolicy)
 		if err != nil && testCase.shouldPass {
 			t.Errorf("Test %d: Expected to pass, but failed with: <ERROR> %s", i+1, err.Error())
 		}
@@ -329,65 +306,6 @@ func TestUnMarshalBucketPolicy(t *testing.T) {
 				t.Errorf("Test %d: The expected statements from resource statement generator doesn't match the actual statements", i+1)
 			}
 		}
-	}
-}
-
-//  Statement.Action, Statement.Resource, Statement.Principal.AWS fields could be just string also.
-// Setting these values to just a string and testing the unMarshalBucketPolicy
-func TestUnMarshalBucketPolicyUntyped(t *testing.T) {
-	obtainRaw := func(v interface{}, t *testing.T) []byte {
-		rawData, err := json.Marshal(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return rawData
-	}
-
-	type untypedStatement struct {
-		Sid       string
-		Effect    string
-		Principal struct {
-			AWS json.RawMessage
-		}
-		Action    json.RawMessage
-		Resource  json.RawMessage
-		Condition map[string]map[string]string
-	}
-
-	type bucketAccessPolicyUntyped struct {
-		Version   string
-		Statement []untypedStatement
-	}
-
-	statements := setReadOnlyStatement("my-bucket", "Asia/")
-	expectedBucketPolicy := BucketAccessPolicy{Statements: statements}
-	accessPolicyUntyped := bucketAccessPolicyUntyped{}
-	accessPolicyUntyped.Statement = make([]untypedStatement, len(statements))
-
-	accessPolicyUntyped.Statement[0].Effect = statements[0].Effect
-	accessPolicyUntyped.Statement[0].Principal.AWS = obtainRaw(statements[0].Principal.AWS[0], t)
-	accessPolicyUntyped.Statement[0].Action = obtainRaw(statements[0].Actions, t)
-	accessPolicyUntyped.Statement[0].Resource = obtainRaw(statements[0].Resources, t)
-
-	accessPolicyUntyped.Statement[1].Effect = statements[1].Effect
-	accessPolicyUntyped.Statement[1].Principal.AWS = obtainRaw(statements[1].Principal.AWS[0], t)
-	accessPolicyUntyped.Statement[1].Action = obtainRaw(statements[1].Actions, t)
-	accessPolicyUntyped.Statement[1].Resource = obtainRaw(statements[1].Resources, t)
-	accessPolicyUntyped.Statement[1].Condition = statements[1].Conditions
-
-	// Setting the values are strings.
-	accessPolicyUntyped.Statement[2].Effect = statements[2].Effect
-	accessPolicyUntyped.Statement[2].Principal.AWS = obtainRaw(statements[2].Principal.AWS[0], t)
-	accessPolicyUntyped.Statement[2].Action = obtainRaw(statements[2].Actions[0], t)
-	accessPolicyUntyped.Statement[2].Resource = obtainRaw(statements[2].Resources[0], t)
-
-	inputPolicyBytes := obtainRaw(accessPolicyUntyped, t)
-	actualAccessPolicy, err := unMarshalBucketPolicy(inputPolicyBytes)
-	if err != nil {
-		t.Fatal("Unmarshalling bucket policy from untyped statements failed")
-	}
-	if !reflect.DeepEqual(expectedBucketPolicy, actualAccessPolicy) {
-		t.Errorf("Expected BucketPolicy after unmarshalling untyped statements doesn't match the actual one")
 	}
 }
 
@@ -514,7 +432,7 @@ func TestBucketPolicyResourceMatch(t *testing.T) {
 	// generates\ statement with given resource..
 	generateStatement := func(resource string) Statement {
 		statement := Statement{}
-		statement.Resources = []string{resource}
+		statement.Resources = set.CreateStringSet(resource)
 		return statement
 	}
 
@@ -557,7 +475,8 @@ func TestBucketPolicyResourceMatch(t *testing.T) {
 			"minio-bucket"+"/*/India/*/Bihar/*")), true},
 	}
 	for i, testCase := range testCases {
-		actualResourceMatch := resourceMatch(testCase.statement.Resources[0], testCase.resourceToMatch)
+		resources := testCase.statement.Resources.FuncMatch(resourceMatch, testCase.resourceToMatch)
+		actualResourceMatch := resources.Equals(testCase.statement.Resources)
 		if testCase.expectedResourceMatch != actualResourceMatch {
 			t.Errorf("Test %d: Expected Resource match to be `%v`, but instead found it to be `%v`", i+1, testCase.expectedResourceMatch, actualResourceMatch)
 		}
@@ -567,11 +486,11 @@ func TestBucketPolicyResourceMatch(t *testing.T) {
 // Tests validate whether the bucket policy is read only.
 func TestIsBucketPolicyReadOnly(t *testing.T) {
 	testCases := []struct {
-		bucketName      string
-		objectPrefix    string
-		inputStatements []Statement
+		BbucketName      string      `json:"BucketName"`
+		OobjectPrefix    string      `json:"ObjectPrefix"`
+		IinputStatements []Statement `json:"InputStatements"`
 		// expected result.
-		expectedResult bool
+		EexpectedResult bool `json:"ExpectedResult"`
 	}{
 		{"my-bucket", "", []Statement{}, false},
 		{"read-only-bucket", "", setReadOnlyStatement("read-only-bucket", ""), true},
@@ -584,9 +503,11 @@ func TestIsBucketPolicyReadOnly(t *testing.T) {
 		{"my-bucket", "abc", setWriteOnlyStatement("my-bucket", ""), false},
 	}
 	for i, testCase := range testCases {
-		actualResult := isBucketPolicyReadOnly(testCase.inputStatements, testCase.bucketName, testCase.objectPrefix)
-		if testCase.expectedResult != actualResult {
-			t.Errorf("Test %d: Expected isBucketPolicyReadonly to '%v', but instead found '%v'", i+1, testCase.expectedResult, actualResult)
+		actualResult := isBucketPolicyReadOnly(testCase.IinputStatements, testCase.BbucketName, testCase.OobjectPrefix)
+		if testCase.EexpectedResult != actualResult {
+			s, _ := json.Marshal(testCase)
+			t.Errorf(string(s))
+			t.Errorf("Test %d: Expected isBucketPolicyReadonly to '%v', but instead found '%v'", i+1, testCase.EexpectedResult, actualResult)
 		}
 	}
 }

--- a/pkg/set/stringset.go
+++ b/pkg/set/stringset.go
@@ -1,0 +1,175 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package set
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// StringSet - uses map as set of strings.
+type StringSet map[string]struct{}
+
+// keys - returns StringSet keys.
+func (set StringSet) keys() []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// IsEmpty - returns whether the set is empty or not.
+func (set StringSet) IsEmpty() bool {
+	return len(set) == 0
+}
+
+// Add - adds string to the set.
+func (set StringSet) Add(s string) {
+	set[s] = struct{}{}
+}
+
+// Remove - removes string in the set.  It does nothing if string does not exist in the set.
+func (set StringSet) Remove(s string) {
+	delete(set, s)
+}
+
+// Contains - checks if string is in the set.
+func (set StringSet) Contains(s string) bool {
+	_, ok := set[s]
+	return ok
+}
+
+// FuncMatch - returns new set containing each value who passes match function.
+// A 'matchFn' should accept element in a set as first argument and
+// 'matchString' as second argument.  The function can do any logic to
+// compare both the arguments and should return true to accept element in
+// a set to include in output set else the element is ignored.
+func (set StringSet) FuncMatch(matchFn func(string, string) bool, matchString string) StringSet {
+	nset := NewStringSet()
+	for k := range set {
+		if matchFn(k, matchString) {
+			nset.Add(k)
+		}
+	}
+	return nset
+}
+
+// Equals - checks whether given set is equal to current set or not.
+func (set StringSet) Equals(sset StringSet) bool {
+	// If length of set is not equal to length of given set, the
+	// set is not equal to given set.
+	if len(set) != len(sset) {
+		return false
+	}
+
+	// As both sets are equal in length, check each elements are equal.
+	for k := range set {
+		if _, ok := sset[k]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Intersection - returns the intersection with given set as new set.
+func (set StringSet) Intersection(sset StringSet) StringSet {
+	nset := NewStringSet()
+	for k := range set {
+		if _, ok := sset[k]; ok {
+			nset.Add(k)
+		}
+	}
+
+	return nset
+}
+
+// Difference - returns the difference with given set as new set.
+func (set StringSet) Difference(sset StringSet) StringSet {
+	nset := NewStringSet()
+	for k := range set {
+		if _, ok := sset[k]; !ok {
+			nset.Add(k)
+		}
+	}
+
+	return nset
+}
+
+// Union - returns the union with given set as new set.
+func (set StringSet) Union(sset StringSet) StringSet {
+	nset := NewStringSet()
+	for k := range set {
+		nset.Add(k)
+	}
+
+	for k := range sset {
+		nset.Add(k)
+	}
+
+	return nset
+}
+
+// MarshalJSON - converts to JSON data.
+func (set StringSet) MarshalJSON() ([]byte, error) {
+	return json.Marshal(set.keys())
+}
+
+// UnmarshalJSON - parses JSON data and creates new set with it.
+// If 'data' contains JSON string array, the set contains each string.
+// If 'data' contains JSON string, the set contains the string as one element.
+// If 'data' contains Other JSON types, JSON parse error is returned.
+func (set *StringSet) UnmarshalJSON(data []byte) error {
+	sl := []string{}
+	var err error
+	if err = json.Unmarshal(data, &sl); err == nil {
+		*set = make(StringSet)
+		for _, s := range sl {
+			set.Add(s)
+		}
+	} else {
+		var s string
+		if err = json.Unmarshal(data, &s); err == nil {
+			*set = make(StringSet)
+			set.Add(s)
+		}
+	}
+
+	return err
+}
+
+// String - returns printable string of the set.
+func (set StringSet) String() string {
+	return fmt.Sprintf("%s", set.keys())
+}
+
+// NewStringSet - creates new string set.
+func NewStringSet() StringSet {
+	return make(StringSet)
+}
+
+// CreateStringSet - creates new string set with given string values.
+func CreateStringSet(sl ...string) StringSet {
+	set := make(StringSet)
+	for _, k := range sl {
+		set.Add(k)
+	}
+	return set
+}

--- a/pkg/set/stringset_test.go
+++ b/pkg/set/stringset_test.go
@@ -1,0 +1,292 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package set
+
+import (
+	"strings"
+	"testing"
+)
+
+// NewStringSet() is called and the result is validated.
+func TestNewStringSet(t *testing.T) {
+	if ss := NewStringSet(); !ss.IsEmpty() {
+		t.Fatalf("expected: true, got: false")
+	}
+}
+
+// CreateStringSet() is called and the result is validated.
+func TestCreateStringSet(t *testing.T) {
+	ss := CreateStringSet("foo")
+	if str := ss.String(); str != `[foo]` {
+		t.Fatalf("expected: %s, got: %s", `["foo"]`, str)
+	}
+}
+
+// StringSet.Add() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetAdd(t *testing.T) {
+	testCases := []struct {
+		value          string
+		expectedResult string
+	}{
+		// Test first addition.
+		{"foo", `[foo]`},
+		// Test duplicate addition.
+		{"foo", `[foo]`},
+		// Test new addition.
+		{"bar", `[bar foo]`},
+	}
+
+	ss := NewStringSet()
+	for _, testCase := range testCases {
+		ss.Add(testCase.value)
+		if str := ss.String(); str != testCase.expectedResult {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, str)
+		}
+	}
+}
+
+// StringSet.Remove() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetRemove(t *testing.T) {
+	ss := CreateStringSet("foo", "bar")
+	testCases := []struct {
+		value          string
+		expectedResult string
+	}{
+		// Test removing non-existen item.
+		{"baz", `[bar foo]`},
+		// Test remove existing item.
+		{"foo", `[bar]`},
+		// Test remove existing item again.
+		{"foo", `[bar]`},
+		// Test remove to make set to empty.
+		{"bar", `[]`},
+	}
+
+	for _, testCase := range testCases {
+		ss.Remove(testCase.value)
+		if str := ss.String(); str != testCase.expectedResult {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, str)
+		}
+	}
+}
+
+// StringSet.Contains() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetContains(t *testing.T) {
+	ss := CreateStringSet("foo")
+	testCases := []struct {
+		value          string
+		expectedResult bool
+	}{
+		// Test to check non-existent item.
+		{"bar", false},
+		// Test to check existent item.
+		{"foo", true},
+		// Test to verify case sensitivity.
+		{"Foo", false},
+	}
+
+	for _, testCase := range testCases {
+		if result := ss.Contains(testCase.value); result != testCase.expectedResult {
+			t.Fatalf("expected: %t, got: %t", testCase.expectedResult, result)
+		}
+	}
+}
+
+// StringSet.FuncMatch() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetFuncMatch(t *testing.T) {
+	ss := CreateStringSet("foo", "bar")
+	testCases := []struct {
+		matchFn        func(string, string) bool
+		value          string
+		expectedResult string
+	}{
+		// Test to check match function doing case insensive compare.
+		{func(setValue string, compareValue string) bool {
+			return strings.ToUpper(setValue) == strings.ToUpper(compareValue)
+		}, "Bar", `[bar]`},
+		// Test to check match function doing prefix check.
+		{func(setValue string, compareValue string) bool {
+			return strings.HasPrefix(compareValue, setValue)
+		}, "foobar", `[foo]`},
+	}
+
+	for _, testCase := range testCases {
+		s := ss.FuncMatch(testCase.matchFn, testCase.value)
+		if result := s.String(); result != testCase.expectedResult {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, result)
+		}
+	}
+}
+
+// StringSet.Equals() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetEquals(t *testing.T) {
+	testCases := []struct {
+		set1           StringSet
+		set2           StringSet
+		expectedResult bool
+	}{
+		// Test equal set
+		{CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar"), true},
+		// Test second set with more items
+		{CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar", "baz"), false},
+		// Test second set with less items
+		{CreateStringSet("foo", "bar"), CreateStringSet("bar"), false},
+	}
+
+	for _, testCase := range testCases {
+		if result := testCase.set1.Equals(testCase.set2); result != testCase.expectedResult {
+			t.Fatalf("expected: %t, got: %t", testCase.expectedResult, result)
+		}
+	}
+}
+
+// StringSet.Intersection() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetIntersection(t *testing.T) {
+	testCases := []struct {
+		set1           StringSet
+		set2           StringSet
+		expectedResult StringSet
+	}{
+		// Test intersecting all values.
+		{CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar")},
+		// Test intersecting all values in second set.
+		{CreateStringSet("foo", "bar", "baz"), CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar")},
+		// Test intersecting different values in second set.
+		{CreateStringSet("foo", "baz"), CreateStringSet("baz", "bar"), CreateStringSet("baz")},
+		// Test intersecting none.
+		{CreateStringSet("foo", "baz"), CreateStringSet("poo", "bar"), NewStringSet()},
+	}
+
+	for _, testCase := range testCases {
+		if result := testCase.set1.Intersection(testCase.set2); !result.Equals(testCase.expectedResult) {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, result)
+		}
+	}
+}
+
+// StringSet.Difference() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetDifference(t *testing.T) {
+	testCases := []struct {
+		set1           StringSet
+		set2           StringSet
+		expectedResult StringSet
+	}{
+		// Test differing none.
+		{CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar"), NewStringSet()},
+		// Test differing in first set.
+		{CreateStringSet("foo", "bar", "baz"), CreateStringSet("foo", "bar"), CreateStringSet("baz")},
+		// Test differing values in both set.
+		{CreateStringSet("foo", "baz"), CreateStringSet("baz", "bar"), CreateStringSet("foo")},
+		// Test differing all values.
+		{CreateStringSet("foo", "baz"), CreateStringSet("poo", "bar"), CreateStringSet("foo", "baz")},
+	}
+
+	for _, testCase := range testCases {
+		if result := testCase.set1.Difference(testCase.set2); !result.Equals(testCase.expectedResult) {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, result)
+		}
+	}
+}
+
+// StringSet.Union() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetUnion(t *testing.T) {
+	testCases := []struct {
+		set1           StringSet
+		set2           StringSet
+		expectedResult StringSet
+	}{
+		// Test union same values.
+		{CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar")},
+		// Test union same values in second set.
+		{CreateStringSet("foo", "bar", "baz"), CreateStringSet("foo", "bar"), CreateStringSet("foo", "bar", "baz")},
+		// Test union different values in both set.
+		{CreateStringSet("foo", "baz"), CreateStringSet("baz", "bar"), CreateStringSet("foo", "baz", "bar")},
+		// Test union all different values.
+		{CreateStringSet("foo", "baz"), CreateStringSet("poo", "bar"), CreateStringSet("foo", "baz", "poo", "bar")},
+	}
+
+	for _, testCase := range testCases {
+		if result := testCase.set1.Union(testCase.set2); !result.Equals(testCase.expectedResult) {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, result)
+		}
+	}
+}
+
+// StringSet.MarshalJSON() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		set            StringSet
+		expectedResult string
+	}{
+		// Test set with values.
+		{CreateStringSet("foo", "bar"), `["bar","foo"]`},
+		// Test empty set.
+		{NewStringSet(), "[]"},
+	}
+
+	for _, testCase := range testCases {
+		if result, _ := testCase.set.MarshalJSON(); string(result) != testCase.expectedResult {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, string(result))
+		}
+	}
+}
+
+// StringSet.UnmarshalJSON() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		data           []byte
+		expectedResult string
+	}{
+		// Test to convert JSON array to set.
+		{[]byte(`["bar","foo"]`), `[bar foo]`},
+		// Test to convert JSON string to set.
+		{[]byte(`"bar"`), `[bar]`},
+		// Test to convert JSON empty array to set.
+		{[]byte(`[]`), `[]`},
+		// Test to convert JSON empty string to set.
+		{[]byte(`""`), `[]`},
+	}
+
+	for _, testCase := range testCases {
+		var set StringSet
+		set.UnmarshalJSON(testCase.data)
+		if result := set.String(); result != testCase.expectedResult {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, result)
+		}
+	}
+}
+
+// StringSet.String() is called with series of cases for valid and erroneous inputs and the result is validated.
+func TestStringSetString(t *testing.T) {
+	testCases := []struct {
+		set            StringSet
+		expectedResult string
+	}{
+		// Test empty set.
+		{NewStringSet(), `[]`},
+		// Test set with empty value.
+		{CreateStringSet(""), `[]`},
+		// Test set with value.
+		{CreateStringSet("foo"), `[foo]`},
+	}
+
+	for _, testCase := range testCases {
+		if str := testCase.set.String(); str != testCase.expectedResult {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedResult, str)
+		}
+	}
+}


### PR DESCRIPTION
This package contains StringSet like string slice where it allows to
be a set.  StringSet has set operation methods like Intersection(),
Difference() and Union().  It also has JSON marshal/unmarshal
functions which generates/reads JSON array strings.

bucket-policy.Statement structure is modified to use StringSet than
string slice.