### PR TITLE
[need-review] sigv2: Do not encode canonical sub-resource value

### DIFF
--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -316,7 +316,7 @@ func writeCanonicalizedResource(buf *bytes.Buffer, req http.Request, isPreSign b
 				// Request parameters
 				if len(vv[0]) > 0 {
 					buf.WriteByte('=')
-					buf.WriteString(strings.Replace(url.QueryEscape(vv[0]), "+", "%20", -1))
+					buf.WriteString(vv[0])
 				}
 			}
 		}


### PR DESCRIPTION
Do not encode sub-resource value (such is uploadID) when building
canonicalized request string.

