### PR TITLE
GetObject: allow reading only a limited range of a file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 
 os:
 - linux
-- osx
+- osx 
 
 env:
 - ARCH=x86_64


### PR DESCRIPTION
Fixes: #484 

This removes a test in api_unit_test.go because newObject no longer functions by taking in ObjectInfo as a parameter. 

Running $ go test -v ./... runs into #464 but testing all individual GetObject tests and PutObject tests runs just fine.