### PR TITLE
Add S3 Acceleration endpoint via "accelerate" bucket

### DIFF
--- a/s3-endpoints.go
+++ b/s3-endpoints.go
@@ -19,6 +19,7 @@ package minio
 // awsS3EndpointMap Amazon S3 endpoint map.
 // "cn-north-1" adds support for AWS China.
 var awsS3EndpointMap = map[string]string{
+	"accelerate":     "s3-accelerate.amazonaws.com",
 	"us-east-1":      "s3.amazonaws.com",
 	"us-east-2":      "s3-us-east-2.amazonaws.com",
 	"us-west-2":      "s3-us-west-2.amazonaws.com",


### PR DESCRIPTION
There is currently no way use [Amazon S3 Acceleration](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html) without Minio defaulting to s3.amazonaws.com. This would fix https://gitlab.com/gitlab-org/omnibus-gitlab/issues/1804 for GitLab.