### PR TITLE
Add API to compose objects through server-side copying

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -1,0 +1,516 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/minio/minio-go/pkg/s3utils"
+)
+
+// SSEInfo - represents Server-Side-Encryption parameters specified by
+// a user.
+type SSEInfo struct {
+	key  []byte
+	algo string
+}
+
+// NewSSEInfo - specifies (binary or un-encoded) encryption key and
+// algorithm name. If algo is empty, it defaults to "AES256". Ref:
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html
+func NewSSEInfo(key []byte, algo string) SSEInfo {
+	if algo == "" {
+		algo = "AES256"
+	}
+	return SSEInfo{key, algo}
+}
+
+// internal method to output the generated SSE headers.
+func (s *SSEInfo) getSSEHeaders(isCopySource bool) map[string]string {
+	if s == nil {
+		return nil
+	}
+
+	cs := ""
+	if isCopySource {
+		cs = "copy-source-"
+	}
+	return map[string]string{
+		"x-amz-" + cs + "server-side-encryption-customer-algorithm": s.algo,
+		"x-amz-" + cs + "server-side-encryption-customer-key":       base64.StdEncoding.EncodeToString(s.key),
+		"x-amz-" + cs + "server-side-encryption-customer-key-MD5":   base64.StdEncoding.EncodeToString(sumMD5(s.key)),
+	}
+}
+
+// DestinationInfo - type with information about the object to be
+// created via server-side copy requests, using the Compose API.
+type DestinationInfo struct {
+	bucket, object string
+
+	// key for encrypting destination
+	encryption *SSEInfo
+
+	// if no user-metadata is provided, it is copied from source
+	// (when there is only once source object in the compose
+	// request)
+	userMetadata map[string]string
+}
+
+// NewDestinationInfo - creates a compose-object/copy-source
+// destination info object.
+//
+// `encSSEC` is the key info for server-side-encryption with customer
+// provided key. If it is nil, no encryption is performed.
+//
+// `userMeta` is the user-metadata key-value pairs to be set on the
+// destination. The keys are automatically prefixed with `x-amz-meta-`
+// if needed. If nil is passed, and if only a single source (of any
+// size) is provided in the ComposeObject call, then metadata from the
+// source is copied to the destination.
+func NewDestinationInfo(bucket, object string, encryptSSEC *SSEInfo,
+	userMeta map[string]string) (d DestinationInfo, err error) {
+
+	// Input validation.
+	if err = s3utils.CheckValidBucketName(bucket); err != nil {
+		return d, err
+	}
+	if err = s3utils.CheckValidObjectName(object); err != nil {
+		return d, err
+	}
+
+	// Process custom-metadata to remove a `x-amz-meta-` prefix if
+	// present and validate that keys are distinct (after this
+	// prefix removal).
+	m := make(map[string]string)
+	for k, v := range userMeta {
+		if strings.HasPrefix(k, "x-amz-meta-") {
+			k = strings.TrimPrefix(k, "x-amz-meta-")
+		}
+		if _, ok := m[k]; ok {
+			return d, fmt.Errorf("Cannot add both %s and x-amz-meta-%s keys as custom metadata", k, k)
+		}
+		m[k] = v
+	}
+
+	return DestinationInfo{
+		bucket:       bucket,
+		object:       object,
+		encryption:   encryptSSEC,
+		userMetadata: m,
+	}, nil
+}
+
+// getUserMetaHeadersMap - construct appropriate key-value pairs to send
+// as headers from metadata map to pass into copy-object request. For
+// single part copy-object (i.e. non-multipart object), enable the
+// withCopyDirectiveHeader to set the `x-amz-metadata-directive` to
+// `REPLACE`, so that metadata headers from the source are not copied
+// over.
+func (d *DestinationInfo) getUserMetaHeadersMap(withCopyDirectiveHeader bool) map[string]string {
+	if d.userMetadata == nil {
+		return nil
+	}
+	r := make(map[string]string)
+	if withCopyDirectiveHeader {
+		r["x-amz-metadata-directive"] = "REPLACE"
+	}
+	for k, v := range d.userMetadata {
+		r["x-amz-meta-"+k] = v
+	}
+	return r
+}
+
+// SourceInfo - represents a source object to be copied, using
+// server-side copying APIs.
+type SourceInfo struct {
+	bucket, object string
+
+	start, end int64
+
+	decryptKey *SSEInfo
+	// Headers to send with the upload-part-copy request involving
+	// this source object.
+	Headers http.Header
+}
+
+// NewSourceInfo - create a compose-object/copy-object source info
+// object.
+//
+// `decryptSSEC` is the decryption key using server-side-encryption
+// with customer provided key. It may be nil if the source is not
+// encrypted.
+func NewSourceInfo(bucket, object string, decryptSSEC *SSEInfo) SourceInfo {
+	r := SourceInfo{
+		bucket:     bucket,
+		object:     object,
+		start:      -1, // range is unspecified by default
+		decryptKey: decryptSSEC,
+		Headers:    make(http.Header),
+	}
+
+	// Set the source header
+	r.Headers.Set("x-amz-copy-source", s3utils.EncodePath(bucket+"/"+object))
+
+	// Assemble decryption headers for upload-part-copy request
+	for k, v := range decryptSSEC.getSSEHeaders(true) {
+		r.Headers.Set(k, v)
+	}
+
+	return r
+}
+
+// SetRange - Set the start and end offset of the source object to be
+// copied. If this method is not called, the whole source object is
+// copied.
+func (s *SourceInfo) SetRange(start, end int64) error {
+	if start > end || start < 0 {
+		return ErrInvalidArgument("start must be non-negative, and start must be at most end.")
+	}
+	// Note that 0 <= start <= end
+	s.start, s.end = start, end
+	return nil
+}
+
+// SetMatchETagCond - Set ETag match condition. The object is copied
+// only if the etag of the source matches the value given here.
+func (s *SourceInfo) SetMatchETagCond(etag string) error {
+	if etag == "" {
+		return ErrInvalidArgument("ETag cannot be empty.")
+	}
+	s.Headers.Set("x-amz-copy-source-if-match", etag)
+	return nil
+}
+
+// SetMatchETagExceptCond - Set the ETag match exception
+// condition. The object is copied only if the etag of the source is
+// not the value given here.
+func (s *SourceInfo) SetMatchETagExceptCond(etag string) error {
+	if etag == "" {
+		return ErrInvalidArgument("ETag cannot be empty.")
+	}
+	s.Headers.Set("x-amz-copy-source-if-none-match", etag)
+	return nil
+}
+
+// SetModifiedSinceCond - Set the modified since condition.
+func (s *SourceInfo) SetModifiedSinceCond(modTime time.Time) error {
+	if modTime.IsZero() {
+		return ErrInvalidArgument("Input time cannot be 0.")
+	}
+	s.Headers.Set("x-amz-copy-source-if-modified-since", modTime.Format(http.TimeFormat))
+	return nil
+}
+
+// SetUnmodifiedSinceCond - Set the unmodified since condition.
+func (s *SourceInfo) SetUnmodifiedSinceCond(modTime time.Time) error {
+	if modTime.IsZero() {
+		return ErrInvalidArgument("Input time cannot be 0.")
+	}
+	s.Headers.Set("x-amz-copy-source-if-unmodified-since", modTime.Format(http.TimeFormat))
+	return nil
+}
+
+// Helper to fetch size and etag of an object using a StatObject call.
+func (s *SourceInfo) getProps(c Client) (size int64, etag string, userMeta map[string]string, err error) {
+	// Get object info - need size and etag here. Also, decryption
+	// headers are added to the stat request if given.
+	var objInfo ObjectInfo
+	rh := NewGetReqHeaders()
+	for k, v := range s.decryptKey.getSSEHeaders(false) {
+		rh.Set(k, v)
+	}
+	objInfo, err = c.statObject(s.bucket, s.object, rh)
+	if err != nil {
+		err = fmt.Errorf("Could not stat object - %s/%s: %v", s.bucket, s.object, err)
+	} else {
+		size = objInfo.Size
+		etag = objInfo.ETag
+		userMeta = make(map[string]string)
+		for k, v := range objInfo.Metadata {
+			if strings.HasPrefix(k, "x-amz-meta-") {
+				if len(v) > 0 {
+					userMeta[k] = v[0]
+				}
+			}
+		}
+	}
+	return
+}
+
+// uploadPartCopy - helper function to create a part in a multipart
+// upload via an upload-part-copy request
+// https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html
+func (c Client) uploadPartCopy(bucket, object, uploadID string, partNumber int,
+	headers http.Header) (p CompletePart, err error) {
+
+	// Build query parameters
+	urlValues := make(url.Values)
+	urlValues.Set("partNumber", strconv.Itoa(partNumber))
+	urlValues.Set("uploadId", uploadID)
+
+	// Send upload-part-copy request
+	resp, err := c.executeMethod("PUT", requestMetadata{
+		bucketName:   bucket,
+		objectName:   object,
+		customHeader: headers,
+		queryValues:  urlValues,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return p, err
+	}
+
+	// Check if we got an error response.
+	if resp.StatusCode != http.StatusOK {
+		return p, httpRespToErrorResponse(resp, bucket, object)
+	}
+
+	// Decode copy-part response on success.
+	cpObjRes := copyObjectResult{}
+	err = xmlDecoder(resp.Body, &cpObjRes)
+	if err != nil {
+		return p, err
+	}
+	p.PartNumber, p.ETag = partNumber, cpObjRes.ETag
+	return p, nil
+}
+
+// ComposeObject - creates an object using server-side copying of
+// existing objects. It takes a list of source objects (with optional
+// offsets) and concatenates them into a new object using only
+// server-side copying operations.
+func (c Client) ComposeObject(dst DestinationInfo, srcs []SourceInfo) error {
+	if len(srcs) < 1 || len(srcs) > maxPartsCount {
+		return ErrInvalidArgument("There must be as least one and upto 10000 source objects.")
+	}
+
+	srcSizes := make([]int64, len(srcs))
+	var totalSize, size, totalParts int64
+	var srcUserMeta map[string]string
+	var etag string
+	var err error
+	for i, src := range srcs {
+		size, etag, srcUserMeta, err = src.getProps(c)
+		if err != nil {
+			return fmt.Errorf("Could not get source props for %s/%s: %v", src.bucket, src.object, err)
+		}
+
+		// Since we did a HEAD to get size, we use the ETag
+		// value to make sure the object has not changed by
+		// the time we perform the copy. This is done, only if
+		// the user has not set their own ETag match
+		// condition.
+		if src.Headers.Get("x-amz-copy-source-if-match") == "" {
+			src.SetMatchETagCond(etag)
+		}
+
+		// Check if a segment is specified, and if so, is the
+		// segment within object bounds?
+		if src.start != -1 {
+			// Since range is specified,
+			//    0 <= src.start <= src.end
+			// so only invalid case to check is:
+			if src.end >= size {
+				return ErrInvalidArgument(
+					fmt.Sprintf("SourceInfo %d has invalid segment-to-copy [%d, %d] (size is %d)",
+						i, src.start, src.end, size))
+			}
+			size = src.end - src.start + 1
+		}
+
+		// Only the last source may be less than `absMinPartSize`
+		if size < absMinPartSize && i < len(srcs)-1 {
+			return ErrInvalidArgument(
+				fmt.Sprintf("SourceInfo %d is too small (%d) and it is not the last part", i, size))
+		}
+
+		// Is data to copy too large?
+		totalSize += size
+		if totalSize > maxMultipartPutObjectSize {
+			return ErrInvalidArgument(fmt.Sprintf("Cannot compose an object of size %d (> 5TiB)", totalSize))
+		}
+
+		// record source size
+		srcSizes[i] = size
+
+		// calculate parts needed for current source
+		totalParts += partsRequired(size)
+		// Do we need more parts than we are allowed?
+		if totalParts > maxPartsCount {
+			return ErrInvalidArgument(fmt.Sprintf(
+				"Your proposed compose object requires more than %d parts", maxPartsCount))
+		}
+	}
+
+	// Single source object case (i.e. when only one source is
+	// involved, it is being copied wholly and at most 5GiB in
+	// size).
+	if totalParts == 1 && srcs[0].start == -1 && totalSize <= maxPartSize {
+		h := srcs[0].Headers
+		// Add destination encryption headers
+		for k, v := range dst.encryption.getSSEHeaders(false) {
+			h.Set(k, v)
+		}
+		// Add user metadata headers from source object
+		metaMap := srcUserMeta
+		if dst.userMetadata != nil {
+			metaMap = dst.getUserMetaHeadersMap(true)
+		}
+		for k, v := range metaMap {
+			h.Set(k, v)
+		}
+
+		// Send copy request
+		resp, err := c.executeMethod("PUT", requestMetadata{
+			bucketName:   dst.bucket,
+			objectName:   dst.object,
+			customHeader: h,
+		})
+		defer closeResponse(resp)
+		if err != nil {
+			return err
+		}
+		// Check if we got an error response.
+		if resp.StatusCode != http.StatusOK {
+			return httpRespToErrorResponse(resp, dst.bucket, dst.object)
+		}
+
+		// Return nil on success.
+		return nil
+	}
+
+	// Now, handle multipart-copy cases.
+
+	// 1. Initiate a new multipart upload.
+
+	// Set user-metadata on the destination object.
+	userMeta := dst.getUserMetaHeadersMap(false)
+	metaMap := srcUserMeta
+	if len(srcs) > 1 || userMeta != nil {
+		// cannot copy metadata if there is more than 1 source
+		metaMap = userMeta
+	}
+	metaHeaders := make(map[string][]string)
+	for k, v := range metaMap {
+		metaHeaders[k] = []string{v}
+	}
+	uploadID, err := c.newUploadID(dst.bucket, dst.object, metaHeaders)
+	if err != nil {
+		return fmt.Errorf("Error creating new upload: %v", err)
+	}
+
+	// 2. Perform copy part uploads
+	objParts := []CompletePart{}
+	partIndex := 1
+	for i, src := range srcs {
+		h := src.Headers
+		// Add destination encryption headers
+		for k, v := range dst.encryption.getSSEHeaders(false) {
+			h.Set(k, v)
+		}
+
+		// calculate start/end indices of parts after
+		// splitting.
+		startIdx, endIdx := calculateEvenSplits(srcSizes[i], src)
+		for j, start := range startIdx {
+			end := endIdx[j]
+
+			// Add (or reset) source range header for
+			// upload part copy request.
+			h.Set("x-amz-copy-source-range",
+				fmt.Sprintf("bytes=%d-%d", start, end))
+
+			// make upload-part-copy request
+			complPart, err := c.uploadPartCopy(dst.bucket,
+				dst.object, uploadID, partIndex, h)
+			if err != nil {
+				return fmt.Errorf("Error in upload-part-copy - %v", err)
+			}
+			objParts = append(objParts, complPart)
+			partIndex++
+		}
+	}
+
+	// 3. Make final complete-multipart request.
+	_, err = c.completeMultipartUpload(dst.bucket, dst.object, uploadID,
+		completeMultipartUpload{Parts: objParts})
+	if err != nil {
+		err = fmt.Errorf("Error in complete-multipart request - %v", err)
+	}
+	return err
+}
+
+// partsRequired is ceiling(size / copyPartSize)
+func partsRequired(size int64) int64 {
+	r := size / copyPartSize
+	if size%copyPartSize > 0 {
+		r++
+	}
+	return r
+}
+
+// calculateEvenSplits - computes splits for a source and returns
+// start and end index slices. Splits happen evenly to be sure that no
+// part is less than 5MiB, as that could fail the multipart request if
+// it is not the last part.
+func calculateEvenSplits(size int64, src SourceInfo) (startIndex, endIndex []int64) {
+	if size == 0 {
+		return
+	}
+
+	reqParts := partsRequired(size)
+	startIndex = make([]int64, reqParts)
+	endIndex = make([]int64, reqParts)
+	// Compute number of required parts `k`, as:
+	//
+	// k = ceiling(size / copyPartSize)
+	//
+	// Now, distribute the `size` bytes in the source into
+	// k parts as evenly as possible:
+	//
+	// r parts sized (q+1) bytes, and
+	// (k - r) parts sized q bytes, where
+	//
+	// size = q * k + r (by simple division of size by k,
+	// so that 0 <= r < k)
+	//
+	start := src.start
+	if start == -1 {
+		start = 0
+	}
+	quot, rem := size/reqParts, size%reqParts
+	nextStart := start
+	for j := int64(0); j < reqParts; j++ {
+		curPartSize := quot
+		if j < rem {
+			curPartSize++
+		}
+
+		cStart := nextStart
+		cEnd := cStart + curPartSize - 1
+		nextStart = cEnd + 1
+
+		startIndex[j], endIndex[j] = cStart, cEnd
+	}
+	return
+}

--- a/api-compose-object_test.go
+++ b/api-compose-object_test.go
@@ -1,0 +1,88 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package minio
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	gb1    = 1024 * 1024 * 1024
+	gb5    = 5 * gb1
+	gb5p1  = gb5 + 1
+	gb10p1 = 2*gb5 + 1
+	gb10p2 = 2*gb5 + 2
+)
+
+func TestPartsRequired(t *testing.T) {
+	testCases := []struct {
+		size, ref int64
+	}{
+		{0, 0},
+		{1, 1},
+		{gb5, 1},
+		{2 * gb5, 2},
+		{gb10p1, 3},
+		{gb10p2, 3},
+	}
+
+	for i, testCase := range testCases {
+		res := partsRequired(testCase.size)
+		if res != testCase.ref {
+			t.Errorf("Test %d - output did not match with reference results", i+1)
+		}
+	}
+}
+
+func TestCalculateEvenSplits(t *testing.T) {
+
+	testCases := []struct {
+		// input size and source object
+		size int64
+		src  SourceInfo
+
+		// output part-indexes
+		starts, ends []int64
+	}{
+		{0, SourceInfo{start: -1}, nil, nil},
+		{1, SourceInfo{start: -1}, []int64{0}, []int64{0}},
+		{1, SourceInfo{start: 0}, []int64{0}, []int64{0}},
+
+		{gb1, SourceInfo{start: -1}, []int64{0}, []int64{gb1 - 1}},
+		{gb5, SourceInfo{start: -1}, []int64{0}, []int64{gb5 - 1}},
+
+		// 2 part splits
+		{gb5p1, SourceInfo{start: -1}, []int64{0, gb5/2 + 1}, []int64{gb5 / 2, gb5}},
+		{gb5p1, SourceInfo{start: -1}, []int64{0, gb5/2 + 1}, []int64{gb5 / 2, gb5}},
+
+		// 3 part splits
+		{gb10p1, SourceInfo{start: -1},
+			[]int64{0, gb10p1/3 + 1, 2*gb10p1/3 + 1},
+			[]int64{gb10p1 / 3, 2 * gb10p1 / 3, gb10p1 - 1}},
+
+		{gb10p2, SourceInfo{start: -1},
+			[]int64{0, gb10p2 / 3, 2 * gb10p2 / 3},
+			[]int64{gb10p2/3 - 1, 2*gb10p2/3 - 1, gb10p2 - 1}},
+	}
+
+	for i, testCase := range testCases {
+		resStart, resEnd := calculateEvenSplits(testCase.size, testCase.src)
+		if !reflect.DeepEqual(testCase.starts, resStart) || !reflect.DeepEqual(testCase.ends, resEnd) {
+			t.Errorf("Test %d - output did not match with reference results", i+1)
+		}
+	}
+}

--- a/constants.go
+++ b/constants.go
@@ -18,9 +18,17 @@ package minio
 
 /// Multipart upload defaults.
 
-// miniPartSize - minimum part size 64MiB per object after which
+// absMinPartSize - absolute minimum part size (5 MiB) below which
+// a part in a multipart upload may not be uploaded.
+const absMinPartSize = 1024 * 1024 * 5
+
+// minPartSize - minimum part size 64MiB per object after which
 // putObject behaves internally as multipart.
 const minPartSize = 1024 * 1024 * 64
+
+// copyPartSize - default (and maximum) part size to copy in a
+// copy-object request (5GiB)
+const copyPartSize = 1024 * 1024 * 1024 * 5
 
 // maxPartsCount - maximum number of parts for a single multipart session.
 const maxPartsCount = 10000

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,17 +50,21 @@ func main() {
 }
 ```
 
-| Bucket operations  |Object operations | Encrypted Object operations  | Presigned operations  | Bucket Policy/Notification Operations | Client custom settings |
-|:---|:---|:---|:---|:---|:---|
-|[`MakeBucket`](#MakeBucket)   |[`GetObject`](#GetObject) | [`NewSymmetricKey`](#NewSymmetricKey) | [`PresignedGetObject`](#PresignedGetObject)  |[`SetBucketPolicy`](#SetBucketPolicy)   | [`SetAppInfo`](#SetAppInfo) |
-|[`ListBuckets`](#ListBuckets)   |[`PutObject`](#PutObject) | [`NewAsymmetricKey`](#NewAsymmetricKey) |[`PresignedPutObject`](#PresignedPutObject)   | [`GetBucketPolicy`](#GetBucketPolicy)  | [`SetCustomTransport`](#SetCustomTransport) |
-|[`BucketExists`](#BucketExists)   |[`CopyObject`](#CopyObject) |  [`GetEncryptedObject`](#GetEncryptedObject)  |[`PresignedPostPolicy`](#PresignedPostPolicy)   |  [`ListBucketPolicies`](#ListBucketPolicies)  | [`TraceOn`](#TraceOn) |
-| [`RemoveBucket`](#RemoveBucket)  |[`StatObject`](#StatObject) | [`PutObjectStreaming`](#PutObjectStreaming) |   |  [`SetBucketNotification`](#SetBucketNotification)  | [`TraceOff`](#TraceOff) |
-|[`ListObjects`](#ListObjects)  |[`RemoveObject`](#RemoveObject) | [`PutEncryptedObject`](#PutEncryptedObject) |   |  [`GetBucketNotification`](#GetBucketNotification)  | [`SetS3TransferAccelerate`](#SetS3TransferAccelerate) |
-|[`ListObjectsV2`](#ListObjectsV2) | [`RemoveObjects`](#RemoveObjects) |  |   | [`RemoveAllBucketNotification`](#RemoveAllBucketNotification)  |
-|[`ListIncompleteUploads`](#ListIncompleteUploads) | [`RemoveIncompleteUpload`](#RemoveIncompleteUpload) |  |  |  [`ListenBucketNotification`](#ListenBucketNotification)  |
-|   | [`FPutObject`](#FPutObject)  | |   |   |
-|   | [`FGetObject`](#FGetObject)  | |   |   |
+| Bucket operations                                 | Object operations                                   | Encrypted Object operations                 | Presigned operations                          | Bucket Policy/Notification Operations                         | Client custom settings                                |
+| :---                                              | :---                                                | :---                                        | :---                                          | :---                                                          | :---                                                  |
+| [`MakeBucket`](#MakeBucket)                       | [`GetObject`](#GetObject)                           | [`NewSymmetricKey`](#NewSymmetricKey)       | [`PresignedGetObject`](#PresignedGetObject)   | [`SetBucketPolicy`](#SetBucketPolicy)                         | [`SetAppInfo`](#SetAppInfo)                           |
+| [`ListBuckets`](#ListBuckets)                     | [`PutObject`](#PutObject)                           | [`NewAsymmetricKey`](#NewAsymmetricKey)     | [`PresignedPutObject`](#PresignedPutObject)   | [`GetBucketPolicy`](#GetBucketPolicy)                         | [`SetCustomTransport`](#SetCustomTransport)           |
+| [`BucketExists`](#BucketExists)                   | [`CopyObject`](#CopyObject)                         | [`GetEncryptedObject`](#GetEncryptedObject) | [`PresignedPostPolicy`](#PresignedPostPolicy) | [`ListBucketPolicies`](#ListBucketPolicies)                   | [`TraceOn`](#TraceOn)                                 |
+| [`RemoveBucket`](#RemoveBucket)                   | [`StatObject`](#StatObject)                         | [`PutObjectStreaming`](#PutObjectStreaming) |                                               | [`SetBucketNotification`](#SetBucketNotification)             | [`TraceOff`](#TraceOff)                               |
+| [`ListObjects`](#ListObjects)                     | [`RemoveObject`](#RemoveObject)                     | [`PutEncryptedObject`](#PutEncryptedObject) |                                               | [`GetBucketNotification`](#GetBucketNotification)             | [`SetS3TransferAccelerate`](#SetS3TransferAccelerate) |
+| [`ListObjectsV2`](#ListObjectsV2)                 | [`RemoveObjects`](#RemoveObjects)                   | [`NewSSEInfo`](#NewSSEInfo)                 |                                               | [`RemoveAllBucketNotification`](#RemoveAllBucketNotification) |                                                       |
+| [`ListIncompleteUploads`](#ListIncompleteUploads) | [`RemoveIncompleteUpload`](#RemoveIncompleteUpload) |                                             |                                               | [`ListenBucketNotification`](#ListenBucketNotification)       |                                                       |
+|                                                   | [`FPutObject`](#FPutObject)                         |                                             |                                               |                                                               |                                                       |
+|                                                   | [`FGetObject`](#FGetObject)                         |                                             |                                               |                                                               |                                                       |
+|                                                   | [`ComposeObject`](#ComposeObject)                   |                                             |                                               |                                                               |                                                       |
+|                                                   | [`NewSourceInfo`](#NewSourceInfo)                   |                                             |                                               |                                                               |                                                       |
+|                                                   | [`NewDestinationInfo`](#NewDestinationInfo)         |                                             |                                               |                                                               |                                                       |
+
 
 ## 1. Constructor
 <a name="Minio"></a>
@@ -502,9 +506,11 @@ if err != nil {
 
 
 <a name="CopyObject"></a>
-### CopyObject(bucketName, objectName, objectSource string, conditions CopyConditions) error
+### CopyObject(dst DestinationInfo, src SourceInfo) error
 
-Copy a source object into a new object with the provided name in the provided bucket.
+Create or replace an object through server-side copying of an existing object. It supports conditional copying, copying a part of an object and server-side encryption of destination and decryption of source. See the `SourceInfo` and `DestinationInfo` types for further details.
+
+To copy multiple source objects into a single destination object see the `ComposeObject` API.
 
 
 __Parameters__
@@ -512,49 +518,160 @@ __Parameters__
 
 |Param   |Type   |Description   |
 |:---|:---| :---|
-|`bucketName`  | _string_  |Name of the bucket |
-|`objectName` | _string_  |Name of the object   |
-|`objectSource` | _string_  |Name of the source object  |
-|`conditions` | _CopyConditions_  |Collection of supported CopyObject conditions. [`x-amz-copy-source`, `x-amz-copy-source-if-match`, `x-amz-copy-source-if-none-match`, `x-amz-copy-source-if-unmodified-since`, `x-amz-copy-source-if-modified-since`]|
+|`dst`  | _DestinationInfo_  |Argument describing the destination object |
+|`src` | _SourceInfo_  |Argument describing the source object |
 
 
 __Example__
 
 
 ```go
-// Use-case-1
-// To copy an existing object to a new object with _no_ copy conditions.
-copyConds := minio.CopyConditions{}
-err := minioClient.CopyObject("mybucket", "myobject", "my-sourcebucketname/my-sourceobjectname", copyConds)
+// Use-case 1: Simple copy object with no conditions, etc
+// Source object
+src := minio.NewSourceInfo("my-sourcebucketname", "my-sourceobjectname", nil)
+
+// Destination object
+dst := minio.NewDestinationInfo("my-bucketname", "my-objectname", nil, nil)
+
+/ Copy object call
+err = s3Client.CopyObject(dst, src)
 if err != nil {
     fmt.Println(err)
     return
 }
 
-// Use-case-2
-// To copy an existing object to a new object with the following copy conditions
+// Use-case 2: Copy object with copy-conditions, and copying only part of the source object.
 // 1. that matches a given ETag
 // 2. and modified after 1st April 2014
 // 3. but unmodified since 23rd April 2014
+// 4. copy only first 1MiB of object.
 
-// Initialize empty copy conditions.
-var copyConds = minio.CopyConditions{}
+// Source object
+src := minio.NewSourceInfo("my-sourcebucketname", "my-sourceobjectname", nil)
 
-// copy object that matches the given ETag.
-copyConds.SetMatchETag("31624deb84149d2f8ef9c385918b653a")
+// Set matching ETag condition, copy object which matches the following ETag.
+src.SetMatchETagCond("31624deb84149d2f8ef9c385918b653a")
 
-// and modified after 1st April 2014
-copyConds.SetModified(time.Date(2014, time.April, 1, 0, 0, 0, 0, time.UTC))
+// Set modified condition, copy object modified since 2014 April 1.
+src.SetModifiedSinceCond(time.Date(2014, time.April, 1, 0, 0, 0, 0, time.UTC))
 
-// but unmodified since 23rd April 2014
-copyConds.SetUnmodified(time.Date(2014, time.April, 23, 0, 0, 0, 0, time.UTC))
+// Set unmodified condition, copy object unmodified since 2014 April 23.
+src.SetUnmodifiedSinceCond(time.Date(2014, time.April, 23, 0, 0, 0, 0, time.UTC))
 
-err := minioClient.CopyObject("mybucket", "myobject", "my-sourcebucketname/my-sourceobjectname", copyConds)
+// Set copy-range of only first 1MiB of file.
+src.SetRange(0, 1024*1024-1)
+
+// Destination object
+dst := minio.NewDestinationInfo("my-bucketname", "my-objectname", nil, nil)
+
+/ Copy object call
+err = s3Client.CopyObject(dst, src)
 if err != nil {
     fmt.Println(err)
     return
 }
 ```
+
+<a name="ComposeObject"></a>
+### ComposeObject(dst DestinationInfo, srcs []SourceInfo) error
+
+Create an object by concatenating a list of source objects using
+server-side copying.
+
+__Parameters__
+
+
+|Param   |Type   |Description   |
+|:---|:---|:---|
+|`dst`  | _minio.DestinationInfo_  |Struct with info about the object to be created. |
+|`srcs` | _[]minio.SourceInfo_  |Slice of struct with info about source objects to be concatenated in order. |
+
+
+__Example__
+
+
+```go
+// Prepare source decryption key (here we assume same key to
+// decrypt all source objects.)
+decKey := minio.NewSSEInfo([]byte{1, 2, 3}, "")
+
+// Source objects to concatenate. We also specify decryption
+// key for each
+src1 := minio.NewSourceInfo("bucket1", "object1", decKey)
+src1.SetMatchETag("31624deb84149d2f8ef9c385918b653a")
+
+src2 := minio.NewSourceInfo("bucket2", "object2", decKey)
+src2.SetMatchETag("f8ef9c385918b653a31624deb84149d2")
+
+src3 := minio.NewSourceInfo("bucket3", "object3", decKey)
+src3.SetMatchETag("5918b653a31624deb84149d2f8ef9c38")
+
+// Create slice of sources.
+srcs := []minio.SourceInfo{src1, src2, src3}
+
+// Prepare destination encryption key
+encKey := minio.NewSSEInfo([]byte{8, 9, 0}, "")
+
+// Create destination info
+dst := minio.NewDestinationInfo("bucket", "object", encKey, nil)
+err = s3Client.ComposeObject(dst, srcs)
+if err != nil {
+	log.Println(err)
+	return
+}
+
+log.Println("Composed object successfully.")
+```
+
+<a name="NewSourceInfo"></a>
+### NewSourceInfo(bucket, object string, decryptSSEC *SSEInfo) SourceInfo
+
+Construct a `SourceInfo` object that can be used as the source for server-side copying operations like `CopyObject` and `ComposeObject`. This object can be used to set copy-conditions on the source.
+
+__Parameters__
+
+| Param         | Type             | Description                                                      |
+| :---          | :---             | :---                                                             |
+| `bucket`      | _string_         | Name of the source bucket                                        |
+| `object`      | _string_         | Name of the source object                                        |
+| `decryptSSEC` | _*minio.SSEInfo_ | Decryption info for the source object (`nil` without encryption) |
+
+__Example__
+
+``` go
+// No decryption parameter.
+src := NewSourceInfo("bucket", "object", nil)
+
+// With decryption parameter.
+decKey := NewSSEKey([]byte{1,2,3}, "")
+src := NewSourceInfo("bucket", "object", decKey)
+```
+
+<a name="NewDestinationInfo"></a>
+### NewDestinationInfo(bucket, object string, encryptSSEC *SSEInfo, userMeta map[string]string) DestinationInfo
+
+Construct a `DestinationInfo` object that can be used as the destination object for server-side copying operations like `CopyObject` and `ComposeObject`.
+
+__Parameters__
+
+| Param         | Type                | Description                                                                                                    |
+| :---          | :---                | :---                                                                                                           |
+| `bucket`      | _string_            | Name of the destination bucket                                                                                 |
+| `object`      | _string_            | Name of the destination object                                                                                 |
+| `encryptSSEC` | _*minio.SSEInfo_    | Encryption info for the source object (`nil` without encryption)                                               |
+| `userMeta`    | _map[string]string_ | User metadata to be set on the destination. If nil, with only one source, user-metadata is copied from source. |
+
+__Example__
+
+``` go
+// No encryption parameter.
+src := NewDestinationInfo("bucket", "object", nil, nil)
+
+// With encryption parameter.
+encKey := NewSSEKey([]byte{1,2,3}, "")
+src := NewDecryptionInfo("bucket", "object", encKey, nil)
+```
+
 
 <a name="FPutObject"></a>
 ### FPutObject(bucketName, objectName, filePath, contentType string) (length int64, err error)
@@ -879,6 +996,26 @@ if err != nil {
     fmt.Println(err)
     return
 }
+```
+
+<a name="NewSSEInfo"></a>
+
+### NewSSEInfo(key []byte, algo string) SSEInfo
+
+Create a key object for use as encryption or decryption parameter in operations involving server-side-encryption with customer provided key (SSE-C).
+
+__Parameters__
+
+| Param  | Type     | Description                                                                                          |
+| :---   | :---     | :---                                                                                                 |
+| `key`  | _[]byte_ | Byte-slice of the raw, un-encoded binary key                                                         |
+| `algo` | _string_ | Algorithm to use in encryption or decryption with the given key. Can be empty (defaults to `AES256`) |
+
+__Example__
+
+``` go
+// Key for use in encryption/decryption
+keyInfo := NewSSEInfo([]byte{1,2,3}, "")
 ```
 
 ## 5. Presigned operations


### PR DESCRIPTION
The new ComposeObject API provides a way to create objects by
concatenating existing objects. It takes a list of source objects
along with optional start-end range specifications, and concatenates
them into a new object.

The API supports:

* Create an object from upto 10000 existing objects.
* Create object of any size upto 5TiB.
* Creates objects from even existing objects that are larger than
  5GiB (part size limit in multipart PUTs)
* Support copy-conditions on each source object separately.
* Support SSE-C (i.e. Server-Side-Encryption with Customer provided
  key) for both encryption of destination object, and decryption of
  source objects.
* Support for setting/replacing custom metadata in the destination
  object.

This API has been used to refactor the CopyObject API - that API now
supports source objects of any size, SSE-C for source and destination,
and settings custom metadata.

Finally, the type for a source object (`SourceInfo`) allows the user to set custom headers (by hand) for further extended usage (such as using AWS KMS based SSE).