### PR TITLE
Validate minio.Object ETag between read requests

### DIFF
--- a/api-error-response.go
+++ b/api-error-response.go
@@ -134,6 +134,13 @@ func httpRespToErrorResponse(resp *http.Response, bucketName, objectName string)
 				Message:    "Bucket not empty.",
 				BucketName: bucketName,
 			}
+		case http.StatusPreconditionFailed:
+			errResp = ErrorResponse{
+				Code:       "PreconditionFailed",
+				Message:    s3ErrorResponseMap["PreconditionFailed"],
+				BucketName: bucketName,
+				Key:        objectName,
+			}
 		default:
 			errResp = ErrorResponse{
 				Code:       resp.Status,


### PR DESCRIPTION
On each new request, we compare `minio.Object`'s cached ETag with the current response ETag to error out if the object has changed since the last read.

Fixes #656 