### PR TITLE
trie: new package

### DIFF
--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -1,0 +1,113 @@
+/*
+ * Minio Go SDK for Amazon S3 Compatible Cloud Storage (C) 2014, 2015, 2016, 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file implements a simple trie tree for minio server/tools.
+// This package borrows idea from - https://godoc.org/golang.org/x/text/internal/triegen.
+package trie
+
+// Trie is a trie container.
+type Trie struct {
+	root *trieNode
+	size int
+}
+
+// NewTrie create a new trie.
+func NewTrie() *Trie {
+	return &Trie{
+		root: newTrieNode(),
+		size: 0,
+	}
+}
+
+// trieNode trie tree node container carries value and children.
+type trieNode struct {
+	exists bool
+	value  interface{}
+	child  map[rune]*trieNode // runes as child.
+}
+
+// newTrieNode create a new trie node.
+func newTrieNode() *trieNode {
+	return &trieNode{
+		exists: false,
+		value:  nil,
+		child:  make(map[rune]*trieNode),
+	}
+}
+
+// Insert insert a key.
+func (t *Trie) Insert(key string) {
+	curNode := t.root
+	for _, v := range key {
+		if curNode.child[v] == nil {
+			curNode.child[v] = newTrieNode()
+		}
+		curNode = curNode.child[v]
+	}
+
+	if !curNode.exists {
+		// increment when new rune child is added.
+		t.size++
+		curNode.exists = true
+	}
+	// value is stored for retrieval in future.
+	curNode.value = key
+}
+
+// PrefixMatch - prefix match.
+func (t *Trie) PrefixMatch(key string) []interface{} {
+	node, _ := t.findNode(key)
+	if node != nil {
+		return t.walk(node)
+	}
+	return []interface{}{}
+}
+
+// walk the tree.
+func (t *Trie) walk(node *trieNode) (ret []interface{}) {
+	if node.exists {
+		ret = append(ret, node.value)
+	}
+	for _, v := range node.child {
+		ret = append(ret, t.walk(v)...)
+	}
+	return
+}
+
+// find nodes corresponding to key.
+func (t *Trie) findNode(key string) (node *trieNode, index int) {
+	curNode := t.root
+	f := false
+	for k, v := range key {
+		if f {
+			index = k
+			f = false
+		}
+		if curNode.child[v] == nil {
+			return nil, index
+		}
+		curNode = curNode.child[v]
+		if curNode.exists {
+			f = true
+		}
+	}
+
+	if curNode.exists {
+		index = len(key)
+	}
+
+	return curNode, index
+}

--- a/pkg/trie/trie_test.go
+++ b/pkg/trie/trie_test.go
@@ -1,0 +1,71 @@
+/*
+ * Minio Cloud Storage, (C) 2016, 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package trie
+
+import (
+	"testing"
+)
+
+// Simply make sure creating a new tree works.
+func TestNewTrie(t *testing.T) {
+	var trie *Trie
+	trie = NewTrie()
+
+	if trie.size != 0 {
+		t.Errorf("expected size 0, got: %d", trie.size)
+	}
+}
+
+// Ensure that we can insert new keys into the tree, then check the size.
+func TestInsert(t *testing.T) {
+	var trie *Trie
+	trie = NewTrie()
+
+	// We need to have an empty tree to begin with.
+	if trie.size != 0 {
+		t.Errorf("expected size 0, got: %d", trie.size)
+	}
+
+	trie.Insert("key")
+	trie.Insert("keyy")
+
+	// After inserting, we should have a size of two.
+	if trie.size != 2 {
+		t.Errorf("expected size 2, got: %d", trie.size)
+	}
+}
+
+// Ensure that PrefixMatch gives us the correct two keys in the tree.
+func TestPrefixMatch(t *testing.T) {
+	var trie *Trie
+	trie = NewTrie()
+
+	// Feed it some fodder: only 'minio' and 'miny-os' should trip the matcher.
+	trie.Insert("minio")
+	trie.Insert("amazon")
+	trie.Insert("cheerio")
+	trie.Insert("miny-o's")
+
+	matches := trie.PrefixMatch("min")
+	if len(matches) != 2 {
+		t.Errorf("expected two matches, got: %d", len(matches))
+	}
+
+	if matches[0] != "minio" && matches[1] != "minio" {
+		t.Errorf("expected one match to be 'minio', got: '%s' and '%s'", matches[0], matches[1])
+	}
+}


### PR DESCRIPTION
This implements a simple trie tree for minio server/tools.
This package borrows idea from
https://godoc.org/golang.org/x/text/internal/triegen.