### PR TITLE
PutObject streams with unknown size use streaming V4.

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -17,13 +17,15 @@
 package minio
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 
-	"github.com/minio/minio-go/pkg/credentials"
 	"github.com/minio/minio-go/pkg/s3utils"
 )
 
@@ -200,16 +202,9 @@ func (c Client) putObjectCommon(bucketName, objectName string, reader io.Reader,
 		return c.putObjectMultipart(bucketName, objectName, reader, size, metadata, progress)
 	}
 
-	// If size cannot be found on a stream, it is not possible
-	// to upload using streaming signature, fall back to multipart.
 	if size < 0 {
-		// Set regular signature calculation.
-		c.overrideSignerType = credentials.SignatureV4
-		return c.putObjectMultipart(bucketName, objectName, reader, size, metadata, progress)
+		return c.putObjectMultipartStreamNoLength(bucketName, objectName, reader, size, metadata, progress)
 	}
-
-	// Set streaming signature.
-	c.overrideSignerType = credentials.SignatureV4Streaming
 
 	if size < minPartSize {
 		return c.putObjectNoChecksum(bucketName, objectName, reader, size, metadata, progress)
@@ -217,4 +212,119 @@ func (c Client) putObjectCommon(bucketName, objectName string, reader io.Reader,
 
 	// For all sizes greater than 64MiB do multipart.
 	return c.putObjectMultipartStream(bucketName, objectName, reader, size, metadata, progress)
+}
+
+func (c Client) putObjectMultipartStreamNoLength(bucketName, objectName string, reader io.Reader, size int64,
+	metadata map[string][]string, progress io.Reader) (n int64, err error) {
+	// Input validation.
+	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
+		return 0, err
+	}
+	if err = s3utils.CheckValidObjectName(objectName); err != nil {
+		return 0, err
+	}
+
+	// Total data read and written to server. should be equal to
+	// 'size' at the end of the call.
+	var totalUploadedSize int64
+
+	// Complete multipart upload.
+	var complMultipartUpload completeMultipartUpload
+
+	// Calculate the optimal parts info for a given size.
+	totalPartsCount, partSize, _, err := optimalPartInfo(size)
+	if err != nil {
+		return 0, err
+	}
+
+	// Initiate a new multipart upload.
+	uploadID, err := c.newUploadID(bucketName, objectName, metadata)
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() {
+		if err != nil {
+			c.abortMultipartUpload(bucketName, objectName, uploadID)
+		}
+	}()
+
+	// Part number always starts with '1'.
+	partNumber := 1
+
+	// Initialize a temporary buffer.
+	tmpBuffer := new(bytes.Buffer)
+
+	// Initialize parts uploaded map.
+	partsInfo := make(map[int]ObjectPart)
+
+	for partNumber <= totalPartsCount {
+		// Calculates hash sums while copying partSize bytes into tmpBuffer.
+		prtSize, rErr := io.CopyN(tmpBuffer, reader, partSize)
+		if rErr != nil && rErr != io.EOF {
+			return 0, rErr
+		}
+
+		var reader io.Reader
+		// Update progress reader appropriately to the latest offset
+		// as we read from the source.
+		reader = newHook(tmpBuffer, progress)
+
+		// Proceed to upload the part.
+		var objPart ObjectPart
+		objPart, err = c.uploadPart(bucketName, objectName, uploadID, reader, partNumber,
+			nil, nil, prtSize, metadata)
+		if err != nil {
+			// Reset the temporary buffer upon any error.
+			tmpBuffer.Reset()
+			return totalUploadedSize, err
+		}
+
+		// Save successfully uploaded part metadata.
+		partsInfo[partNumber] = objPart
+
+		// Reset the temporary buffer.
+		tmpBuffer.Reset()
+
+		// Save successfully uploaded size.
+		totalUploadedSize += prtSize
+
+		// Increment part number.
+		partNumber++
+
+		// For unknown size, Read EOF we break away.
+		// We do not have to upload till totalPartsCount.
+		if size < 0 && rErr == io.EOF {
+			break
+		}
+	}
+
+	// Verify if we uploaded all the data.
+	if size > 0 {
+		if totalUploadedSize != size {
+			return totalUploadedSize, ErrUnexpectedEOF(totalUploadedSize, size, bucketName, objectName)
+		}
+	}
+
+	// Loop over total uploaded parts to save them in
+	// Parts array before completing the multipart request.
+	for i := 1; i < partNumber; i++ {
+		part, ok := partsInfo[i]
+		if !ok {
+			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
+		}
+		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
+			ETag:       part.ETag,
+			PartNumber: part.PartNumber,
+		})
+	}
+
+	// Sort all completed parts.
+	sort.Sort(completedParts(complMultipartUpload.Parts))
+	if _, err = c.completeMultipartUpload(bucketName, objectName, uploadID, complMultipartUpload); err != nil {
+		return totalUploadedSize, err
+	}
+
+	// Return final size.
+	return totalUploadedSize, nil
 }

--- a/api.go
+++ b/api.go
@@ -700,7 +700,10 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	case signerType.IsV2():
 		// Add signature version '2' authorization header.
 		req = s3signer.SignV2(*req, accessKeyID, secretAccessKey)
-	case signerType.IsStreamingV4() && method == "PUT":
+	case metadata.objectName != "" && method == "PUT" && metadata.customHeader.Get("X-Amz-Copy-Source") == "" && !c.secure:
+		// Streaming signature is used by default for a PUT object request. Additionally we also
+		// look if the initialized client is secure, if yes then we don't need to perform
+		// streaming signature.
 		req = s3signer.StreamingSignV4(req, accessKeyID,
 			secretAccessKey, sessionToken, location, metadata.contentLength, time.Now().UTC())
 	default:

--- a/core_test.go
+++ b/core_test.go
@@ -419,11 +419,6 @@ func TestCorePutObject(t *testing.T) {
 		t.Fatal("Error expected: nil, got: ", err)
 	}
 
-	objInfo, err = c.PutObject(bucketName, objectName, int64(len(buf)), bytes.NewReader(buf), nil, sum256(nil), metadata)
-	if err == nil {
-		t.Fatal("Error expected: nil, got: ", err)
-	}
-
 	objInfo, err = c.PutObject(bucketName, objectName, int64(len(buf)), bytes.NewReader(buf), nil, nil, metadata)
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)


### PR DESCRIPTION
Currently we used to fall back and use non-streaming
version but we can instead just use the streaming
version instead.

Does not fix any apparent bug, but it just allows
for avoiding any checksum calculation for large buffers.