### PR TITLE
Set http.NoBody if contentLength is 0

### DIFF
--- a/api.go
+++ b/api.go
@@ -622,7 +622,11 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	// by making sure to wrap the closer as a nop.
 	var body io.ReadCloser
 	if metadata.contentBody != nil {
-		body = ioutil.NopCloser(metadata.contentBody)
+		if metadata.contentLength > 0 {
+			body = ioutil.NopCloser(metadata.contentBody)
+		} else {
+			body = http.NoBody
+		}
 	}
 
 	// Initialize a new HTTP request for the method.

--- a/api.go
+++ b/api.go
@@ -616,17 +616,8 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 		return nil, err
 	}
 
-	// Go net/http notoriously closes the request body.
-	// - The request Body, if non-nil, will be closed by the underlying Transport, even on errors.
-	// This can cause underlying *os.File seekers to fail, avoid that
-	// by making sure to wrap the closer as a nop.
-	var body io.ReadCloser
-	if metadata.contentBody != nil && metadata.contentLength > 0 {
-		body = ioutil.NopCloser(metadata.contentBody)
-	}
-
 	// Initialize a new HTTP request for the method.
-	req, err = http.NewRequest(method, targetURL.String(), body)
+	req, err = http.NewRequest(method, targetURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -676,6 +667,14 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	// Set all headers.
 	for k, v := range metadata.customHeader {
 		req.Header.Set(k, v[0])
+	}
+
+	// Go net/http notoriously closes the request body.
+	// - The request Body, if non-nil, will be closed by the underlying Transport, even on errors.
+	// This can cause underlying *os.File seekers to fail, avoid that
+	// by making sure to wrap the closer as a nop.
+	if metadata.contentBody != nil && metadata.contentLength > 0 {
+		req.Body = ioutil.NopCloser(metadata.contentBody)
 	}
 
 	// Set incoming content-length.

--- a/api.go
+++ b/api.go
@@ -621,12 +621,8 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	// This can cause underlying *os.File seekers to fail, avoid that
 	// by making sure to wrap the closer as a nop.
 	var body io.ReadCloser
-	if metadata.contentBody != nil {
-		if metadata.contentLength > 0 {
-			body = ioutil.NopCloser(metadata.contentBody)
-		} else {
-			body = nil
-		}
+	if metadata.contentBody != nil && metadata.contentLength > 0 {
+		body = ioutil.NopCloser(metadata.contentBody)
 	}
 
 	// Initialize a new HTTP request for the method.

--- a/api.go
+++ b/api.go
@@ -625,7 +625,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 		if metadata.contentLength > 0 {
 			body = ioutil.NopCloser(metadata.contentBody)
 		} else {
-			body = http.NoBody
+			body = nil
 		}
 	}
 

--- a/api.go
+++ b/api.go
@@ -673,7 +673,9 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	// - The request Body, if non-nil, will be closed by the underlying Transport, even on errors.
 	// This can cause underlying *os.File seekers to fail, avoid that
 	// by making sure to wrap the closer as a nop.
-	if metadata.contentBody != nil && metadata.contentLength > 0 {
+	if metadata.contentLength == 0 {
+		req.Body = nil
+	} else {
 		req.Body = ioutil.NopCloser(metadata.contentBody)
 	}
 

--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -204,6 +205,12 @@ func StreamingSignV4(req *http.Request, accessKeyID, secretAccessKey, sessionTok
 
 	// Set headers needed for streaming signature.
 	prepareStreamingRequest(req, sessionToken, dataLen, reqTime)
+
+	if req.Body == nil {
+		// TODO: this still fails api_functional_v4_test.go:406
+		// even with req.Body = http.NoBody for go1.8.3
+		req.Body = ioutil.NopCloser(bytes.NewReader([]byte("")))
+	}
 
 	stReader := &StreamingReader{
 		baseReadCloser:  req.Body,

--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -207,8 +207,6 @@ func StreamingSignV4(req *http.Request, accessKeyID, secretAccessKey, sessionTok
 	prepareStreamingRequest(req, sessionToken, dataLen, reqTime)
 
 	if req.Body == nil {
-		// TODO: this still fails api_functional_v4_test.go:406
-		// even with req.Body = http.NoBody for go1.8.3
 		req.Body = ioutil.NopCloser(bytes.NewReader([]byte("")))
 	}
 


### PR DESCRIPTION
We've experienced a production bug using `minio-go` with `minio:latest` server and `go version go1.8.3 linux/amd64`.

A valid call to `PutObject` with a zero-length `reader` argument...

```
reader := bytes.NewReader(make([]byte, 0))
contentType := "application/octet-stream"
_, err = minioClient.PutObject(bucketName, objectName, reader, contentType)
```

...caused a server error:

```
You must provide the Content-Length HTTP header
```

We managed to pinpoint the problem to a go update (1.7 -> 1.8.3) we've done recently - it seems that an empty body is now treated differently by `net/http`. Check this issue: https://github.com/golang/go/issues/20257.

This is a fix that works for our use case, but I am not sure about backwards compatibility with older Go versions. I'd also be happy to add unit tests for it, but I might need some guidance on that.