### PR TITLE
api: GetObject. Seek method should behave like os.File

### DIFF
--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -709,8 +709,8 @@ func TestGetObjectReadSeekFunctionalV2(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
-	if n != 0 {
-		t.Fatalf("Error: number of bytes seeked back does not match, want 0, got %v\n", n)
+	if n != st.Size-offset {
+		t.Fatalf("Error: number of bytes seeked back does not match, want %d, got %v\n", st.Size-offset, n)
 	}
 
 	var buffer1 bytes.Buffer
@@ -719,7 +719,7 @@ func TestGetObjectReadSeekFunctionalV2(t *testing.T) {
 			t.Fatal("Error:", err)
 		}
 	}
-	if !bytes.Equal(buf, buffer1.Bytes()) {
+	if !bytes.Equal(buf[len(buf)-int(offset):], buffer1.Bytes()) {
 		t.Fatal("Error: Incorrect read bytes v/s original buffer.")
 	}
 


### PR DESCRIPTION
In current code the Seek at negative offset when whence is
set to '2' we would read from the beginning of the io.Reader
which is incorrect from how POSIX behaves.

Seek at a negative offset would need to read from the end.

This patch fixes #476