### PR TITLE
fix: Mutating variables within go closures should be explicit.

### DIFF
--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -153,7 +153,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(bucketName, objectName string
 
 	// Receive each part number from the channel allowing three parallel uploads.
 	for w := 1; w <= totalWorkers; w++ {
-		go func() {
+		go func(partSize int64) {
 			// Each worker will draw from the part channel and upload in parallel.
 			for uploadReq := range uploadPartsCh {
 
@@ -197,7 +197,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(bucketName, objectName string
 					Error:   nil,
 				}
 			}
-		}()
+		}(partSize)
 	}
 
 	// Gather the responses as they occur and update any


### PR DESCRIPTION
partSize, a variable on the stack, changes over the course of
uploading multiple objects. This was being used in a function
closure as a go-routine. The variables used in the closure
depend on their values the time of evaluation providing inconsistent
behavior. It is racy to depend on values of variables on stack
at the end of function, when go-routines are executed.

Fixes #784