### PR TITLE
Make copy conditions type simpler

### DIFF
--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -943,7 +943,7 @@ func TestCopyObjectV2(t *testing.T) {
 	}
 
 	// Set copy conditions.
-	copyConds := NewCopyConditions()
+	copyConds := CopyConditions{}
 	err = copyConds.SetModified(time.Date(2014, time.April, 0, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatal("Error:", err)

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -1662,7 +1662,7 @@ func TestCopyObject(t *testing.T) {
 	}
 
 	// Set copy conditions.
-	copyConds := NewCopyConditions()
+	copyConds := CopyConditions{}
 
 	// Start by setting wrong conditions
 	err = copyConds.SetModified(time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC))
@@ -1725,7 +1725,7 @@ func TestCopyObject(t *testing.T) {
 	}
 
 	// CopyObject again but with wrong conditions
-	copyConds = NewCopyConditions()
+	copyConds = CopyConditions{}
 	err = copyConds.SetUnmodified(time.Date(2014, time.April, 0, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatal("Error:", err)

--- a/copy-conditions.go
+++ b/copy-conditions.go
@@ -41,11 +41,13 @@ type CopyConditions struct {
 	conditions []copyCondition
 }
 
-// NewCopyConditions - Instantiate new list of conditions.
+// NewCopyConditions - Instantiate new list of conditions.  This
+// function is left behind for backward compatibility. The idiomatic
+// way to set an empty set of copy conditions is,
+//    ``copyConditions := CopyConditions{}``.
+//
 func NewCopyConditions() CopyConditions {
-	return CopyConditions{
-		conditions: make([]copyCondition, 0),
-	}
+	return CopyConditions{}
 }
 
 // SetMatchETag - set match etag.

--- a/docs/API.md
+++ b/docs/API.md
@@ -511,7 +511,7 @@ __Example__
 ```go
 // Use-case-1
 // To copy an existing object to a new object with _no_ copy conditions.
-copyConditions := minio.NewCopyConditions()
+copyConditions := minio.CopyConditions{}
 err := minioClient.CopyObject("mybucket", "myobject", "my-sourcebucketname/my-sourceobjectname", copyConds)
 if err != nil {
     fmt.Println(err)
@@ -524,13 +524,13 @@ if err != nil {
 // 2. and modified after 1st April 2014
 // 3. but unmodified since 23rd April 2014
 
-// Set copy conditions.
-var copyConds = minio.NewCopyConditions()
+// Initialize empty copy conditions.
+var copyConds = minio.CopyConditions{}
 
 // copy object that matches the given ETag.
 copyConds.SetMatchETag("31624deb84149d2f8ef9c385918b653a")
 
-// and modified after 1st April 2014 
+// and modified after 1st April 2014
 copyConds.SetModified(time.Date(2014, time.April, 1, 0, 0, 0, 0, time.UTC))
 
 // but unmodified since 23rd April 2014

--- a/examples/s3/copyobject.go
+++ b/examples/s3/copyobject.go
@@ -45,7 +45,7 @@ func main() {
 	// All following conditions are allowed and can be combined together.
 
 	// Set copy conditions.
-	var copyConds = minio.NewCopyConditions()
+	var copyConds = minio.CopyConditions{}
 	// Set modified condition, copy object modified since 2014 April.
 	copyConds.SetModified(time.Date(2014, time.April, 0, 0, 0, 0, 0, time.UTC))
 


### PR DESCRIPTION
This change is to simplify API usage for users who wish to copy objects 'unconditionally' using CopyObject API. ``NewCopyConditions`` is left behind for users who have applications that already use the function.