### PR TITLE
core: Implement native GetBucketPolicy, PutBucketPolicy

### DIFF
--- a/api-get-policy.go
+++ b/api-get-policy.go
@@ -34,7 +34,7 @@ func (c Client) GetBucketPolicy(bucketName, objectPrefix string) (bucketPolicy p
 	if err := isValidObjectPrefix(objectPrefix); err != nil {
 		return policy.BucketPolicyNone, err
 	}
-	policyInfo, err := c.getBucketPolicy(bucketName, objectPrefix)
+	policyInfo, err := c.getBucketPolicy(bucketName)
 	if err != nil {
 		return policy.BucketPolicyNone, err
 	}
@@ -50,7 +50,7 @@ func (c Client) ListBucketPolicies(bucketName, objectPrefix string) (bucketPolic
 	if err := isValidObjectPrefix(objectPrefix); err != nil {
 		return map[string]policy.BucketPolicy{}, err
 	}
-	policyInfo, err := c.getBucketPolicy(bucketName, objectPrefix)
+	policyInfo, err := c.getBucketPolicy(bucketName)
 	if err != nil {
 		return map[string]policy.BucketPolicy{}, err
 	}
@@ -58,7 +58,7 @@ func (c Client) ListBucketPolicies(bucketName, objectPrefix string) (bucketPolic
 }
 
 // Request server for current bucket policy.
-func (c Client) getBucketPolicy(bucketName string, objectPrefix string) (policy.BucketAccessPolicy, error) {
+func (c Client) getBucketPolicy(bucketName string) (policy.BucketAccessPolicy, error) {
 	// Get resources properly escaped and lined up before
 	// using them in http request.
 	urlValues := make(url.Values)

--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -157,10 +157,12 @@ func (c Client) SetBucketPolicy(bucketName string, objectPrefix string, bucketPo
 	if err := isValidObjectPrefix(objectPrefix); err != nil {
 		return err
 	}
+
 	if !bucketPolicy.IsValidBucketPolicy() {
 		return ErrInvalidArgument(fmt.Sprintf("Invalid bucket policy provided. %s", bucketPolicy))
 	}
-	policyInfo, err := c.getBucketPolicy(bucketName, objectPrefix)
+
+	policyInfo, err := c.getBucketPolicy(bucketName)
 	if err != nil {
 		return err
 	}

--- a/core.go
+++ b/core.go
@@ -16,7 +16,11 @@
 
 package minio
 
-import "io"
+import (
+	"io"
+
+	"github.com/minio/minio-go/pkg/policy"
+)
 
 // Core - Inherits Client and adds new methods to expose the low level S3 APIs.
 type Core struct {
@@ -83,4 +87,14 @@ func (c Core) CompleteMultipartUpload(bucket, object, uploadID string, parts []C
 // AbortMultipartUpload - Abort an incomplete upload.
 func (c Core) AbortMultipartUpload(bucket, object, uploadID string) error {
 	return c.abortMultipartUpload(bucket, object, uploadID)
+}
+
+// GetBucketPolicy - fetches bucket access policy for a given bucket.
+func (c Core) GetBucketPolicy(bucket string) (policy.BucketAccessPolicy, error) {
+	return c.getBucketPolicy(bucket)
+}
+
+// PutBucketPolicy - applies a new bucket access policy for a given bucket.
+func (c Core) PutBucketPolicy(bucket string, bucketPolicy policy.BucketAccessPolicy) error {
+	return c.putBucketPolicy(bucket, bucketPolicy)
 }


### PR DESCRIPTION
This is implemented to address the problems of applications
wanting to validate the entire bucket policy in a custom
manner.

Fixes #659

Refer https://github.com/minio/minio/issues/4131