### PR TITLE
api: relax strict Content-Length check for GCS.

### DIFF
--- a/api-get-policy.go
+++ b/api-get-policy.go
@@ -41,7 +41,7 @@ func (c Client) GetBucketPolicy(bucketName, objectPrefix string) (bucketPolicy p
 	return policy.GetPolicy(policyInfo.Statements, bucketName, objectPrefix), nil
 }
 
-// GetBucketPolicy - get bucket policy rules at a given path.
+// ListBucketPolicies - list all policies for a given prefix and all its children.
 func (c Client) ListBucketPolicies(bucketName, objectPrefix string) (bucketPolicies map[string]policy.BucketPolicy, err error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
@@ -57,7 +57,7 @@ func (c Client) ListBucketPolicies(bucketName, objectPrefix string) (bucketPolic
 	return policy.GetPolicies(policyInfo.Statements, bucketName), nil
 }
 
-// Request server for policy.
+// Request server for current bucket policy.
 func (c Client) getBucketPolicy(bucketName string, objectPrefix string) (policy.BucketAccessPolicy, error) {
 	// Get resources properly escaped and lined up before
 	// using them in http request.

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -210,15 +210,16 @@ type createBucketConfiguration struct {
 // deleteObject container for Delete element in MultiObjects Delete XML request
 type deleteObject struct {
 	Key       string
-	VersionId string `xml:"VersionId,omitempty"`
+	VersionID string `xml:"VersionId,omitempty"`
 }
 
 // deletedObject container for Deleted element in MultiObjects Delete XML response
 type deletedObject struct {
-	Key                   string
-	VersionId             string `xml:"VersionId,omitempty"`
+	Key       string
+	VersionID string `xml:"VersionId,omitempty"`
+	// These fields are ignored.
 	DeleteMarker          bool
-	DeleteMarkerVersionId string
+	DeleteMarkerVersionID string
 }
 
 // nonDeletedObject container for Error element (failed deletion) in MultiObjects Delete XML response

--- a/bucket-notification.go
+++ b/bucket-notification.go
@@ -84,7 +84,7 @@ func (arn Arn) String() string {
 // NotificationConfig - represents one single notification configuration
 // such as topic, queue or lambda configuration.
 type NotificationConfig struct {
-	Id     string                  `xml:"Id,omitempty"`
+	ID     string                  `xml:"Id,omitempty"`
 	Arn    Arn                     `xml:"-"`
 	Events []NotificationEventType `xml:"Event"`
 	Filter *Filter                 `xml:"Filter,omitempty"`

--- a/pkg/policy/bucket-policy.go
+++ b/pkg/policy/bucket-policy.go
@@ -34,7 +34,7 @@ const (
 	BucketPolicyWriteOnly              = "writeonly"
 )
 
-// isValidBucketPolicy - Is provided policy value supported.
+// IsValidBucketPolicy - returns true if policy is valid and supported, false otherwise.
 func (p BucketPolicy) IsValidBucketPolicy() bool {
 	switch p {
 	case BucketPolicyNone, BucketPolicyReadOnly, BucketPolicyReadWrite, BucketPolicyWriteOnly:
@@ -508,7 +508,7 @@ func getObjectPolicy(statement Statement) (readOnly bool, writeOnly bool) {
 	return readOnly, writeOnly
 }
 
-// Returns policy of given bucket name, prefix in given statements.
+// GetPolicy - Returns policy of given bucket name, prefix in given statements.
 func GetPolicy(statements []Statement, bucketName string, prefix string) BucketPolicy {
 	bucketResource := awsResourcePrefix + bucketName
 	objectResource := awsResourcePrefix + bucketName + "/" + prefix + "*"
@@ -563,7 +563,7 @@ func GetPolicy(statements []Statement, bucketName string, prefix string) BucketP
 	return policy
 }
 
-// GetPolicies returns a map of policies rules of given bucket name, prefix in given statements.
+// GetPolicies - returns a map of policies rules of given bucket name, prefix in given statements.
 func GetPolicies(statements []Statement, bucketName string) map[string]BucketPolicy {
 	policyRules := map[string]BucketPolicy{}
 	objResources := set.NewStringSet()
@@ -590,8 +590,7 @@ func GetPolicies(statements []Statement, bucketName string) map[string]BucketPol
 	return policyRules
 }
 
-// Returns new statements containing policy of given bucket name and
-// prefix are appended.
+// SetPolicy - Returns new statements containing policy of given bucket name and prefix are appended.
 func SetPolicy(statements []Statement, policy BucketPolicy, bucketName string, prefix string) []Statement {
 	out := removeStatements(statements, bucketName, prefix)
 	// fmt.Println("out = ")


### PR DESCRIPTION
GCS has a bug where HEAD replies are inconsistent.
i.e Content-Length is added and removed in successive
requests. This makes it harder to add strict checks.

Relax this for now, until GCS fixes this bug on their end.

Fixes #532