### PR TITLE
Make some changes to PutObjectStreaming() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The full API Reference is available here.
 
 * [`GetObject`](https://docs.minio.io/docs/golang-client-api-reference#GetObject)
 * [`PutObject`](https://docs.minio.io/docs/golang-client-api-reference#PutObject)
+* [`PutObjectStreaming`](https://docs.minio.io/docs/golang-client-api-reference#PutObjectStreaming)
 * [`StatObject`](https://docs.minio.io/docs/golang-client-api-reference#StatObject)
 * [`CopyObject`](https://docs.minio.io/docs/golang-client-api-reference#CopyObject)
 * [`RemoveObject`](https://docs.minio.io/docs/golang-client-api-reference#RemoveObject)

--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -173,7 +173,7 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 	close(uploadPartsCh)
 
 	// Use three 'workers' to upload parts in parallel.
-	for w := 1; w <= 3; w++ {
+	for w := 1; w <= totalWorkers; w++ {
 		go func() {
 			// Deal with each part as it comes through the channel.
 			for uploadReq := range uploadPartsCh {

--- a/api-put-object-readat.go
+++ b/api-put-object-readat.go
@@ -115,7 +115,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 	close(uploadPartsCh)
 
 	// Receive each part number from the channel allowing three parallel uploads.
-	for w := 1; w <= 3; w++ {
+	for w := 1; w <= totalWorkers; w++ {
 		go func() {
 			// Read defaults to reading at 5MiB buffer.
 			readAtBuffer := make([]byte, optimalReadBufferSize)

--- a/api.go
+++ b/api.go
@@ -654,7 +654,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	if c.signature.isV2() {
 		// Add signature version '2' authorization header.
 		req = s3signer.SignV2(*req, c.accessKeyID, c.secretAccessKey)
-	} else if c.signature.isV4() || c.signature.isChunkedV4() &&
+	} else if c.signature.isV4() || c.signature.isStreamingV4() &&
 		method != "PUT" {
 		// Set sha256 sum for signature calculation only with signature version '4'.
 		shaHeader := unsignedPayload
@@ -669,9 +669,9 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 
 		// Add signature version '4' authorization header.
 		req = s3signer.SignV4(*req, c.accessKeyID, c.secretAccessKey, location)
-	} else if c.signature.isChunkedV4() {
-		req = s3signer.NewStreamingSignV4(req, c.accessKeyID,
-			c.secretAccessKey, c.region, metadata.contentLength, time.Now().UTC())
+	} else if c.signature.isStreamingV4() {
+		req = s3signer.StreamingSignV4(req, c.accessKeyID,
+			c.secretAccessKey, location, metadata.contentLength, time.Now().UTC())
 	}
 
 	// Return request.

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -375,6 +375,9 @@ func TestPutObjectStreaming(t *testing.T) {
 		t.Fatal("Error:", err)
 	}
 
+	// Enable tracing, write to stderr.
+	// c.TraceOn(os.Stderr)
+
 	// Set user agent.
 	c.SetAppInfo("Minio-go-FunctionalTest", "0.1.0")
 
@@ -393,7 +396,7 @@ func TestPutObjectStreaming(t *testing.T) {
 	objectName := "test-object"
 	for i, size := range sizes {
 		data := bytes.Repeat([]byte("a"), int(size))
-		n, err := c.PutObjectStreaming(bucketName, objectName, bytes.NewReader(data), size)
+		n, err := c.PutObjectStreaming(bucketName, objectName, bytes.NewReader(data))
 		if err != nil {
 			t.Fatalf("Test %d Error: %v %s %s", i+1, err, bucketName, objectName)
 		}

--- a/constants.go
+++ b/constants.go
@@ -45,6 +45,9 @@ const optimalReadBufferSize = 1024 * 1024 * 5
 // we don't want to sign the request payload
 const unsignedPayload = "UNSIGNED-PAYLOAD"
 
+// Total number of parallel workers used for multipart operation.
+var totalWorkers = 3
+
 // Signature related constants.
 const (
 	signV4Algorithm   = "AWS4-HMAC-SHA256"

--- a/docs/API.md
+++ b/docs/API.md
@@ -470,8 +470,8 @@ if err != nil {
 }
 ```
 
-<a name="PutObject"></a>
-### PutObjectStreaming(bucketName, objectName string, reader io.Reader, size int64) (n int, err error)
+<a name="PutObjectStreaming"></a>
+### PutObjectStreaming(bucketName, objectName string, reader io.Reader) (n int, err error)
 
 Uploads an object as multiple chunks keeping memory consumption constant. It is similar to PutObject in how objects are broken into multiple parts. Each part in turn is transferred as multiple chunks with constant memory usage. However resuming previously failed uploads from where it was left is not supported.
 
@@ -484,8 +484,6 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket  |
 |`objectName` | _string_  |Name of the object   |
 |`reader` | _io.Reader_  |Any Go type that implements io.Reader |
-|`size` | _int64_ |Size of the object |
-
 
 __Example__
 
@@ -498,13 +496,7 @@ if err != nil {
 }
 defer file.Close()
 
-st, err := os.Stat()
-if err != nil {
-    fmt.Println(err)
-    return
-}
-
-n, err := minioClient.PutObjectStreaming("mybucket", "myobject", file, st.Size())
+n, err := minioClient.PutObjectStreaming("mybucket", "myobject", file)
 if err != nil {
     fmt.Println(err)
     return

--- a/examples/s3/putobject-streaming.go
+++ b/examples/s3/putobject-streaming.go
@@ -45,7 +45,7 @@ func main() {
 	}
 	defer object.Close()
 
-	n, err := s3Client.PutObjectStreaming("my-bucketname", "my-objectname", object, size)
+	n, err := s3Client.PutObjectStreaming("my-bucketname", "my-objectname", object)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -99,15 +99,8 @@ func prepareStreamingRequest(req *http.Request, dataLen int64, timestamp time.Ti
 	req.Header.Set("X-Amz-Date", timestamp.Format(iso8601DateFormat))
 
 	// Set content length with streaming signature for each chunk included.
-	streamContentLen := getStreamLength(dataLen, int64(payloadChunkSize))
+	req.ContentLength = getStreamLength(dataLen, int64(payloadChunkSize))
 	req.Header.Set("x-amz-decoded-content-length", strconv.FormatInt(dataLen, 10))
-	if streamContentLen > 0 {
-		req.Header.Set("Content-Length", strconv.FormatInt(streamContentLen, 10))
-		req.ContentLength = streamContentLen
-	} else {
-		req.Header.Set("Content-Length", "-1")
-		req.ContentLength = -1
-	}
 }
 
 // buildChunkHeader - returns the chunk header.
@@ -200,9 +193,9 @@ func (s *StreamingReader) setStreamingAuthHeader(req *http.Request) {
 	req.Header.Set("Authorization", auth)
 }
 
-// NewStreamingSignV4 - provides chunked upload signatureV4 support by
+// StreamingSignV4 - provides chunked upload signatureV4 support by
 // implementing io.Reader.
-func NewStreamingSignV4(req *http.Request, accessKeyID, secretAccessKey,
+func StreamingSignV4(req *http.Request, accessKeyID, secretAccessKey,
 	region string, dataLen int64, reqTime time.Time) *http.Request {
 
 	// Set headers needed for streaming signature.

--- a/signature-type.go
+++ b/signature-type.go
@@ -24,7 +24,7 @@ const (
 	Latest SignatureType = iota
 	SignatureV4
 	SignatureV2
-	ChunkedV4
+	SignatureV4Streaming
 )
 
 // isV2 - is signature SignatureV2?
@@ -37,6 +37,7 @@ func (s SignatureType) isV4() bool {
 	return s == SignatureV4 || s == Latest
 }
 
-func (s SignatureType) isChunkedV4() bool {
-	return s == ChunkedV4
+// isStreamingV4 - is signature SignatureV4Streaming?
+func (s SignatureType) isStreamingV4() bool {
+	return s == SignatureV4Streaming
 }


### PR DESCRIPTION
- Detect size automatically like other PutObject() operations.
- Allow progress bar to be passed into PutObjectStreaming().
- Allow also metadata to be passed into PutObjectStreaming().
- Rename NewStreamingV4 to just StreamingV4(). Keeping it
  consistent with other signature methods.