### PR TITLE
Fix for looking up bucket locations in S3 Acceleration endpoints

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -163,6 +163,13 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 
 	// Set get bucket location always as path style.
 	targetURL := c.endpointURL
+
+	// Requesting a bucket location from an accelerate endpoint returns a 400,
+	// so default to us-east-1 for the lookup
+	if isAmazonS3AccelerateEndpoint(c.endpointURL) {
+		targetURL.Host = getS3Endpoint("us-east-1")
+	}
+
 	targetURL.Path = path.Join(bucketName, "") + "/"
 	targetURL.RawQuery = urlValues.Encode()
 


### PR DESCRIPTION
Attempting to lookup a bucket via the s3-accelerate.amazonaws.com host
returns an Error 400. Fall back to looking up with the us-east-1 endpoint.

Closes #576