### PR TITLE
Use UNSIGNED-PAYLOAD if sha256 is not calculated

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -616,9 +616,10 @@ func (c Client) getObject(bucketName, objectName string, offset, length int64) (
 
 	// Execute GET on objectName.
 	resp, err := c.executeMethod("GET", requestMetadata{
-		bucketName:   bucketName,
-		objectName:   objectName,
-		customHeader: customHeader,
+		bucketName:         bucketName,
+		objectName:         objectName,
+		customHeader:       customHeader,
+		contentSHA256Bytes: emptySHA256,
 	})
 	if err != nil {
 		return nil, ObjectInfo{}, err

--- a/api-get-policy.go
+++ b/api-get-policy.go
@@ -79,8 +79,9 @@ func (c Client) getBucketPolicy(bucketName string) (policy.BucketAccessPolicy, e
 
 	// Execute GET on bucket to list objects.
 	resp, err := c.executeMethod("GET", requestMetadata{
-		bucketName:  bucketName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 
 	defer closeResponse(resp)

--- a/api-list.go
+++ b/api-list.go
@@ -35,7 +35,7 @@ import (
 //
 func (c Client) ListBuckets() ([]BucketInfo, error) {
 	// Execute GET on service.
-	resp, err := c.executeMethod("GET", requestMetadata{})
+	resp, err := c.executeMethod("GET", requestMetadata{contentSHA256Bytes: emptySHA256})
 	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
@@ -211,8 +211,9 @@ func (c Client) listObjectsV2Query(bucketName, objectPrefix, continuationToken s
 
 	// Execute GET on bucket to list objects.
 	resp, err := c.executeMethod("GET", requestMetadata{
-		bucketName:  bucketName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {
@@ -381,8 +382,9 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 
 	// Execute GET on bucket to list objects.
 	resp, err := c.executeMethod("GET", requestMetadata{
-		bucketName:  bucketName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {
@@ -559,8 +561,9 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 
 	// Execute GET on bucketName to list multipart uploads.
 	resp, err := c.executeMethod("GET", requestMetadata{
-		bucketName:  bucketName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {
@@ -676,9 +679,10 @@ func (c Client) listObjectPartsQuery(bucketName, objectName, uploadID string, pa
 
 	// Execute GET on objectName to get list of parts.
 	resp, err := c.executeMethod("GET", requestMetadata{
-		bucketName:  bucketName,
-		objectName:  objectName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		objectName:         objectName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {

--- a/api-notification.go
+++ b/api-notification.go
@@ -47,8 +47,9 @@ func (c Client) getBucketNotification(bucketName string) (BucketNotification, er
 
 	// Execute GET on bucket to list objects.
 	resp, err := c.executeMethod("GET", requestMetadata{
-		bucketName:  bucketName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 
 	defer closeResponse(resp)
@@ -170,8 +171,9 @@ func (c Client) ListenBucketNotification(bucketName, prefix, suffix string, even
 
 			// Execute GET on bucket to list objects.
 			resp, err := c.executeMethod("GET", requestMetadata{
-				bucketName:  bucketName,
-				queryValues: urlValues,
+				bucketName:         bucketName,
+				queryValues:        urlValues,
+				contentSHA256Bytes: emptySHA256,
 			})
 			if err != nil {
 				continue

--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -272,8 +272,9 @@ func (c Client) removeBucketPolicy(bucketName string) error {
 
 	// Execute DELETE on objectName.
 	resp, err := c.executeMethod("DELETE", requestMetadata{
-		bucketName:  bucketName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {

--- a/api-remove.go
+++ b/api-remove.go
@@ -35,7 +35,8 @@ func (c Client) RemoveBucket(bucketName string) error {
 	}
 	// Execute DELETE on bucket.
 	resp, err := c.executeMethod("DELETE", requestMetadata{
-		bucketName: bucketName,
+		bucketName:         bucketName,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {
@@ -64,8 +65,9 @@ func (c Client) RemoveObject(bucketName, objectName string) error {
 	}
 	// Execute DELETE on objectName.
 	resp, err := c.executeMethod("DELETE", requestMetadata{
-		bucketName: bucketName,
-		objectName: objectName,
+		bucketName:         bucketName,
+		objectName:         objectName,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {
@@ -248,9 +250,10 @@ func (c Client) abortMultipartUpload(bucketName, objectName, uploadID string) er
 
 	// Execute DELETE on multipart upload.
 	resp, err := c.executeMethod("DELETE", requestMetadata{
-		bucketName:  bucketName,
-		objectName:  objectName,
-		queryValues: urlValues,
+		bucketName:         bucketName,
+		objectName:         objectName,
+		queryValues:        urlValues,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {

--- a/api-stat.go
+++ b/api-stat.go
@@ -34,7 +34,8 @@ func (c Client) BucketExists(bucketName string) (bool, error) {
 
 	// Execute HEAD on bucketName.
 	resp, err := c.executeMethod("HEAD", requestMetadata{
-		bucketName: bucketName,
+		bucketName:         bucketName,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {
@@ -88,8 +89,9 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 
 	// Execute HEAD on objectName.
 	resp, err := c.executeMethod("HEAD", requestMetadata{
-		bucketName: bucketName,
-		objectName: objectName,
+		bucketName:         bucketName,
+		objectName:         objectName,
+		contentSHA256Bytes: emptySHA256,
 	})
 	defer closeResponse(resp)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -661,12 +661,8 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	case c.signature.isV4():
 		// Set sha256 sum for signature calculation only with signature version '4'.
 		shaHeader := unsignedPayload
-		if !c.secure {
-			if metadata.contentSHA256Bytes == nil {
-				shaHeader = hex.EncodeToString(sum256([]byte{}))
-			} else {
-				shaHeader = hex.EncodeToString(metadata.contentSHA256Bytes)
-			}
+		if len(metadata.contentSHA256Bytes) > 0 {
+			shaHeader = hex.EncodeToString(metadata.contentSHA256Bytes)
 		}
 		req.Header.Set("X-Amz-Content-Sha256", shaHeader)
 

--- a/api.go
+++ b/api.go
@@ -654,11 +654,11 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 		return req, nil
 	} // Sign the request for all authenticated requests.
 
-	if c.signature.isV2() {
+	switch {
+	case c.signature.isV2():
 		// Add signature version '2' authorization header.
 		req = s3signer.SignV2(*req, c.accessKeyID, c.secretAccessKey)
-	} else if c.signature.isV4() || c.signature.isStreamingV4() &&
-		method != "PUT" {
+	case c.signature.isV4():
 		// Set sha256 sum for signature calculation only with signature version '4'.
 		shaHeader := unsignedPayload
 		if !c.secure {
@@ -672,7 +672,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 
 		// Add signature version '4' authorization header.
 		req = s3signer.SignV4(*req, c.accessKeyID, c.secretAccessKey, location)
-	} else if c.signature.isStreamingV4() {
+	case c.signature.isStreamingV4():
 		req = s3signer.StreamingSignV4(req, c.accessKeyID,
 			c.secretAccessKey, location, metadata.contentLength, time.Now().UTC())
 	}

--- a/core_test.go
+++ b/core_test.go
@@ -134,7 +134,7 @@ func TestCorePutObject(t *testing.T) {
 		t.Fatal("Error:", err)
 	}
 	if size != minPartSize {
-		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", minPartSize*4, size)
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", minPartSize, size)
 	}
 
 	// Save the data
@@ -173,16 +173,20 @@ func TestCorePutObject(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
+
 	if st.Size != int64(len(buf)) {
 		t.Fatalf("Error: number of bytes in stat does not match, want %v, got %v\n",
 			len(buf), st.Size)
 	}
+
 	if st.ContentType != objectContentType {
 		t.Fatalf("Error: Content types don't match, expected: %+v, found: %+v\n", objectContentType, st.ContentType)
 	}
+
 	if err := r.Close(); err != nil {
 		t.Fatal("Error:", err)
 	}
+
 	if err := r.Close(); err == nil {
 		t.Fatal("Error: object is already closed, should return error")
 	}
@@ -191,6 +195,7 @@ func TestCorePutObject(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
+
 	err = c.RemoveBucket(bucketName)
 	if err != nil {
 		t.Fatal("Error:", err)

--- a/core_test.go
+++ b/core_test.go
@@ -17,6 +17,11 @@
 package minio
 
 import (
+	"bytes"
+	"crypto/md5"
+	crand "crypto/rand"
+
+	"io"
 	"math/rand"
 	"os"
 	"reflect"
@@ -81,6 +86,111 @@ func TestGetBucketPolicy(t *testing.T) {
 		t.Errorf("Bucket policy expected %#v, got %#v", emptyBucketAccessPolicy, bucketPolicy)
 	}
 
+	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+}
+
+// Test Core PutObject.
+func TestCorePutObject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping functional tests for short runs")
+	}
+
+	// Seed random based on current time.
+	rand.Seed(time.Now().Unix())
+
+	// Instantiate new minio client object.
+	c, err := NewCore(
+		os.Getenv("S3_ADDRESS"),
+		os.Getenv("ACCESS_KEY"),
+		os.Getenv("SECRET_KEY"),
+		mustParseBool(os.Getenv("S3_SECURE")),
+	)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	// Enable tracing, write to stderr.
+	// c.TraceOn(os.Stderr)
+
+	// Set user agent.
+	c.SetAppInfo("Minio-go-FunctionalTest", "0.1.0")
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()), "minio-go-test")
+
+	// Make a new bucket.
+	err = c.MakeBucket(bucketName, "us-east-1")
+	if err != nil {
+		t.Fatal("Error:", err, bucketName)
+	}
+
+	buf := make([]byte, minPartSize)
+
+	size, err := io.ReadFull(crand.Reader, buf)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+	if size != minPartSize {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", minPartSize*4, size)
+	}
+
+	// Save the data
+	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
+	// Object content type
+	objectContentType := "binary/octet-stream"
+	metadata := make(map[string][]string)
+	metadata["Content-Type"] = []string{objectContentType}
+
+	objInfo, err := c.PutObject(bucketName, objectName, int64(len(buf)), bytes.NewReader(buf), md5.New().Sum(nil), nil, metadata)
+	if err == nil {
+		t.Fatal("Error expected: nil, got: ", err)
+	}
+
+	objInfo, err = c.PutObject(bucketName, objectName, int64(len(buf)), bytes.NewReader(buf), nil, sum256(nil), metadata)
+	if err == nil {
+		t.Fatal("Error expected: nil, got: ", err)
+	}
+
+	objInfo, err = c.PutObject(bucketName, objectName, int64(len(buf)), bytes.NewReader(buf), nil, nil, metadata)
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName)
+	}
+
+	if objInfo.Size != int64(len(buf)) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), objInfo.Size)
+	}
+
+	// Read the data back
+	r, err := c.GetObject(bucketName, objectName)
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName)
+	}
+
+	st, err := r.Stat()
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName)
+	}
+	if st.Size != int64(len(buf)) {
+		t.Fatalf("Error: number of bytes in stat does not match, want %v, got %v\n",
+			len(buf), st.Size)
+	}
+	if st.ContentType != objectContentType {
+		t.Fatalf("Error: Content types don't match, expected: %+v, found: %+v\n", objectContentType, st.ContentType)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal("Error:", err)
+	}
+	if err := r.Close(); err == nil {
+		t.Fatal("Error: object is already closed, should return error")
+	}
+
+	err = c.RemoveObject(bucketName, objectName)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
 	err = c.RemoveBucket(bucketName)
 	if err != nil {
 		t.Fatal("Error:", err)

--- a/signature-type.go
+++ b/signature-type.go
@@ -27,7 +27,7 @@ const (
 	SignatureV4Streaming
 )
 
-var emptySHA256 = sum256([]byte{})
+var emptySHA256 = sum256(nil)
 
 // isV2 - is signature SignatureV2?
 func (s SignatureType) isV2() bool {

--- a/signature-type.go
+++ b/signature-type.go
@@ -27,6 +27,8 @@ const (
 	SignatureV4Streaming
 )
 
+var emptySHA256 = sum256([]byte{})
+
 // isV2 - is signature SignatureV2?
 func (s SignatureType) isV2() bool {
 	return s == SignatureV2


### PR DESCRIPTION
The issue was found when testing S3 gateway. In gateway setup, if client does
presignedPUT the sha256 value is not valid in which case we should use
UNSIGNED-PAYLOAD instead of calculating sha256sum() on empty byte array

Reference: https://github.com/minio/minio-go/pull/661

Tested api_functional_v4_test.go on localhost:9000 minio
Tested with `mc --debug` on aws-s3
