### PR TITLE
Allow number of workers used for multipart operation to be configurable

### DIFF
--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -152,7 +152,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(bucketName, objectName string
 	close(uploadPartsCh)
 
 	// Receive each part number from the channel allowing three parallel uploads.
-	for w := 1; w <= totalWorkers; w++ {
+	for w := 1; w <= c.NumParallelWorkers; w++ {
 		go func(partSize int64) {
 			// Each worker will draw from the part channel and upload in parallel.
 			for uploadReq := range uploadPartsCh {

--- a/api.go
+++ b/api.go
@@ -82,6 +82,9 @@ type Client struct {
 
 	// Random seed.
 	random *rand.Rand
+
+	// Total number of parallel workers used for multipart operation.
+	NumParallelWorkers int
 }
 
 // Global constants.
@@ -252,6 +255,8 @@ func privateNew(endpoint string, creds *credentials.Credentials, secure bool, re
 	// Introduce a new locked random seed.
 	clnt.random = rand.New(&lockedRandSource{src: rand.NewSource(time.Now().UTC().UnixNano())})
 
+	// Default Total number of parallel workers used for multipart operation.
+	clnt.NumParallelWorkers = 3
 	// Return.
 	return clnt, nil
 }

--- a/constants.go
+++ b/constants.go
@@ -49,9 +49,6 @@ const maxMultipartPutObjectSize = 1024 * 1024 * 1024 * 1024 * 5
 // we don't want to sign the request payload
 const unsignedPayload = "UNSIGNED-PAYLOAD"
 
-// Total number of parallel workers used for multipart operation.
-var totalWorkers = 3
-
 // Signature related constants.
 const (
 	signV4Algorithm   = "AWS4-HMAC-SHA256"


### PR DESCRIPTION
Fixes #759.

Currently, total number of parallel workers is set as constant at 3. With this PR, it is exposed as a public variable that can be configured so that user can configure number of parallel workers for streaming put operations.