### PR TITLE
Remove duplicate validation code in StatObject

### DIFF
--- a/api-stat.go
+++ b/api-stat.go
@@ -81,13 +81,6 @@ func extractObjMetadata(header http.Header) http.Header {
 
 // StatObject verifies if object exists and you have permission to access.
 func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
-	// Input validation.
-	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
-		return ObjectInfo{}, err
-	}
-	if err := s3utils.CheckValidObjectName(objectName); err != nil {
-		return ObjectInfo{}, err
-	}
 	reqHeaders := NewHeadReqHeaders()
 	return c.statObject(bucketName, objectName, reqHeaders)
 }


### PR DESCRIPTION
The validation code that is being removed from `StatObject` is also called in `statObject`, therefore the duplicate validation can be removed.

Note: Unit tests on the master branch are failing for me. Below is my output:

```
go test -race ./...
--- FAIL: TestGetObjectClosedTwiceV2 (0.00s)
	api_functional_v2_test.go:100: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestRemovePartiallyUploadedV2 (0.00s)
	api_functional_v2_test.go:180: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestFPutObjectV2 (0.00s)
	api_functional_v2_test.go:249: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetObjectReadSeekFunctionalV2 (0.00s)
	api_functional_v2_test.go:452: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetObjectReadAtFunctionalV2 (0.00s)
	api_functional_v2_test.go:585: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestCopyObjectV2 (0.00s)
	api_functional_v2_test.go:721: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestFunctionalV2 (0.00s)
	api_functional_v2_test.go:838: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestPutObjectReadAt (0.00s)
	api_functional_v4_test.go:198: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestPutObjectWithMetadata (0.00s)
	api_functional_v4_test.go:288: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestPutObjectStreaming (0.00s)
	api_functional_v4_test.go:382: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestListPartiallyUploaded (0.00s)
	api_functional_v4_test.go:446: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetOjectSeekEnd (0.00s)
	api_functional_v4_test.go:522: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetObjectClosedTwice (0.00s)
	api_functional_v4_test.go:617: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestRemoveMultipleObjects (0.00s)
	api_functional_v4_test.go:698: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestRemovePartiallyUploaded (0.00s)
	api_functional_v4_test.go:772: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestFPutObjectMultipart (0.00s)
	api_functional_v4_test.go:841: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestFPutObject (0.00s)
	api_functional_v4_test.go:942: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetObjectReadSeekFunctional (0.00s)
	api_functional_v4_test.go:1098: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetObjectReadAtFunctional (0.00s)
	api_functional_v4_test.go:1252: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestPresignedPostPolicy (0.00s)
	api_functional_v4_test.go:1401: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestCopyObject (0.00s)
	api_functional_v4_test.go:1496: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestEncryptionPutGet (0.00s)
	api_functional_v4_test.go:1664: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestFunctional (0.00s)
	api_functional_v4_test.go:1907: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetObjectObjectModified (0.00s)
	api_functional_v4_test.go:2235: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestPutObjectUploadSeekedObject (0.00s)
	api_functional_v4_test.go:2309: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetObjectCore (0.00s)
	core_test.go:55: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestGetBucketPolicy (0.00s)
	core_test.go:229: Error: Endpoint:  does not follow ip address or domain name standards.
--- FAIL: TestCorePutObject (0.00s)
	core_test.go:292: Error: Endpoint:  does not follow ip address or domain name standards.
FAIL
FAIL	_/Users/me/code/minio-go	0.130s
ok  	_/Users/me/code/minio-go/pkg/credentials	1.172s
?   	_/Users/me/code/minio-go/pkg/encrypt	[no test files]
ok  	_/Users/me/code/minio-go/pkg/policy	1.153s
ok  	_/Users/me/code/minio-go/pkg/s3signer	1.198s
ok  	_/Users/me/code/minio-go/pkg/s3utils	1.080s
ok  	_/Users/me/code/minio-go/pkg/set	1.093s
```