### PR TITLE
mustParseBool should return false for empty string

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -124,7 +124,7 @@ func testMakeBucketError() {
 		mustParseBool(os.Getenv(enableHTTPS)),
 	)
 	if err != nil {
-		log.Fatalf("Error:", err)
+		log.Fatalf("Error: %s", err)
 	}
 
 	// Enable tracing, write to stderr.
@@ -3917,7 +3917,7 @@ func testFunctionalV2() {
 	}
 }
 
-// Convert string to bool and always return true if any error
+// Convert string to bool and always return false if any error
 func mustParseBool(str string) bool {
 	b, err := strconv.ParseBool(str)
 	if err != nil {

--- a/test-utils_test.go
+++ b/test-utils_test.go
@@ -64,11 +64,11 @@ func encodeResponse(response interface{}) []byte {
 	return bytesBuffer.Bytes()
 }
 
-// Convert string to bool and always return true if any error
+// Convert string to bool and always return false if any error
 func mustParseBool(str string) bool {
 	b, err := strconv.ParseBool(str)
 	if err != nil {
-		return true
+		return false
 	}
 	return b
 }


### PR DESCRIPTION
I.e, ENABLE_HTTPS environment variable is not set
`mustParseBool(os.Getenv("ENABLE_HTTPS"))` should be `false`

Fixes #751 