### PR TITLE
putObject: Streaming uploads with size -1 should avoid erroring out f…

### DIFF
--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -236,7 +236,7 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 	}
 
 	// Loop over uploaded parts to save them in a Parts array before completing the multipart request.
-	for i := 1; i <= totalPartsCount; i++ {
+	for i := 1; i <= partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return totalUploadedSize, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -94,7 +94,8 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 	}
 
 	// If This session is a continuation of a previous session fetch all
-	// previously uploaded parts info.
+	// previously uploaded parts info and as a special case only fetch partsInfo
+	// for only known upload size.
 	if !isNew {
 		// Fetch previously uploaded parts and maximum part size.
 		partsInfo, err = c.listObjectParts(bucketName, objectName, uploadID)
@@ -186,8 +187,9 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 		}
 	}
 
-	// Loop over uploaded parts to save them in a Parts array before completing the multipart request.
-	for i := 1; i <= totalPartsCount; i++ {
+	// Loop over total uploaded parts to save them in
+	// Parts array before completing the multipart request.
+	for i := 1; i <= partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))

--- a/api-put-object-readat.go
+++ b/api-put-object-readat.go
@@ -188,7 +188,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 	}
 
 	// Loop over uploaded parts to save them in a Parts array before completing the multipart request.
-	for i := 1; i <= totalPartsCount; i++ {
+	for i := 1; i <= partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))


### PR DESCRIPTION
…or missing parts.

size == -1 should be treated specially for putObjectStream() missing parts
shouldn't error out since with '-1' number of parts are dynamic only when
the stream ends we do know that the we have finished the upload.

Fixes - minio/mc#1819