### PR TITLE
api: Always strip 80/443 port from host

### DIFF
--- a/api.go
+++ b/api.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -733,6 +734,15 @@ func (c Client) makeTargetURL(bucketName, objectName, bucketLocation string, que
 
 	// Save scheme.
 	scheme := c.endpointURL.Scheme
+
+	// Strip port 80 and 443 so we won't send these ports in Host header.
+	// The reason is that browsers and curl automatically remove :80 and :443
+	// with the generated presigned urls, then a signature mismatch error.
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		if scheme == "http" && p == "80" || scheme == "https" && p == "443" {
+			host = h
+		}
+	}
 
 	urlStr := scheme + "://" + host + "/"
 	// Make URL only if bucketName is available, otherwise use the


### PR DESCRIPTION
HTTP clients like browsers or curl automatically strip port 80 and 443
in Host header. This PR makes minio-go follow the same behavior
so the generated presigned urls can work without having signature
mismatch error.

Fixes #695 