### PR TITLE
api: Pass down encryption metadata to all the multipart callers.

### DIFF
--- a/api_functional_v4_test.go
+++ b/api_functional_v4_test.go
@@ -112,14 +112,14 @@ func TestMakeBucketError(t *testing.T) {
 		t.Fatal("Error:", err, bucketName+"..-1")
 	}
 	// Verify valid error response.
-	if ToErrorResponse(err).Code != "InvalidBucketName" {
+	if err != nil && err.Error() != "Bucket name contains invalid characters" {
 		t.Fatal("Error: Invalid error returned by server", err)
 	}
 	if err = c.MakeBucket(bucketName+"AAA-1", "eu-central-1"); err == nil {
 		t.Fatal("Error:", err, bucketName+"..-1")
 	}
 	// Verify valid error response.
-	if ToErrorResponse(err).Code != "InvalidBucketName" {
+	if err != nil && err.Error() != "Bucket name contains invalid characters" {
 		t.Fatal("Error: Invalid error returned by server", err)
 	}
 }

--- a/core.go
+++ b/core.go
@@ -70,7 +70,13 @@ func (c Core) ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, de
 
 // PutObjectPart - Upload an object part.
 func (c Core) PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Sum, sha256Sum []byte) (ObjectPart, error) {
-	return c.uploadPart(bucket, object, uploadID, data, partID, md5Sum, sha256Sum, size)
+	return c.PutObjectPartWithMetadata(bucket, object, uploadID, partID, size, data, md5Sum, sha256Sum, nil)
+}
+
+// PutObjectPartWithMetadata - upload an object part with additional request metadata.
+func (c Core) PutObjectPartWithMetadata(bucket, object, uploadID string, partID int,
+	size int64, data io.Reader, md5Sum, sha256Sum []byte, metadata map[string][]string) (ObjectPart, error) {
+	return c.uploadPart(bucket, object, uploadID, data, partID, md5Sum, sha256Sum, size, metadata)
 }
 
 // ListObjectParts - List uploaded parts of an incomplete upload.x
@@ -80,7 +86,9 @@ func (c Core) ListObjectParts(bucket, object, uploadID string, partNumberMarker 
 
 // CompleteMultipartUpload - Concatenate uploaded parts and commit to an object.
 func (c Core) CompleteMultipartUpload(bucket, object, uploadID string, parts []CompletePart) error {
-	_, err := c.completeMultipartUpload(bucket, object, uploadID, completeMultipartUpload{Parts: parts})
+	_, err := c.completeMultipartUpload(bucket, object, uploadID, completeMultipartUpload{
+		Parts: parts,
+	})
 	return err
 }
 


### PR DESCRIPTION
This allows for server side encryption to work properly for
file sizes bigger than 64MB.

This PR also addresses another problem of SignatureV2 signature.