### PR TITLE
Refer to SDK as Minio Go client SDK

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# Golang Client API Reference [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# Minio Go Client API Reference [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Initialize Minio Client object.
 


### PR DESCRIPTION
The preferred way of referring to the Go programming language is Go as opposed to Golang.