### PR TITLE
api: use simple streaming upload for GetObject() reader.

### DIFF
--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -254,7 +254,18 @@ func (s *StreamingReader) Read(buf []byte) (int, error) {
 		s.chunkBufLen = 0
 		for {
 			n1, err := s.baseReadCloser.Read(s.chunkBuf[s.chunkBufLen:])
-			if err == nil || err == io.ErrUnexpectedEOF {
+			// Usually we validate `err` first, but in this case
+			// we are validating n > 0 for the following reasons.
+			//
+			// 1. n > 0, err is one of io.EOF, nil (near end of stream)
+			// A Reader returning a non-zero number of bytes at the end
+			// of the input stream may return either err == EOF or err == nil
+			//
+			// 2. n == 0, err is io.EOF (actual end of stream)
+			//
+			// Callers should always process the n > 0 bytes returned
+			// before considering the error err.
+			if n1 > 0 {
 				s.chunkBufLen += n1
 				s.bytesRead += int64(n1)
 
@@ -265,25 +276,26 @@ func (s *StreamingReader) Read(buf []byte) (int, error) {
 					s.signChunk(s.chunkBufLen)
 					break
 				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					// No more data left in baseReader - last chunk.
+					// Done reading the last chunk from baseReader.
+					s.done = true
 
-			} else if err == io.EOF {
-				// No more data left in baseReader - last chunk.
-				// Done reading the last chunk from baseReader.
-				s.done = true
+					// bytes read from baseReader different than
+					// content length provided.
+					if s.bytesRead != s.contentLen {
+						return 0, io.ErrUnexpectedEOF
+					}
 
-				// bytes read from baseReader different than
-				// content length provided.
-				if s.bytesRead != s.contentLen {
-					return 0, io.ErrUnexpectedEOF
+					// Sign the chunk and write it to s.buf.
+					s.signChunk(0)
+					break
 				}
-
-				// Sign the chunk and write it to s.buf.
-				s.signChunk(0)
-				break
-
-			} else {
 				return 0, err
 			}
+
 		}
 	}
 	return s.buf.Read(buf)


### PR DESCRIPTION
This change is needed to avoid the offset based ReadAt()
calls which can occur if using io.SectionReader().

Optimizing this part re-implementing a sectionReader()
based on Seeker() wasn't worth the complexity.