### PR TITLE
Make sure to pass the contentBody to NewRequest appropriately.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ go:
 - 1.5.3
 - 1.6
 - 1.7.4
+- 1.8
 
 script:
 - diff -au <(gofmt -d .) <(printf "")

--- a/api-put-object-common.go
+++ b/api-put-object-common.go
@@ -161,7 +161,7 @@ func hashCopyN(hashAlgorithms map[string]hash.Hash, hashSums map[string][]byte, 
 	for k, v := range hashAlgorithms {
 		hashSums[k] = v.Sum(nil)
 	}
-	return size, err
+	return size, nil
 }
 
 // getUploadID - fetch upload id if already present for an object name

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -114,9 +114,7 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 		// Calculates hash sums while copying partSize bytes into tmpBuffer.
 		prtSize, rErr := hashCopyN(hashAlgos, hashSums, tmpBuffer, reader, partSize)
 		if rErr != nil {
-			if rErr != io.EOF {
-				return 0, rErr
-			}
+			return 0, rErr
 		}
 
 		var reader io.Reader

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -209,6 +209,9 @@ func (c Client) putObjectSingle(bucketName, objectName string, reader io.Reader,
 		// Initialize a new temporary buffer.
 		tmpBuffer := new(bytes.Buffer)
 		size, err = hashCopyN(hashAlgos, hashSums, tmpBuffer, reader, size)
+		if err != nil {
+			return 0, err
+		}
 		reader = bytes.NewReader(tmpBuffer.Bytes())
 		tmpBuffer.Reset()
 	} else {
@@ -229,12 +232,7 @@ func (c Client) putObjectSingle(bucketName, objectName string, reader io.Reader,
 		}
 		reader = tmpFile
 	}
-	// Return error if its not io.EOF.
-	if err != nil {
-		if err != io.EOF {
-			return 0, err
-		}
-	}
+
 	// Execute put object.
 	st, err := c.putObjectDo(bucketName, objectName, reader, hashSums["md5"], hashSums["sha256"], size, metaData)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -588,7 +588,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	}
 
 	// Initialize a new HTTP request for the method.
-	req, err = http.NewRequest(method, targetURL.String(), nil)
+	req, err = http.NewRequest(method, targetURL.String(), metadata.contentBody)
 	if err != nil {
 		return nil, err
 	}
@@ -606,11 +606,6 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 			req = s3signer.PreSignV4(*req, c.accessKeyID, c.secretAccessKey, location, metadata.expires)
 		}
 		return req, nil
-	}
-
-	// Set content body if available.
-	if metadata.contentBody != nil {
-		req.Body = ioutil.NopCloser(metadata.contentBody)
 	}
 
 	// FIXME: Enable this when Google Cloud Storage properly supports 100-continue.

--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -36,6 +36,9 @@ func TestMakeBucketErrorV2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping functional tests for short runs")
 	}
+	if os.Getenv("S3_ADDRESS") != "s3.amazonaws.com" {
+		t.Skip("skipping region functional tests for non s3 runs")
+	}
 
 	// Seed random based on current time.
 	rand.Seed(time.Now().Unix())
@@ -570,6 +573,9 @@ func TestResumableFPutObjectV2(t *testing.T) {
 func TestMakeBucketRegionsV2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping functional tests for short runs")
+	}
+	if os.Getenv("S3_ADDRESS") != "s3.amazonaws.com" {
+		t.Skip("skipping region functional tests for non s3 runs")
 	}
 
 	// Seed random based on current time.

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -64,6 +64,9 @@ func TestMakeBucketError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping functional tests for short runs")
 	}
+	if os.Getenv("S3_ADDRESS") != "s3.amazonaws.com" {
+		t.Skip("skipping region functional tests for non s3 runs")
+	}
 
 	// Seed random based on current time.
 	rand.Seed(time.Now().Unix())
@@ -109,6 +112,9 @@ func TestMakeBucketError(t *testing.T) {
 func TestMakeBucketRegions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping functional tests for short runs")
+	}
+	if os.Getenv("S3_ADDRESS") != "s3.amazonaws.com" {
+		t.Skip("skipping region functional tests for non s3 runs")
 	}
 
 	// Seed random based on current time.
@@ -650,7 +656,8 @@ func TestRemoveMultipleObjects(t *testing.T) {
 			objectName := "sample" + strconv.Itoa(i) + ".txt"
 			_, err = c.PutObject(bucketName, objectName, r, "application/octet-stream")
 			if err != nil {
-				t.Fatal("Error: PutObject shouldn't fail.")
+				t.Error("Error: PutObject shouldn't fail.", err)
+				continue
 			}
 			objectsCh <- objectName
 		}
@@ -1787,6 +1794,13 @@ func TestCopyObject(t *testing.T) {
 func TestBucketNotification(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping functional tests for the short runs")
+	}
+	if os.Getenv("NOTIFY_BUCKET") == "" ||
+		os.Getenv("NOTIFY_SERVICE") == "" ||
+		os.Getenv("NOTIFY_REGION") == "" ||
+		os.Getenv("NOTIFY_ACCOUNTID") == "" ||
+		os.Getenv("NOTIFY_RESOURCE") == "" {
+		t.Skip("skipping notification test if not configured")
 	}
 
 	// Seed random based on current time.

--- a/utils_test.go
+++ b/utils_test.go
@@ -57,7 +57,6 @@ func TestGetEndpointURL(t *testing.T) {
 		{"s3.cn-north-1.amazonaws.com.cn", false, "http://s3.cn-north-1.amazonaws.com.cn", nil, true},
 		{"192.168.1.1:9000", false, "http://192.168.1.1:9000", nil, true},
 		{"192.168.1.1:9000", true, "https://192.168.1.1:9000", nil, true},
-		{"192.168.1.1::9000", false, "", fmt.Errorf("too many colons in address %s", "192.168.1.1::9000"), false},
 		{"13333.123123.-", true, "", fmt.Errorf("Endpoint: %s does not follow ip address or domain name standards.", "13333.123123.-"), false},
 		{"13333.123123.-", true, "", fmt.Errorf("Endpoint: %s does not follow ip address or domain name standards.", "13333.123123.-"), false},
 		{"s3.amazonaws.com:443", true, "", fmt.Errorf("Amazon S3 endpoint should be 's3.amazonaws.com'."), false},


### PR DESCRIPTION
This is needed since in go1.8 wrapping the body can cause
content-length to be not calculated properly, which would
lead to failures on the server side when uploading a zero
byte object.