### PR TITLE
GetObject: Don't set objectInfo until first read/seek/stat call

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -221,6 +221,9 @@ func (c Client) putObjectSingle(bucketName, objectName string, reader io.Reader,
 		}
 		defer tmpFile.Close()
 		size, err = hashCopyN(hashAlgos, hashSums, tmpFile, reader, size)
+		if err != nil {
+			return 0, err
+		}
 		// Seek back to beginning of the temporary file.
 		if _, err = tmpFile.Seek(0, 0); err != nil {
 			return 0, err

--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -716,7 +716,7 @@ func TestGetObjectReadSeekFunctionalV2(t *testing.T) {
 	}
 
 	var buffer1 bytes.Buffer
-	if n, err = io.CopyN(&buffer1, r, st.Size); err != nil {
+	if _, err = io.CopyN(&buffer1, r, st.Size); err != nil {
 		if err != io.EOF {
 			t.Fatal("Error:", err)
 		}

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -1083,7 +1083,7 @@ func TestGetObjectReadSeekFunctional(t *testing.T) {
 	}
 
 	var buffer1 bytes.Buffer
-	if n, err = io.CopyN(&buffer1, r, st.Size); err != nil {
+	if _, err = io.CopyN(&buffer1, r, st.Size); err != nil {
 		if err != io.EOF {
 			t.Fatal("Error:", err)
 		}
@@ -1181,6 +1181,26 @@ func TestGetObjectReadAtFunctional(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
+	offset := int64(2048)
+
+	// read directly
+	buf1 := make([]byte, 512)
+	buf2 := make([]byte, 512)
+	buf3 := make([]byte, 512)
+	buf4 := make([]byte, 512)
+
+	// Test readAt before stat is called.
+	m, err := r.ReadAt(buf1, offset)
+	if err != nil {
+		t.Fatal("Error:", err, len(buf1), offset)
+	}
+	if m != len(buf1) {
+		t.Fatalf("Error: ReadAt read shorter bytes before reaching EOF, want %v, got %v\n", m, len(buf1))
+	}
+	if !bytes.Equal(buf1, buf[offset:offset+512]) {
+		t.Fatal("Error: Incorrect read between two ReadAt from same offset.")
+	}
+	offset += 512
 
 	st, err := r.Stat()
 	if err != nil {
@@ -1191,14 +1211,7 @@ func TestGetObjectReadAtFunctional(t *testing.T) {
 			len(buf), st.Size)
 	}
 
-	offset := int64(2048)
-
-	// read directly
-	buf2 := make([]byte, 512)
-	buf3 := make([]byte, 512)
-	buf4 := make([]byte, 512)
-
-	m, err := r.ReadAt(buf2, offset)
+	m, err = r.ReadAt(buf2, offset)
 	if err != nil {
 		t.Fatal("Error:", err, st.Size, len(buf2), offset)
 	}

--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -354,11 +354,11 @@ func TestBucketPolicyTypes(t *testing.T) {
 
 // Tests optimal part size.
 func TestPartSize(t *testing.T) {
-	totalPartsCount, partSize, lastPartSize, err := optimalPartInfo(5000000000000000000)
+	_, _, _, err := optimalPartInfo(5000000000000000000)
 	if err == nil {
 		t.Fatal("Error: should fail")
 	}
-	totalPartsCount, partSize, lastPartSize, err = optimalPartInfo(5497558138880)
+	totalPartsCount, partSize, lastPartSize, err := optimalPartInfo(5497558138880)
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
@@ -371,7 +371,7 @@ func TestPartSize(t *testing.T) {
 	if lastPartSize != 134217728 {
 		t.Fatalf("Error: expecting last part size of 241172480: got %v instead", lastPartSize)
 	}
-	totalPartsCount, partSize, lastPartSize, err = optimalPartInfo(5000000000)
+	_, partSize, _, err = optimalPartInfo(5000000000)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}


### PR DESCRIPTION
Fixes: #501 

adds test case where #501 happens as well.