### PR TITLE
api/encrypt: Get() on encrypted object should be a readCloser

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -28,9 +28,9 @@ import (
 	"github.com/minio/minio-go/pkg/encrypt"
 )
 
-// GetEncryptedObject deciphers and streams data stored in the server after applying a specifed encryption materiels
-func (c Client) GetEncryptedObject(bucketName, objectName string, encryptMaterials encrypt.Materials) (io.Reader, error) {
-
+// GetEncryptedObject deciphers and streams data stored in the server after applying a specifed encryption materials,
+// returned stream should be closed by the caller.
+func (c Client) GetEncryptedObject(bucketName, objectName string, encryptMaterials encrypt.Materials) (io.ReadCloser, error) {
 	if encryptMaterials == nil {
 		return nil, ErrInvalidArgument("Unable to recognize empty encryption properties")
 	}

--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -1962,6 +1962,7 @@ func TestEncryptionPutGet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test %d, error: %v %v %v", i+1, err, bucketName, objectName)
 		}
+		defer r.Close()
 
 		// Compare the sent object with the received one
 		recvBuffer := bytes.NewBuffer([]byte{})

--- a/docs/API.md
+++ b/docs/API.md
@@ -771,7 +771,7 @@ if err != nil {
 ```
 
 <a name="GetEncryptedObject"></a>
-### GetEncryptedObject(bucketName, objectName string, encryptMaterials minio.EncryptionMaterials) (io.Reader, error)
+### GetEncryptedObject(bucketName, objectName string, encryptMaterials minio.EncryptionMaterials) (io.ReadCloser, error)
 
 Returns the decrypted stream of the object data based of the given encryption materiels. Most of the common errors occur when reading the stream.
 
@@ -788,7 +788,7 @@ __Return Value__
 
 |Param   |Type   |Description   |
 |:---|:---| :---|
-|`stream`  | _io.Reader_ | Returns the deciphered object reader. |
+|`stream`  | _io.ReadCloser_ | Returns the deciphered object reader, caller should close after reading. |
 |`err`  | _error | Returns errors. |
 
 
@@ -810,11 +810,14 @@ if err != nil {
     fmt.Println(err)
     return
 }
+defer object.Close()
+
 localFile, err := os.Create("/tmp/local-file.jpg")
 if err != nil {
     fmt.Println(err)
     return
 }
+
 if _, err = io.Copy(localFile, object); err != nil {
     fmt.Println(err)
     return

--- a/examples/s3/get-encrypted-object.go
+++ b/examples/s3/get-encrypted-object.go
@@ -72,6 +72,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	defer reader.Close()
 
 	// Local file which holds plain data
 	localFile, err := os.Create("my-testfile")

--- a/pkg/encrypt/cbc.go
+++ b/pkg/encrypt/cbc.go
@@ -89,6 +89,15 @@ func NewCBCSecureMaterials(key Key) (*CBCSecureMaterials, error) {
 
 }
 
+// Close implements closes the internal stream.
+func (s *CBCSecureMaterials) Close() error {
+	closer, ok := s.stream.(io.Closer)
+	if ok {
+		return closer.Close()
+	}
+	return nil
+}
+
 // SetupEncryptMode - tells CBC that we are going to encrypt data
 func (s *CBCSecureMaterials) SetupEncryptMode(stream io.Reader) error {
 	// Set mode to encrypt

--- a/pkg/encrypt/interface.go
+++ b/pkg/encrypt/interface.go
@@ -25,6 +25,9 @@ import "io"
 // Materials - provides generic interface to encrypt any stream of data.
 type Materials interface {
 
+	// Closes the wrapped stream properly, initiated by the caller.
+	Close() error
+
 	// Returns encrypted/decrypted data, io.Reader compatible.
 	Read(b []byte) (int, error)
 


### PR DESCRIPTION
We should implement `io.Closer` for the encryption materials
to close the underlying reader whenever a caller requests.

GetEncryptedObject() should have returned `io.ReadCloser`
in the first place.