### PR TITLE
Send logger output to stdout by default for functional tests

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4140,6 +4140,8 @@ func logger() *logrus.Entry {
 }
 
 func main() {
+	// Output to stdout instead of the default stderr
+	log.SetOutput(os.Stdout)
 	logger().Info("Running functional tests for minio-go sdk....")
 	if !isQuickMode() {
 		testMakeBucketErrorV2()


### PR DESCRIPTION
Logrus uses stderr as default output destination. Instead need to set output writer as stdout so that Mint doesn't switch output and error logs.