### PR TITLE
Percent encode '/' (forward slash) in query string

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -310,7 +310,22 @@ func isValidObjectPrefix(objectPrefix string) error {
 	return nil
 }
 
-// queryEncode - encodes query values in their URL encoded form.
+//expects ascii encoded strings - from output of urlEncodePath
+func percentEncodeSlash(s string) string {
+	r := ""
+	for _, k := range s {
+		if k == '/' {
+			r += "%2F"
+		} else {
+			r += string(k)
+		}
+	}
+	return r
+}
+
+// queryEncode - encodes query values in their URL encoded form. In
+// addition to the percent encoding performed by urlEncodePath() used
+// here, it also percent encodes '/' (forward slash)
 func queryEncode(v url.Values) string {
 	if v == nil {
 		return ""
@@ -323,13 +338,13 @@ func queryEncode(v url.Values) string {
 	sort.Strings(keys)
 	for _, k := range keys {
 		vs := v[k]
-		prefix := urlEncodePath(k) + "="
+		prefix := percentEncodeSlash(urlEncodePath(k)) + "="
 		for _, v := range vs {
 			if buf.Len() > 0 {
 				buf.WriteByte('&')
 			}
 			buf.WriteString(prefix)
-			buf.WriteString(urlEncodePath(v))
+			buf.WriteString(percentEncodeSlash(urlEncodePath(v)))
 		}
 	}
 	return buf.String()

--- a/utils_test.go
+++ b/utils_test.go
@@ -356,6 +356,31 @@ func TestIsValidBucketName(t *testing.T) {
 
 }
 
+func TestPercentEncodeSlash(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{"test123", "test123"},
+		{"abc,+_1", "abc,+_1"},
+		{"%40prefix=test%40123", "%40prefix=test%40123"},
+		{"key1=val1/val2", "key1=val1%2Fval2"},
+		{"%40prefix=test%40123/", "%40prefix=test%40123%2F"},
+	}
+
+	for i, testCase := range testCases {
+		receivedOutput := percentEncodeSlash(testCase.input)
+		if testCase.output != receivedOutput {
+			t.Errorf(
+				"Test %d: Input: \"%s\" --> Expected percentEncodeSlash to return \"%s\", but it returned \"%s\" instead!",
+				i+1, testCase.input, testCase.output,
+				receivedOutput,
+			)
+
+		}
+	}
+}
+
 // Tests validate the query encoder.
 func TestQueryEncode(t *testing.T) {
 	testCases := []struct {
@@ -366,6 +391,7 @@ func TestQueryEncode(t *testing.T) {
 	}{
 		{"prefix", []string{"test@123", "test@456"}, "prefix=test%40123&prefix=test%40456"},
 		{"@prefix", []string{"test@123"}, "%40prefix=test%40123"},
+		{"@prefix", []string{"a/b/c/"}, "%40prefix=a%2Fb%2Fc%2F"},
 		{"prefix", []string{"test#123"}, "prefix=test%23123"},
 		{"prefix#", []string{"test#123"}, "prefix%23=test%23123"},
 		{"prefix", []string{"test123"}, "prefix=test123"},


### PR DESCRIPTION
* '/' is not a valid character in query strings as it can be mistaken
  for a path separator.

* Added a test case for this change.

* Additional reference: See definition of UriEncode() in AWS S3 v4
  Signature Authorization documentation:
  https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
  - relevant snippet is: `Encode the forward slash character, '/',
  everywhere except in the object key name. For example, if the object
  key name is photos/Jan/sample.jpg, the forward slash in the key name
  is not encoded.`