### PR TITLE
api: Update progress bar concurrently.

### DIFF
--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -113,13 +113,6 @@ func (c Client) putObjectMultipartNoStream(bucketName, objectName string, reader
 		// Save successfully uploaded part metadata.
 		partsInfo[partNumber] = objPart
 
-		// Update the progress reader for the skipped part.
-		if progress != nil {
-			if _, err = io.CopyN(ioutil.Discard, progress, prtSize); err != nil {
-				return totalUploadedSize, err
-			}
-		}
-
 		// Reset the temporary buffer.
 		tmpBuffer.Reset()
 

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -19,7 +19,6 @@ package minio
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -165,7 +164,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(bucketName, objectName string
 				}
 
 				// Get a section reader on a particular offset.
-				sectionReader := io.NewSectionReader(reader, readOffset, partSize)
+				sectionReader := newHook(io.NewSectionReader(reader, readOffset, partSize), progress)
 
 				// Proceed to upload the part.
 				var objPart ObjectPart
@@ -209,12 +208,6 @@ func (c Client) putObjectMultipartStreamFromReadAt(bucketName, objectName string
 		}
 		// Update the totalUploadedSize.
 		totalUploadedSize += uploadRes.Size
-		// Update the progress bar if there is one.
-		if progress != nil {
-			if _, err = io.CopyN(ioutil.Discard, progress, uploadRes.Size); err != nil {
-				return totalUploadedSize, err
-			}
-		}
 		// Store the parts to be completed in order.
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
 			ETag:       part.ETag,


### PR DESCRIPTION
Currently we had a bug where progress bar
was only updated after the upload has been
completed. With streaming signature we
don't need to do that.

This PR fixes this behavior. This PR also
removes a double progress bar jump
in case of fallback buffer based multipart upload.