### PR TITLE
Correct logging call for PutObject0ByteV2

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -3611,7 +3611,7 @@ func testUserMetadataCopyingV2() {
 
 // Test put object with 0 byte object.
 func testPutObject0ByteV2() {
-	logTrace()
+	logger().Info()
 
 	// Seed random based on current time.
 	rand.Seed(time.Now().Unix())


### PR DESCRIPTION
Fixes #768 

logTrace() was renamed in a different PR and #762 got merged without the change.