### PR TITLE
Example of suggested wording for ceph s3

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -101,7 +101,7 @@ __Parameters__
 | Param  | Type  | Description  |
 |---|---|---|
 |`bucketName`  | _string_  | Name of the bucket |
-| `location`  |  _string_ | Region where the bucket is to be created. Default value is us-east-1. Other valid values are listed below. Note: When used with minio server, use the region specified in its config file (defaults to us-east-1).|
+| `location`  |  _string_ | Region where the bucket is to be created. Default value is us-east-1. Other valid values are listed below. Note: When used with minio server, use the region specified in its config file (defaults to us-east-1).When used with ceph's s3 API, always use use-east-1|
 | | |us-east-1 |
 | | |us-west-1 |
 | | |us-west-2 |


### PR DESCRIPTION
I just raised this in slack, as ceph cyrrently assumes you will always use us-east-1, and v4 authentication fails loudly and unhelpfully if you select anything else.  We used to use ca-east-0, but when we switched to v4 authentication, it broke most _wonderfully_. (And I switched over to minio!)