### PR TITLE
getObject: ReadAt() should return response.Size for reads at io.EOF

### DIFF
--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -191,7 +191,7 @@ func TestPutObjectReadAt(t *testing.T) {
 	}
 
 	// Generate data
-	buf := make([]byte, minPartSize*4)
+	buf := bytes.Repeat([]byte("m"), minPartSize*4)
 
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")


### PR DESCRIPTION
io.EOF shouldn't be treated like a failure condition since
response.Size can be usually > 0 and we need to report this as
such to the caller.

Fixes https://github.com/minio/mc/issues/1821