### PR TITLE
api: Multipart APIs are supported for anonymous requests.

### DIFF
--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -91,25 +91,11 @@ func (c Client) FPutObject(bucketName, objectName, filePath, contentType string)
 		return c.putObjectNoChecksum(bucketName, objectName, fileReader, fileSize, objMetadata, nil)
 	}
 
-	// NOTE: S3 doesn't allow anonymous multipart requests.
-	if s3utils.IsAmazonEndpoint(c.endpointURL) && c.anonymous {
-		if fileSize > int64(maxSinglePutObjectSize) {
-			return 0, ErrorResponse{
-				Code:       "NotImplemented",
-				Message:    fmt.Sprintf("For anonymous requests Content-Length cannot be %d.", fileSize),
-				Key:        objectName,
-				BucketName: bucketName,
-			}
-		}
-		// Do not compute MD5 for anonymous requests to Amazon
-		// S3. Uploads up to 5GiB in size.
-		return c.putObjectNoChecksum(bucketName, objectName, fileReader, fileSize, objMetadata, nil)
-	}
-
 	// Small object upload is initiated for uploads for input data size smaller than 5MiB.
 	if fileSize < minPartSize && fileSize >= 0 {
 		return c.putObjectSingle(bucketName, objectName, fileReader, fileSize, objMetadata, nil)
 	}
+
 	// Upload all large objects as multipart.
 	n, err = c.putObjectMultipartFromFile(bucketName, objectName, fileReader, fileSize, objMetadata, nil)
 	if err != nil {

--- a/api-put-object-progress.go
+++ b/api-put-object-progress.go
@@ -99,24 +99,6 @@ func (c Client) PutObjectWithMetadata(bucketName, objectName string, reader io.R
 		return c.putObjectNoChecksum(bucketName, objectName, reader, size, metaData, progress)
 	}
 
-	// NOTE: S3 doesn't allow anonymous multipart requests.
-	if s3utils.IsAmazonEndpoint(c.endpointURL) && c.anonymous {
-		if size <= -1 {
-			return 0, ErrorResponse{
-				Code:       "NotImplemented",
-				Message:    "Content-Length cannot be negative for anonymous requests.",
-				Key:        objectName,
-				BucketName: bucketName,
-			}
-		}
-		if size > maxSinglePutObjectSize {
-			return 0, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)
-		}
-		// Do not compute MD5 for anonymous requests to Amazon
-		// S3. Uploads up to 5GiB in size.
-		return c.putObjectNoChecksum(bucketName, objectName, reader, size, metaData, progress)
-	}
-
 	// putSmall object.
 	if size < minPartSize && size >= 0 {
 		return c.putObjectSingle(bucketName, objectName, reader, size, metaData, progress)

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -143,7 +143,6 @@ func (a completedParts) Less(i, j int) bool { return a[i].PartNumber < a[j].Part
 // NOTE: Google Cloud Storage does not implement Amazon S3 Compatible multipart PUT.
 // So we fall back to single PUT operation with the maximum limit of 5GiB.
 //
-// NOTE: For anonymous requests Amazon S3 doesn't allow multipart upload. So we fall back to single PUT operation.
 func (c Client) PutObject(bucketName, objectName string, reader io.Reader, contentType string) (n int64, err error) {
 	return c.PutObjectWithProgress(bucketName, objectName, reader, contentType, nil)
 }

--- a/api-remove.go
+++ b/api-remove.go
@@ -208,7 +208,6 @@ func (c Client) RemoveObjects(bucketName string, objectsCh <-chan string) <-chan
 }
 
 // RemoveIncompleteUpload aborts an partially uploaded object.
-// Requires explicit authentication, no anonymous requests are allowed for multipart API.
 func (c Client) RemoveIncompleteUpload(bucketName, objectName string) error {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {

--- a/api.go
+++ b/api.go
@@ -198,9 +198,6 @@ func privateNew(endpoint, accessKeyID, secretAccessKey string, secure bool) (*Cl
 	clnt := new(Client)
 	clnt.accessKeyID = accessKeyID
 	clnt.secretAccessKey = secretAccessKey
-	if clnt.accessKeyID == "" || clnt.secretAccessKey == "" {
-		clnt.anonymous = true
-	}
 
 	// Remember whether we are using https or not
 	clnt.secure = secure
@@ -316,8 +313,7 @@ var regSign = regexp.MustCompile("Signature=([[0-9a-f]+)")
 
 // Filter out signature value from Authorization header.
 func (c Client) filterSignature(req *http.Request) {
-	// For anonymous requests, no need to filter.
-	if c.anonymous {
+	if _, ok := req.Header["Authorization"]; !ok {
 		return
 	}
 	// Handle if Signature V2.
@@ -610,15 +606,18 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 		return nil, err
 	}
 
+	// Anonymous request.
+	anonymous := c.accessKeyID == "" || c.secretAccessKey == ""
+
 	// Generate presign url if needed, return right here.
 	if metadata.expires != 0 && metadata.presignURL {
-		if c.anonymous {
+		if anonymous {
 			return nil, ErrInvalidArgument("Requests cannot be presigned with anonymous credentials.")
 		}
 		if c.signature.isV2() {
 			// Presign URL with signature v2.
 			req = s3signer.PreSignV2(*req, c.accessKeyID, c.secretAccessKey, metadata.expires)
-		} else {
+		} else if c.signature.isV4() {
 			// Presign URL with signature v4.
 			req = s3signer.PreSignV4(*req, c.accessKeyID, c.secretAccessKey, location, metadata.expires)
 		}
@@ -638,37 +637,32 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 		req.ContentLength = metadata.contentLength
 	}
 
-	// Set sha256 sum only for non anonymous credentials.
-	if !c.anonymous {
-		// set sha256 sum for signature calculation only with
-		// signature version '4'.
-		if c.signature.isV4() {
-			shaHeader := unsignedPayload
-			if !c.secure {
-				if metadata.contentSHA256Bytes == nil {
-					shaHeader = hex.EncodeToString(sum256([]byte{}))
-				} else {
-					shaHeader = hex.EncodeToString(metadata.contentSHA256Bytes)
-				}
-			}
-			req.Header.Set("X-Amz-Content-Sha256", shaHeader)
-		}
-	}
-
 	// set md5Sum for content protection.
 	if metadata.contentMD5Bytes != nil {
 		req.Header.Set("Content-Md5", base64.StdEncoding.EncodeToString(metadata.contentMD5Bytes))
 	}
 
-	// Sign the request for all authenticated requests.
-	if !c.anonymous {
-		if c.signature.isV2() {
-			// Add signature version '2' authorization header.
-			req = s3signer.SignV2(*req, c.accessKeyID, c.secretAccessKey)
-		} else if c.signature.isV4() {
-			// Add signature version '4' authorization header.
-			req = s3signer.SignV4(*req, c.accessKeyID, c.secretAccessKey, location)
+	if anonymous {
+		return req, nil
+	} // Sign the request for all authenticated requests.
+
+	if c.signature.isV2() {
+		// Add signature version '2' authorization header.
+		req = s3signer.SignV2(*req, c.accessKeyID, c.secretAccessKey)
+	} else if c.signature.isV4() {
+		// Set sha256 sum for signature calculation only with signature version '4'.
+		shaHeader := unsignedPayload
+		if !c.secure {
+			if metadata.contentSHA256Bytes == nil {
+				shaHeader = hex.EncodeToString(sum256([]byte{}))
+			} else {
+				shaHeader = hex.EncodeToString(metadata.contentSHA256Bytes)
+			}
 		}
+		req.Header.Set("X-Amz-Content-Sha256", shaHeader)
+
+		// Add signature version '4' authorization header.
+		req = s3signer.SignV4(*req, c.accessKeyID, c.secretAccessKey, location)
 	}
 
 	// Return request.


### PR DESCRIPTION
Multipart APIs are supported for anonymous request with
right bucket policies, enable it such that we can fail
later and fall back to PutObject() if needed.