### PR TITLE
api: Create new pkg/encrypt package and use it.

### DIFF
--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/minio/minio-go/pkg/policy"
 )
 
@@ -1828,7 +1829,7 @@ func TestEncryptionPutGet(t *testing.T) {
 	}
 
 	// Generate a symmetric key
-	symKey := NewSymmetricKey([]byte("my-secret-key-00"))
+	symKey := encrypt.NewSymmetricKey([]byte("my-secret-key-00"))
 
 	// Generate an assymmetric key from predefine public and private certificates
 	privateKey, err := hex.DecodeString(
@@ -1870,7 +1871,7 @@ func TestEncryptionPutGet(t *testing.T) {
 	}
 
 	// Generate an asymmetric key
-	asymKey, err := NewAsymmetricKey(privateKey, publicKey)
+	asymKey, err := encrypt.NewAsymmetricKey(privateKey, publicKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1880,7 +1881,7 @@ func TestEncryptionPutGet(t *testing.T) {
 
 	testCases := []struct {
 		buf    []byte
-		encKey EncryptionKey
+		encKey encrypt.Key
 	}{
 		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 0)},
 		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 1)},
@@ -1907,7 +1908,7 @@ func TestEncryptionPutGet(t *testing.T) {
 		objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 
 		// Secured object
-		cbcMaterials, err := NewCBCSecureMaterials(testCase.encKey)
+		cbcMaterials, err := encrypt.NewCBCSecureMaterials(testCase.encKey)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/constants.go
+++ b/constants.go
@@ -50,3 +50,10 @@ const (
 	signV4Algorithm   = "AWS4-HMAC-SHA256"
 	iso8601DateFormat = "20060102T150405Z"
 )
+
+// Encryption headers stored along with the object.
+const (
+	amzHeaderIV      = "X-Amz-Meta-X-Amz-Iv"
+	amzHeaderKey     = "X-Amz-Meta-X-Amz-Key"
+	amzHeaderMatDesc = "X-Amz-Meta-X-Amz-Matdesc"
+)

--- a/pkg/encrypt/interface.go
+++ b/pkg/encrypt/interface.go
@@ -14,31 +14,37 @@
  * limitations under the License.
  */
 
-package minio
+// Package encrypt implements a generic interface to encrypt any stream of data.
+// currently this package implements two types of encryption
+// - Symmetric encryption using AES.
+// - Asymmetric encrytion using RSA.
+package encrypt
 
-import (
-	"io"
-	"net/http"
-)
+import "io"
 
-// EncryptionMaterials - provides generic interface to encrypt
-// any stream of data. Some crypt information can be
-// save in the object metadata
-type EncryptionMaterials interface {
+// Materials - provides generic interface to encrypt any stream of data.
+type Materials interface {
 
-	// Return encrypted/decrypted data.
+	// Returns encrypted/decrypted data, io.Reader compatible.
 	Read(b []byte) (int, error)
 
-	// Metadata that will be stored with the object
-	GetHeaders() http.Header
+	// Get randomly generated IV, base64 encoded.
+	GetIV() (iv string)
+
+	// Get content encrypting key (cek) in encrypted form, base64 encoded.
+	GetKey() (key string)
+
+	// Get user provided encryption material description in
+	// JSON (UTF8) format. This is not used, kept for future.
+	GetDesc() (desc string)
 
 	// Setup encrypt mode, further calls of Read() function
 	// will return the encrypted form of data streamed
 	// by the passed reader
-	SetupEncryptMode(io.Reader) error
+	SetupEncryptMode(stream io.Reader) error
 
 	// Setup decrypted mode, further calls of Read() function
 	// will return the decrypted form of data streamed
 	// by the passed reader
-	SetupDecryptMode(io.Reader, http.Header) error
+	SetupDecryptMode(stream io.Reader, iv string, key string) error
 }

--- a/pkg/encrypt/keys.go
+++ b/pkg/encrypt/keys.go
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package minio
+package encrypt
 
 import (
 	"crypto/aes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"errors"
 )
 
-// EncryptionKey - generic interface to encrypt/decrypt a key.
+// Key - generic interface to encrypt/decrypt a key.
 // We use it to encrypt/decrypt content key which is the key
 // that encrypt/decrypt object data.
-type EncryptionKey interface {
+type Key interface {
 	// Encrypt data using to the set encryption key
 	Encrypt([]byte) ([]byte, error)
 	// Decrypt data using to the set encryption key
@@ -140,7 +141,7 @@ func NewAsymmetricKey(privData []byte, pubData []byte) (*AsymmetricKey, error) {
 	}
 	privKey, ok := priv.(*rsa.PrivateKey)
 	if !ok {
-		return nil, ErrInvalidArgument("not a valid private key")
+		return nil, errors.New("not a valid private key")
 	}
 
 	// Parse public key from passed data
@@ -151,7 +152,7 @@ func NewAsymmetricKey(privData []byte, pubData []byte) (*AsymmetricKey, error) {
 
 	pubKey, ok := pub.(*rsa.PublicKey)
 	if !ok {
-		return nil, ErrInvalidArgument("not a valid public key")
+		return nil, errors.New("not a valid public key")
 	}
 
 	// Associate the private key with the passed public key


### PR DESCRIPTION
This is implemented to avoid references of any
HTTP or aws based constants. Simply to show that
encryption is implemented for generic purposes.