### PR TITLE
Export KeyInfo.GetSSEHeaders so users can more easily generate SSE-C headers

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -45,7 +45,7 @@ func NewSSEInfo(key []byte, algo string) SSEInfo {
 	return SSEInfo{key, algo}
 }
 
-// internal method to output the generated SSE headers.
+// internal method that computes SSE-C headers
 func (s *SSEInfo) getSSEHeaders(isCopySource bool) map[string]string {
 	if s == nil {
 		return nil
@@ -60,6 +60,14 @@ func (s *SSEInfo) getSSEHeaders(isCopySource bool) map[string]string {
 		"x-amz-" + cs + "server-side-encryption-customer-key":       base64.StdEncoding.EncodeToString(s.key),
 		"x-amz-" + cs + "server-side-encryption-customer-key-MD5":   base64.StdEncoding.EncodeToString(sumMD5(s.key)),
 	}
+}
+
+// GetSSEHeaders - computes and returns headers for SSE-C as key-value
+// pairs. They can be set as metadata in PutObject* requests (for
+// encryption) or be set as request headers in `Core.GetObject` (for
+// decryption).
+func (s *SSEInfo) GetSSEHeaders() map[string]string {
+	return s.getSSEHeaders(false)
 }
 
 // DestinationInfo - type with information about the object to be

--- a/api_functional_v2_test.go
+++ b/api_functional_v2_test.go
@@ -1262,7 +1262,7 @@ func testEncryptedCopyObject(c *Client, t *testing.T) {
 	const srcSize = 1024 * 1024
 	buf := bytes.Repeat([]byte("abcde"), srcSize) // gives a buffer of 5MiB
 	metadata := make(map[string][]string)
-	for k, v := range key1.getSSEHeaders(false) {
+	for k, v := range key1.GetSSEHeaders() {
 		metadata[k] = append(metadata[k], v)
 	}
 	_, err = c.PutObjectWithSize(bucketName, "srcObject", bytes.NewReader(buf), int64(len(buf)), metadata, nil)
@@ -1284,7 +1284,7 @@ func testEncryptedCopyObject(c *Client, t *testing.T) {
 
 	// 3. get copied object and check if content is equal
 	reqH := NewGetReqHeaders()
-	for k, v := range key2.getSSEHeaders(false) {
+	for k, v := range key2.GetSSEHeaders() {
 		reqH.Set(k, v)
 	}
 	coreClient := Core{c}


### PR DESCRIPTION
This adds a method for users to more simply generate and set server-side-encryption headers.