### PR TITLE
allow bucket location responses with empty Message (fixes #629)

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -125,7 +125,7 @@ func processBucketLocationResponse(resp *http.Response, bucketName string) (buck
 			// For access denied error, it could be an anonymous
 			// request. Move forward and let the top level callers
 			// succeed if possible based on their policy.
-			if errResp.Code == "AccessDenied" && (errResp.Message == "" || strings.Contains(errResp.Message, "Access Denied")) {
+			if errResp.Code == "AccessDenied" {
 				return "us-east-1", nil
 			}
 			return "", err

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -125,7 +125,7 @@ func processBucketLocationResponse(resp *http.Response, bucketName string) (buck
 			// For access denied error, it could be an anonymous
 			// request. Move forward and let the top level callers
 			// succeed if possible based on their policy.
-			if errResp.Code == "AccessDenied" && strings.Contains(errResp.Message, "Access Denied") {
+			if errResp.Code == "AccessDenied" && (errResp.Message == "" || strings.Contains(errResp.Message, "Access Denied")) {
 				return "us-east-1", nil
 			}
 			return "", err

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strings"
 	"sync"
 
 	"github.com/minio/minio-go/pkg/s3signer"


### PR DESCRIPTION
When Ceph radosgw responds to a bucket location request for a bucket which is not owned by the user, it issues an "AccessDenied" XML response that does not contain any `<Message>` element. Because of this, the code that handles "anonymous" buckets in `processBucketLocationResponse` is not triggered, as it is looking for both an `errResp.Code` of "AccessDenied" and also an `errResp.Message` containing the substring "Access Denied". 

This PR changes the behaviour of `processBucketLocationResponse` to allow an empty `errResp.Message` to be treated the same as one that contains the substring "Access Denied". 

Fixes #629