### PR TITLE
putObject: use lastPartNumber instead for generating complete multipa…

### DIFF
--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -172,10 +172,13 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 		return 0, err
 	}
 
+	// Used for readability, lastPartNumber is always totalPartsCount.
+	lastPartNumber := totalPartsCount
+
 	// Part number always starts with '1'.
 	partNumber := 1
 
-	for partNumber <= totalPartsCount {
+	for partNumber <= lastPartNumber {
 		// Get a section reader on a particular offset.
 		sectionReader := io.NewSectionReader(fileReader, totalUploadedSize, partSize)
 
@@ -236,7 +239,7 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 	}
 
 	// Loop over uploaded parts to save them in a Parts array before completing the multipart request.
-	for i := 1; i <= partNumber; i++ {
+	for i := 1; i <= lastPartNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return totalUploadedSize, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -170,14 +170,14 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 		// Save successfully uploaded size.
 		totalUploadedSize += prtSize
 
+		// Increment part number.
+		partNumber++
+
 		// For unknown size, Read EOF we break away.
 		// We do not have to upload till totalPartsCount.
 		if size < 0 && rErr == io.EOF {
 			break
 		}
-
-		// Increment part number.
-		partNumber++
 	}
 
 	// Verify if we uploaded all the data.
@@ -189,7 +189,7 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 
 	// Loop over total uploaded parts to save them in
 	// Parts array before completing the multipart request.
-	for i := 1; i <= partNumber; i++ {
+	for i := 1; i < partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))

--- a/api-put-object-readat.go
+++ b/api-put-object-readat.go
@@ -90,8 +90,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 		return 0, err
 	}
 
-	// Used for readability, lastPartNumber is always
-	// totalPartsCount.
+	// Used for readability, lastPartNumber is always totalPartsCount.
 	lastPartNumber := totalPartsCount
 
 	// partNumber always starts with '1'.
@@ -188,7 +187,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 	}
 
 	// Loop over uploaded parts to save them in a Parts array before completing the multipart request.
-	for i := 1; i <= partNumber; i++ {
+	for i := 1; i <= lastPartNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))


### PR DESCRIPTION
…rts.

partNumber is higher than the lastPartNumber due to the loop. Use
lastPartNumber instead since the file size is not expected to change
underneath with in the call.

For streaming based stick to partNumber-1 for generating parts.