### PR TITLE
api, core: Add new Core API {Get,Stat}Object with pre-conditions.

### DIFF
--- a/api-get-object-file.go
+++ b/api-get-object-file.go
@@ -78,8 +78,13 @@ func (c Client) FGetObject(bucketName, objectName, filePath string) error {
 		return err
 	}
 
+	// Initialize get object request headers to set the
+	// appropriate range offsets to read from.
+	reqHeaders := NewGetReqHeaders()
+	reqHeaders.SetRange(st.Size(), 0)
+
 	// Seek to current position for incoming reader.
-	objectReader, objectStat, err := c.getObject(bucketName, objectName, st.Size(), 0)
+	objectReader, objectStat, err := c.getObject(bucketName, objectName, reqHeaders)
 	if err != nil {
 		return err
 	}

--- a/api-stat.go
+++ b/api-stat.go
@@ -86,12 +86,31 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 	if err := isValidObjectName(objectName); err != nil {
 		return ObjectInfo{}, err
 	}
+	reqHeaders := NewHeadReqHeaders()
+	return c.statObject(bucketName, objectName, reqHeaders)
+}
+
+// Lower level API for statObject supporting pre-conditions and range headers.
+func (c Client) statObject(bucketName, objectName string, reqHeaders RequestHeaders) (ObjectInfo, error) {
+	// Input validation.
+	if err := isValidBucketName(bucketName); err != nil {
+		return ObjectInfo{}, err
+	}
+	if err := isValidObjectName(objectName); err != nil {
+		return ObjectInfo{}, err
+	}
+
+	customHeader := make(http.Header)
+	for k, v := range reqHeaders.Header {
+		customHeader[k] = v
+	}
 
 	// Execute HEAD on objectName.
 	resp, err := c.executeMethod("HEAD", requestMetadata{
 		bucketName:         bucketName,
 		objectName:         objectName,
 		contentSHA256Bytes: emptySHA256,
+		customHeader:       customHeader,
 	})
 	defer closeResponse(resp)
 	if err != nil {
@@ -124,6 +143,7 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 			}
 		}
 	}
+
 	// Parse Last-Modified has http time format.
 	date, err := time.Parse(http.TimeFormat, resp.Header.Get("Last-Modified"))
 	if err != nil {
@@ -137,6 +157,7 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 			Region:     resp.Header.Get("x-amz-bucket-region"),
 		}
 	}
+
 	// Fetch content type if any present.
 	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
 	if contentType == "" {

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -310,7 +310,7 @@ func TestPutObjectWithMetadata(t *testing.T) {
 	// Object custom metadata
 	customContentType := "custom/contenttype"
 
-	n, err := c.PutObjectWithMetadata(bucketName, objectName, bytes.NewReader(buf), map[string][]string{"Content-Type": []string{customContentType}}, nil)
+	n, err := c.PutObjectWithMetadata(bucketName, objectName, bytes.NewReader(buf), map[string][]string{"Content-Type": {customContentType}}, nil)
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
@@ -1972,7 +1972,7 @@ func TestEncryptionPutGet(t *testing.T) {
 		}
 
 		// Put encrypted data
-		_, err = c.PutEncryptedObject(bucketName, objectName, bytes.NewReader(testCase.buf), cbcMaterials, map[string][]string{"Content-Type": []string{customContentType}}, nil)
+		_, err = c.PutEncryptedObject(bucketName, objectName, bytes.NewReader(testCase.buf), cbcMaterials, map[string][]string{"Content-Type": {customContentType}}, nil)
 		if err != nil {
 			t.Fatalf("Test %d, error: %v %v %v", i+1, err, bucketName, objectName)
 		}

--- a/core.go
+++ b/core.go
@@ -98,3 +98,16 @@ func (c Core) GetBucketPolicy(bucket string) (policy.BucketAccessPolicy, error) 
 func (c Core) PutBucketPolicy(bucket string, bucketPolicy policy.BucketAccessPolicy) error {
 	return c.putBucketPolicy(bucket, bucketPolicy)
 }
+
+// GetObject is a lower level API implemented to support reading
+// partial objects and also downloading objects with special conditions
+// matching etag, modtime etc.
+func (c Core) GetObject(bucketName, objectName string, reqHeaders RequestHeaders) (io.ReadCloser, ObjectInfo, error) {
+	return c.getObject(bucketName, objectName, reqHeaders)
+}
+
+// StatObject is a lower level API implemented to support special
+// conditions matching etag, modtime on a request.
+func (c Core) StatObject(bucketName, objectName string, reqHeaders RequestHeaders) (ObjectInfo, error) {
+	return c.statObject(bucketName, objectName, reqHeaders)
+}

--- a/pkg/policy/bucket-policy.go
+++ b/pkg/policy/bucket-policy.go
@@ -583,7 +583,7 @@ func GetPolicies(statements []Statement, bucketName string) map[string]BucketPol
 			r = r[:len(r)-1]
 			asterisk = "*"
 		}
-		objectPath := r[len(awsResourcePrefix+bucketName)+1 : len(r)]
+		objectPath := r[len(awsResourcePrefix+bucketName)+1:]
 		p := GetPolicy(statements, bucketName, objectPath)
 		policyRules[bucketName+"/"+objectPath+asterisk] = p
 	}

--- a/request-headers.go
+++ b/request-headers.go
@@ -1,0 +1,105 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// RequestHeaders - implement methods for setting special
+// request headers for GET, HEAD object operations.
+// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
+type RequestHeaders struct {
+	http.Header
+}
+
+// NewGetReqHeaders - initializes a new request headers for GET request.
+func NewGetReqHeaders() RequestHeaders {
+	return RequestHeaders{
+		Header: make(http.Header),
+	}
+}
+
+// NewHeadReqHeaders - initializes a new request headers for HEAD request.
+func NewHeadReqHeaders() RequestHeaders {
+	return RequestHeaders{
+		Header: make(http.Header),
+	}
+}
+
+// SetMatchETag - set match etag.
+func (c RequestHeaders) SetMatchETag(etag string) error {
+	if etag == "" {
+		return ErrInvalidArgument("ETag cannot be empty.")
+	}
+	c.Set("If-Match", etag)
+	return nil
+}
+
+// SetMatchETagExcept - set match etag except.
+func (c RequestHeaders) SetMatchETagExcept(etag string) error {
+	if etag == "" {
+		return ErrInvalidArgument("ETag cannot be empty.")
+	}
+	c.Set("If-None-Match", etag)
+	return nil
+}
+
+// SetUnmodified - set unmodified time since.
+func (c RequestHeaders) SetUnmodified(modTime time.Time) error {
+	if modTime.IsZero() {
+		return ErrInvalidArgument("Modified since cannot be empty.")
+	}
+	c.Set("If-Unmodified-Since", modTime.Format(http.TimeFormat))
+	return nil
+}
+
+// SetModified - set modified time since.
+func (c RequestHeaders) SetModified(modTime time.Time) error {
+	if modTime.IsZero() {
+		return ErrInvalidArgument("Modified since cannot be empty.")
+	}
+	c.Set("If-Modified-Since", modTime.Format(http.TimeFormat))
+	return nil
+}
+
+// SetRange - set the start and end offset of the object to be read.
+// See https://tools.ietf.org/html/rfc7233#section-3.1 for reference.
+func (c RequestHeaders) SetRange(start, end int64) error {
+	switch {
+	case start <= 0 && end < 0:
+		// Read everything until the 'end'. `bytes=-N`
+		c.Set("Range", fmt.Sprintf("bytes=%d", end))
+	case start > 0 && end == 0:
+		// Read everything starting from offset 'start'. `bytes=N-`
+		c.Set("Range", fmt.Sprintf("bytes=%d-", start))
+	case start > 0 && end > 0 && end >= start:
+		// Read everything starting at 'start' till the 'end'. `bytes=N-M`
+		c.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+	case start == 0 && end == 0:
+		// Client attempting to read the whole file.
+		return nil
+	}
+	// All other cases such as
+	// bytes=-N-
+	// bytes=N-M where M < N
+	// These return error and are not supported.
+	return ErrInvalidArgument(fmt.Sprintf("Invalid range start and end specified bytes=%d-%d",
+		start, end))
+}


### PR DESCRIPTION
Implements a new API to provide a way to set headers
for GetObject(), StatObject() request such as to

 - read partial data starting at offsets.
 - read only if etag matches.
 - read only if modtime matches.
 - read only if etag doesn't match.
 - read only if modtime doesn't match.

Fixes #669