### PR TITLE
Strip leading and trailing quotes for etag in object listing

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -231,6 +231,13 @@ func (c Client) listObjectsV2Query(bucketName, objectPrefix, continuationToken s
 	if err != nil {
 		return listBucketResult, err
 	}
+	for i, content := range listBucketResult.Contents {
+		etag := content.ETag
+		// Trim off the odd double quotes from ETag in the beginning and end.
+		etag = strings.TrimPrefix(etag, `"`)
+		etag = strings.TrimSuffix(etag, `"`)
+		listBucketResult.Contents[i].ETag = etag
+	}
 	return listBucketResult, nil
 }
 
@@ -400,6 +407,13 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 	err = xmlDecoder(resp.Body, &listBucketResult)
 	if err != nil {
 		return listBucketResult, err
+	}
+	for i, content := range listBucketResult.Contents {
+		etag := content.ETag
+		// Trim off the odd double quotes from ETag in the beginning and end.
+		etag = strings.TrimPrefix(etag, `"`)
+		etag = strings.TrimSuffix(etag, `"`)
+		listBucketResult.Contents[i].ETag = etag
 	}
 	return listBucketResult, nil
 }


### PR DESCRIPTION
list.go:
```
	ch := minioClient.ListObjects("krisbuck", "", false, nil)
	for entry := range ch {
		fmt.Println(entry)
	}
```

output without this commit:
```
{""9246fd89b86191f32e510b61f6c588e7"" my-objectname 2017-05-10 00:33:35 +0000 UTC 105  map[] {minio minio} STANDARD <nil>}
```

output with this commig:
```
{9246fd89b86191f32e510b61f6c588e7 my-objectname 2017-05-10 00:33:35 +0000 UTC 105  map[] {minio minio} STANDARD <nil>}
```