### PR TITLE
fix examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ func main() {
 	}
 
 	log.Printf("%#v\n", minioClient) // minioClient is now setup
+}
 ```
 
 ## Quick Start Example - File Uploader


### PR DESCRIPTION
The example in the README.md is missing a }.
This change adds it.

Fixes #814