### PR TITLE
Adding a timeout setter for minio http.Client

### DIFF
--- a/api.go
+++ b/api.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"errors"
 
 	"github.com/minio/minio-go/pkg/s3signer"
 	"github.com/minio/minio-go/pkg/s3utils"
@@ -185,6 +186,16 @@ func redirectHeaders(req *http.Request, via []*http.Request) error {
 	for key, val := range via[0].Header {
 		req.Header[key] = val
 	}
+	return nil
+}
+
+// SetClientTimeout set the timeout for the http.Client used the used by minio,
+// timeout duration < 0 is not allowed.
+func SetClientTimeout(client *Client, timeout time.Duration) error {
+	if timeout < 0 {
+		return errors.New("HTTP timeout cannot be negative")
+	}
+	client.httpClient.Timeout = timeout
 	return nil
 }
 


### PR DESCRIPTION
Hello :)

First, thanks for this useful project !

For my project integration, I have the need to set a specific timeout when retrieving a S3 object.
It seems that there's not currently setter for underneath http.Client used by minio.

This public func should allow external code to set this timeout :).

Thanks for this review.
