### PR TITLE
Check the Server header to verify listen bucket notification support

### DIFF
--- a/api-error-response.go
+++ b/api-error-response.go
@@ -233,3 +233,13 @@ func ErrNoSuchBucketPolicy(message string) error {
 		RequestID: "minio",
 	}
 }
+
+// ErrAPINotSupported - API not supported response
+// The specified API call is not supported
+func ErrAPINotSupported(message string) error {
+	return ErrorResponse{
+		Code:      "APINotSupported",
+		Message:   message,
+		RequestID: "minio",
+	}
+}

--- a/api-notification.go
+++ b/api-notification.go
@@ -134,7 +134,15 @@ func (c Client) ListenBucketNotification(bucketName string, accountArn Arn, done
 			return
 		}
 
-		// Continuously run and listen on bucket notification.
+		// Check ARN partition to verify if listening bucket is supported
+		if accountArn.Partition != "minio" {
+			notificationInfoCh <- NotificationInfo{
+				Err: ErrAPINotSupported("Listening bucket notification is specific only to `minio` partitions"),
+			}
+			return
+		}
+
+		// Continously run and listen on bucket notification.
 		for {
 			urlValues := make(url.Values)
 			urlValues.Set("notificationARN", accountArn.String())


### PR DESCRIPTION
We need to check the Server header in listen bucket notification webservice call to be sure that we are talking with minio servers since this is about a custom API.