### PR TITLE
Export API error codes to facilitate error inspection by developers

### DIFF
--- a/api-error-response_test.go
+++ b/api-error-response_test.go
@@ -65,7 +65,7 @@ func TestHttpRespToErrorResponse(t *testing.T) {
 	// 'genErrResponse' contructs error response based http Status Code
 	genErrResponse := func(resp *http.Response, code, message, bucketName, objectName string) ErrorResponse {
 		errResp := ErrorResponse{
-			Code:       code,
+			Code:       APIErrorCode(code),
 			Message:    message,
 			BucketName: bucketName,
 			Key:        objectName,
@@ -79,7 +79,7 @@ func TestHttpRespToErrorResponse(t *testing.T) {
 	// Generate invalid argument error.
 	genInvalidError := func(message string) error {
 		errResp := ErrorResponse{
-			Code:      "InvalidArgument",
+			Code:      ErrCodeInvalidArgument,
 			Message:   message,
 			RequestID: "minio",
 		}
@@ -123,7 +123,7 @@ func TestHttpRespToErrorResponse(t *testing.T) {
 	// List of APIErrors used to generate/mock server side XML error response.
 	APIErrors := []APIError{
 		{
-			Code:           "NoSuchBucketPolicy",
+			Code:           ErrCodeNoSuchBucketPolicy,
 			Description:    "The specified bucket does not have a bucket policy.",
 			HTTPStatusCode: http.StatusNotFound,
 		},
@@ -181,7 +181,7 @@ func TestHttpRespToErrorResponse(t *testing.T) {
 func TestErrEntityTooLarge(t *testing.T) {
 	msg := fmt.Sprintf("Your proposed upload size ‘%d’ exceeds the maximum allowed object size ‘%d’ for single PUT operation.", 1000000, 99999)
 	expectedResult := ErrorResponse{
-		Code:       "EntityTooLarge",
+		Code:       ErrCodeEntityTooLarge,
 		Message:    msg,
 		BucketName: "minio-bucket",
 		Key:        "Asia/",
@@ -196,7 +196,7 @@ func TestErrEntityTooLarge(t *testing.T) {
 func TestErrEntityTooSmall(t *testing.T) {
 	msg := fmt.Sprintf("Your proposed upload size ‘%d’ is below the minimum allowed object size '0B' for single PUT operation.", -1)
 	expectedResult := ErrorResponse{
-		Code:       "EntityTooLarge",
+		Code:       ErrCodeEntityTooLarge,
 		Message:    msg,
 		BucketName: "minio-bucket",
 		Key:        "Asia/",
@@ -212,7 +212,7 @@ func TestErrUnexpectedEOF(t *testing.T) {
 	msg := fmt.Sprintf("Data read ‘%s’ is not equal to the size ‘%s’ of the input Reader.",
 		strconv.FormatInt(100, 10), strconv.FormatInt(101, 10))
 	expectedResult := ErrorResponse{
-		Code:       "UnexpectedEOF",
+		Code:       ErrCodeUnexpectedEOF,
 		Message:    msg,
 		BucketName: "minio-bucket",
 		Key:        "Asia/",
@@ -226,7 +226,7 @@ func TestErrUnexpectedEOF(t *testing.T) {
 // Test validates 'ErrInvalidBucketName' error response.
 func TestErrInvalidBucketName(t *testing.T) {
 	expectedResult := ErrorResponse{
-		Code:      "InvalidBucketName",
+		Code:      ErrCodeInvalidBucketName,
 		Message:   "Invalid Bucket name",
 		RequestID: "minio",
 	}
@@ -239,7 +239,7 @@ func TestErrInvalidBucketName(t *testing.T) {
 // Test validates 'ErrInvalidObjectName' error response.
 func TestErrInvalidObjectName(t *testing.T) {
 	expectedResult := ErrorResponse{
-		Code:      "NoSuchKey",
+		Code:      ErrCodeNoSuchKey,
 		Message:   "Invalid Object Key",
 		RequestID: "minio",
 	}
@@ -252,7 +252,7 @@ func TestErrInvalidObjectName(t *testing.T) {
 // Test validates 'ErrInvalidArgument' response.
 func TestErrInvalidArgument(t *testing.T) {
 	expectedResult := ErrorResponse{
-		Code:      "InvalidArgument",
+		Code:      ErrCodeInvalidArgument,
 		Message:   "Invalid Argument",
 		RequestID: "minio",
 	}

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -619,7 +619,7 @@ func (c Client) getObject(bucketName, objectName string, offset, length int64) (
 	if err != nil {
 		msg := "Last-Modified time format not recognized. " + reportIssue
 		return nil, ObjectInfo{}, ErrorResponse{
-			Code:      "InternalError",
+			Code:      ErrCodeInternalError,
 			Message:   msg,
 			RequestID: resp.Header.Get("x-amz-request-id"),
 			HostID:    resp.Header.Get("x-amz-id-2"),

--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -75,7 +75,7 @@ func (c Client) FPutObject(bucketName, objectName, filePath, contentType string)
 	if isGoogleEndpoint(c.endpointURL) {
 		if fileSize > int64(maxSinglePutObjectSize) {
 			return 0, ErrorResponse{
-				Code:       "NotImplemented",
+				Code:       ErrCodeNotImplemented,
 				Message:    fmt.Sprintf("Invalid Content-Length %d for file uploads to Google Cloud Storage.", fileSize),
 				Key:        objectName,
 				BucketName: bucketName,
@@ -89,7 +89,7 @@ func (c Client) FPutObject(bucketName, objectName, filePath, contentType string)
 	if isAmazonEndpoint(c.endpointURL) && c.anonymous {
 		if fileSize > int64(maxSinglePutObjectSize) {
 			return 0, ErrorResponse{
-				Code:       "NotImplemented",
+				Code:       ErrCodeNotImplemented,
 				Message:    fmt.Sprintf("For anonymous requests Content-Length cannot be %d.", fileSize),
 				Key:        objectName,
 				BucketName: bucketName,
@@ -110,7 +110,7 @@ func (c Client) FPutObject(bucketName, objectName, filePath, contentType string)
 		errResp := ToErrorResponse(err)
 		// Verify if multipart functionality is not available, if not
 		// fall back to single PutObject operation.
-		if errResp.Code == "NotImplemented" {
+		if errResp.Code == ErrCodeNotImplemented {
 			// If size of file is greater than '5GiB' fail.
 			if fileSize > maxSinglePutObjectSize {
 				return 0, ErrEntityTooLarge(fileSize, maxSinglePutObjectSize, bucketName, objectName)

--- a/api-put-object-progress.go
+++ b/api-put-object-progress.go
@@ -53,7 +53,7 @@ func (c Client) PutObjectWithProgress(bucketName, objectName string, reader io.R
 	if isGoogleEndpoint(c.endpointURL) {
 		if size <= -1 {
 			return 0, ErrorResponse{
-				Code:       "NotImplemented",
+				Code:       ErrCodeNotImplemented,
 				Message:    "Content-Length cannot be negative for file uploads to Google Cloud Storage.",
 				Key:        objectName,
 				BucketName: bucketName,
@@ -70,7 +70,7 @@ func (c Client) PutObjectWithProgress(bucketName, objectName string, reader io.R
 	if isAmazonEndpoint(c.endpointURL) && c.anonymous {
 		if size <= -1 {
 			return 0, ErrorResponse{
-				Code:       "NotImplemented",
+				Code:       ErrCodeNotImplemented,
 				Message:    "Content-Length cannot be negative for anonymous requests.",
 				Key:        objectName,
 				BucketName: bucketName,

--- a/api-remove.go
+++ b/api-remove.go
@@ -109,7 +109,7 @@ func processRemoveMultiObjectsResponse(body io.Reader, objects []string, errorCh
 		errorCh <- RemoveObjectError{
 			ObjectName: obj.Key,
 			Err: ErrorResponse{
-				Code:    obj.Code,
+				Code:    APIErrorCode(obj.Code),
 				Message: obj.Message,
 			},
 		}
@@ -255,7 +255,7 @@ func (c Client) abortMultipartUpload(bucketName, objectName, uploadID string) er
 				// This is needed specifically for abort and it cannot
 				// be converged into default case.
 				errorResponse = ErrorResponse{
-					Code:       "NoSuchUpload",
+					Code:       ErrCodeNoSuchUpload,
 					Message:    "The specified multipart upload does not exist.",
 					BucketName: bucketName,
 					Key:        objectName,

--- a/api-stat.go
+++ b/api-stat.go
@@ -82,7 +82,7 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
 	if err != nil {
 		return ObjectInfo{}, ErrorResponse{
-			Code:       "InternalError",
+			Code:       ErrCodeInternalError,
 			Message:    "Content-Length is invalid. " + reportIssue,
 			BucketName: bucketName,
 			Key:        objectName,
@@ -95,7 +95,7 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 	date, err := time.Parse(http.TimeFormat, resp.Header.Get("Last-Modified"))
 	if err != nil {
 		return ObjectInfo{}, ErrorResponse{
-			Code:       "InternalError",
+			Code:       ErrCodeInternalError,
 			Message:    "Last-Modified time format is invalid. " + reportIssue,
 			BucketName: bucketName,
 			Key:        objectName,

--- a/bucket-cache_test.go
+++ b/bucket-cache_test.go
@@ -265,7 +265,7 @@ func TestProcessBucketLocationResponse(t *testing.T) {
 
 	APIErrors := []APIError{
 		{
-			Code:           "AccessDenied",
+			Code:           ErrCodeAccessDenied,
 			Description:    "Access Denied",
 			HTTPStatusCode: http.StatusUnauthorized,
 		},

--- a/retry.go
+++ b/retry.go
@@ -103,21 +103,21 @@ func isNetErrorRetryable(err error) bool {
 }
 
 // List of AWS S3 error codes which are retryable.
-var retryableS3Codes = map[string]struct{}{
-	"RequestError":          {},
-	"RequestTimeout":        {},
-	"Throttling":            {},
-	"ThrottlingException":   {},
-	"RequestLimitExceeded":  {},
-	"RequestThrottled":      {},
-	"InternalError":         {},
-	"ExpiredToken":          {},
-	"ExpiredTokenException": {},
+var retryableS3Codes = map[APIErrorCode]struct{}{
+	ErrCodeRequestError:          {},
+	ErrCodeRequestTimeout:        {},
+	ErrCodeThrottling:            {},
+	ErrCodeThrottlingException:   {},
+	ErrCodeRequestLimitExceeded:  {},
+	ErrCodeRequestThrottled:      {},
+	ErrCodeInternalError:         {},
+	ErrCodeExpiredToken:          {},
+	ErrCodeExpiredTokenException: {},
 	// Add more AWS S3 codes here.
 }
 
 // isS3CodeRetryable - is s3 error code retryable.
-func isS3CodeRetryable(s3Code string) (ok bool) {
+func isS3CodeRetryable(s3Code APIErrorCode) (ok bool) {
 	_, ok = retryableS3Codes[s3Code]
 	return ok
 }

--- a/test-utils_test.go
+++ b/test-utils_test.go
@@ -27,7 +27,7 @@ import (
 
 // APIError Used for mocking error response from server.
 type APIError struct {
-	Code           string
+	Code           APIErrorCode
 	Description    string
 	HTTPStatusCode int
 }


### PR DESCRIPTION
This is an API change but looks like minor since I replaced `ErrorResponse.Code` type to `APIErrorCode`: 
- `type APIErrorCode string`
