### PR TITLE
fix: Extract region from s3-<region>.amazonaws.com

### DIFF
--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -164,6 +164,50 @@ func TestGetReaderSize(t *testing.T) {
 	}
 }
 
+// Tests get region from host URL.
+func TestGetRegionFromURL(t *testing.T) {
+	testCases := []struct {
+		u              url.URL
+		expectedRegion string
+	}{
+		{
+			u:              url.URL{Host: "storage.googleapis.com"},
+			expectedRegion: "",
+		},
+		{
+			u:              url.URL{Host: "s3.cn-north-1.amazonaws.com.cn"},
+			expectedRegion: "cn-north-1",
+		},
+		{
+			u:              url.URL{Host: "s3-fips-us-gov-west-1.amazonaws.com"},
+			expectedRegion: "us-gov-west-1",
+		},
+		{
+			u:              url.URL{Host: "s3-us-gov-west-1.amazonaws.com"},
+			expectedRegion: "us-gov-west-1",
+		},
+		{
+			u:              url.URL{Host: "192.168.1.1"},
+			expectedRegion: "",
+		},
+		{
+			u:              url.URL{Host: "s3-eu-west-1.amazonaws.com"},
+			expectedRegion: "eu-west-1",
+		},
+		{
+			u:              url.URL{Host: "s3.amazonaws.com"},
+			expectedRegion: "",
+		},
+	}
+
+	for i, testCase := range testCases {
+		region := getRegionFromURL(testCase.u)
+		if testCase.expectedRegion != region {
+			t.Errorf("Test %d: Expected region %s, got %s", i+1, testCase.expectedRegion, region)
+		}
+	}
+}
+
 // Tests valid hosts for location.
 func TestValidBucketLocation(t *testing.T) {
 	s3Hosts := []struct {

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -91,20 +91,6 @@ func (c Client) getBucketLocation(bucketName string) (string, error) {
 		return c.region, nil
 	}
 
-	if s3utils.IsAmazonChinaEndpoint(c.endpointURL) {
-		// For china specifically we need to set everything to
-		// cn-north-1 for now, there is no easier way until AWS S3
-		// provides a cleaner compatible API across "us-east-1" and
-		// China region.
-		return "cn-north-1", nil
-	} else if s3utils.IsAmazonGovCloudEndpoint(c.endpointURL) {
-		// For us-gov specifically we need to set everything to
-		// us-gov-west-1 for now, there is no easier way until AWS S3
-		// provides a cleaner compatible API across "us-east-1" and
-		// Gov cloud region.
-		return "us-gov-west-1", nil
-	}
-
 	if location, ok := c.bucketLocCache.Get(bucketName); ok {
 		return location, nil
 	}

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -80,6 +80,9 @@ func IsVirtualHostSupported(endpointURL url.URL, bucketName string) bool {
 	return IsAmazonEndpoint(endpointURL) || IsGoogleEndpoint(endpointURL)
 }
 
+// AmazonS3Host - regular expression used to determine if an arg is s3 host.
+var AmazonS3Host = regexp.MustCompile("^s3[.-]?(.*?)\\.amazonaws\\.com$")
+
 // IsAmazonEndpoint - Match if it is exactly Amazon S3 endpoint.
 func IsAmazonEndpoint(endpointURL url.URL) bool {
 	if IsAmazonChinaEndpoint(endpointURL) {
@@ -88,7 +91,7 @@ func IsAmazonEndpoint(endpointURL url.URL) bool {
 	if IsAmazonGovCloudEndpoint(endpointURL) {
 		return true
 	}
-	return endpointURL.Host == "s3.amazonaws.com"
+	return AmazonS3Host.MatchString(endpointURL.Host)
 }
 
 // IsAmazonGovCloudEndpoint - Match if it is exactly Amazon S3 GovCloud endpoint.


### PR DESCRIPTION
This PR fixes a behavior problem on our end when URLs
like `s3-<region>` are allowed we should use the region
name automatically otherwise calls like GetBucketLocation()
would fail by defaulting to `us-east-1`.

Fixes #785