### PR TITLE
list: Don't send incomplete uploads info with err

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -482,6 +482,7 @@ func (c Client) listIncompleteUploads(bucketName, objectPrefix string, recursive
 						objectMultipartStatCh <- ObjectMultipartInfo{
 							Err: err,
 						}
+						continue
 					}
 				}
 				select {


### PR DESCRIPTION
Incomplete Uploads List API continues to send object information even
when an error is encountered. This commit fixes this behavior with
sending only err in the incomplete upload list.