### PR TITLE
getReaderSize() returns -1 in case of read/write os.Pipe() stream

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -103,11 +103,10 @@ func getReaderSize(reader io.Reader) (size int64, err error) {
 			// implement Seekable calls. Ignore them and treat
 			// them like a stream with unknown length.
 			switch st.Name() {
-			case "stdin":
-				fallthrough
-			case "stdout":
-				fallthrough
-			case "stderr":
+			case "stdin", "stdout", "stderr":
+				return
+			// Ignore read/write stream of os.Pipe() which have unknown length too.
+			case "|0", "|1":
 				return
 			}
 			size = st.Size()


### PR DESCRIPTION
getReaderSize(): when users pass a reader generated by os.Pipe(), avoid fetching for its size and return -1 instead.

Fixes #552 