### PR TITLE
Revert "Revert passing content body to http request (#619)"

### DIFF
--- a/api.go
+++ b/api.go
@@ -588,7 +588,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	}
 
 	// Initialize a new HTTP request for the method.
-	req, err = http.NewRequest(method, targetURL.String(), nil)
+	req, err = http.NewRequest(method, targetURL.String(), metadata.contentBody)
 	if err != nil {
 		return nil, err
 	}
@@ -606,11 +606,6 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 			req = s3signer.PreSignV4(*req, c.accessKeyID, c.secretAccessKey, location, metadata.expires)
 		}
 		return req, nil
-	}
-
-	// Set content body if available.
-	if metadata.contentBody != nil {
-		req.Body = ioutil.NopCloser(metadata.contentBody)
 	}
 
 	// FIXME: Enable this when Google Cloud Storage properly supports 100-continue.


### PR DESCRIPTION
This reverts commit f804d7924e889b4a4c6a8659d16c833bf6e75cda. One bug
was wrongly understood and led to a wrong revert.