### PR TITLE
Use UNSIGNED-PAYLOAD if sha256 is not calculated

### DIFF
--- a/api.go
+++ b/api.go
@@ -659,9 +659,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 		// Set sha256 sum for signature calculation only with signature version '4'.
 		shaHeader := unsignedPayload
 		if !c.secure {
-			if metadata.contentSHA256Bytes == nil {
-				shaHeader = hex.EncodeToString(sum256([]byte{}))
-			} else {
+			if len(metadata.contentSHA256Bytes) > 0 {
 				shaHeader = hex.EncodeToString(metadata.contentSHA256Bytes)
 			}
 		}


### PR DESCRIPTION
The issue was found when testing S3 gateway. In gateway setup, if client does
presignedPUT the sha256 value is not valid in which case we should use
UNSIGNED-PAYLOAD instead of calculating sha256sum() on empty byte array