### PR TITLE
Add delete to subresource list

### DIFF
--- a/request-signature-v2.go
+++ b/request-signature-v2.go
@@ -257,6 +257,7 @@ func writeCanonicalizedHeaders(buf *bytes.Buffer, req http.Request) {
 // have signature-related issues
 var resourceList = []string{
 	"acl",
+	"delete",
 	"location",
 	"logging",
 	"notification",


### PR DESCRIPTION
According to the current [AWS S3 API documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#ConstructingTheCanonicalizedResourceElement) the delete query
string parameter must be included when you create the CanonicalizedResource
for a multi-object Delete request.