### PR TITLE
Add PutEncryptedObject and FPutEncryptedObject calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ func main() {
 	contentType := "application/zip"
 
 	// Upload the zip file with FPutObject
-	n, err := minioClient.FPutObject(bucketName, objectName, filePath, &minio.PutObjectOptions{ContentType:contentType})
+	n, err := minioClient.FPutObject(bucketName, objectName, filePath, minio.PutObjectOptions{ContentType:contentType})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -431,7 +431,7 @@ func (c Client) ComposeObject(dst DestinationInfo, srcs []SourceInfo) error {
 	for k, v := range metaMap {
 		metaHeaders[k] = v
 	}
-	uploadID, err := c.newUploadID(ctx, dst.bucket, dst.object, &PutObjectOptions{UserMetadata: metaHeaders})
+	uploadID, err := c.newUploadID(ctx, dst.bucket, dst.object, PutObjectOptions{UserMetadata: metaHeaders})
 	if err != nil {
 		return fmt.Errorf("Error creating new upload: %v", err)
 	}

--- a/api-put-object-common.go
+++ b/api-put-object-common.go
@@ -78,7 +78,7 @@ func optimalPartInfo(objectSize int64) (totalPartsCount int, partSize int64, las
 
 // getUploadID - fetch upload id if already present for an object name
 // or initiate a new request to fetch a new upload id.
-func (c Client) newUploadID(ctx context.Context, bucketName, objectName string, opts *PutObjectOptions) (uploadID string, err error) {
+func (c Client) newUploadID(ctx context.Context, bucketName, objectName string, opts PutObjectOptions) (uploadID string, err error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return "", err

--- a/api-put-object-context.go
+++ b/api-put-object-context.go
@@ -23,11 +23,11 @@ import (
 
 // PutObjectWithContext - Identical to PutObject call, but accepts context to facilitate request cancellation.
 func (c Client) PutObjectWithContext(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64,
-	opts *PutObjectOptions) (n int64, err error) {
-	if opts == nil {
-		opts = &PutObjectOptions{}
+	opts PutObjectOptions) (n int64, err error) {
+	err = opts.validate()
+	if err != nil {
+		return 0, err
 	}
-
 	if opts.EncryptMaterials != nil {
 		if err = opts.EncryptMaterials.SetupEncryptMode(reader); err != nil {
 			return 0, err

--- a/api-put-object-encrypted.go
+++ b/api-put-object-encrypted.go
@@ -1,0 +1,43 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"context"
+	"io"
+
+	"github.com/minio/minio-go/pkg/encrypt"
+)
+
+// PutEncryptedObject - Encrypt and store object.
+func (c Client) PutEncryptedObject(bucketName, objectName string, reader io.Reader, encryptMaterials encrypt.Materials) (n int64, err error) {
+
+	if encryptMaterials == nil {
+		return 0, ErrInvalidArgument("Unable to recognize empty encryption properties")
+	}
+
+	if err := encryptMaterials.SetupEncryptMode(reader); err != nil {
+		return 0, err
+	}
+
+	return c.PutObjectWithContext(context.Background(), bucketName, objectName, reader, -1, PutObjectOptions{EncryptMaterials: encryptMaterials})
+}
+
+// FPutEncryptedObject - Encrypt and store an object with contents from file at filePath.
+func (c Client) FPutEncryptedObject(bucketName, objectName, filePath string, encryptMaterials encrypt.Materials) (n int64, err error) {
+	return c.FPutObjectWithContext(context.Background(), bucketName, objectName, filePath, PutObjectOptions{EncryptMaterials: encryptMaterials})
+}

--- a/api-put-object-file-context.go
+++ b/api-put-object-file-context.go
@@ -26,7 +26,7 @@ import (
 )
 
 // FPutObjectWithContext - Create an object in a bucket, with contents from file at filePath. Allows request cancellation.
-func (c Client) FPutObjectWithContext(ctx context.Context, bucketName, objectName, filePath string, opts *PutObjectOptions) (n int64, err error) {
+func (c Client) FPutObjectWithContext(ctx context.Context, bucketName, objectName, filePath string, opts PutObjectOptions) (n int64, err error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -52,9 +52,6 @@ func (c Client) FPutObjectWithContext(ctx context.Context, bucketName, objectNam
 	// Save the file size.
 	fileSize := fileStat.Size()
 
-	if opts == nil {
-		opts = &PutObjectOptions{}
-	}
 	// Set contentType based on filepath extension if not given or default
 	// value of "application/octet-stream" if the extension has no associated type.
 	if opts.ContentType == "" {

--- a/api-put-object-file.go
+++ b/api-put-object-file.go
@@ -21,6 +21,6 @@ import (
 )
 
 // FPutObject - Create an object in a bucket, with contents from file at filePath
-func (c Client) FPutObject(bucketName, objectName, filePath string, opts *PutObjectOptions) (n int64, err error) {
+func (c Client) FPutObject(bucketName, objectName, filePath string, opts PutObjectOptions) (n int64, err error) {
 	return c.FPutObjectWithContext(context.Background(), bucketName, objectName, filePath, opts)
 }

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -34,7 +34,7 @@ import (
 )
 
 func (c Client) putObjectMultipart(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64,
-	opts *PutObjectOptions) (n int64, err error) {
+	opts PutObjectOptions) (n int64, err error) {
 	n, err = c.putObjectMultipartNoStream(ctx, bucketName, objectName, reader, opts)
 	if err != nil {
 		errResp := ToErrorResponse(err)
@@ -52,7 +52,7 @@ func (c Client) putObjectMultipart(ctx context.Context, bucketName, objectName s
 	return n, err
 }
 
-func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, objectName string, reader io.Reader, opts *PutObjectOptions) (n int64, err error) {
+func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, objectName string, reader io.Reader, opts PutObjectOptions) (n int64, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -168,7 +168,7 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 }
 
 // initiateMultipartUpload - Initiates a multipart upload and returns an upload ID.
-func (c Client) initiateMultipartUpload(ctx context.Context, bucketName, objectName string, opts *PutObjectOptions) (initiateMultipartUploadResult, error) {
+func (c Client) initiateMultipartUpload(ctx context.Context, bucketName, objectName string, opts PutObjectOptions) (initiateMultipartUploadResult, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return initiateMultipartUploadResult{}, err
@@ -182,7 +182,7 @@ func (c Client) initiateMultipartUpload(ctx context.Context, bucketName, objectN
 	urlValues.Set("uploads", "")
 
 	// Set ContentType header.
-	customHeader := opts.getMetadata()
+	customHeader := opts.Header()
 
 	reqMetadata := requestMetadata{
 		bucketName:   bucketName,

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -38,7 +38,7 @@ import (
 //  - Any reader which has a method 'ReadAt()'
 //
 func (c Client) putObjectMultipartStream(ctx context.Context, bucketName, objectName string,
-	reader io.Reader, size int64, opts *PutObjectOptions) (n int64, err error) {
+	reader io.Reader, size int64, opts PutObjectOptions) (n int64, err error) {
 
 	// Verify if reader is *minio.Object, *os.File or io.ReaderAt.
 	// NOTE: Verification of object is kept for a specific purpose
@@ -91,7 +91,7 @@ type uploadPartReq struct {
 // cleaned automatically when the caller i.e http client closes the
 // stream after uploading all the contents successfully.
 func (c Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketName, objectName string,
-	reader io.ReaderAt, size int64, opts *PutObjectOptions) (n int64, err error) {
+	reader io.ReaderAt, size int64, opts PutObjectOptions) (n int64, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -234,7 +234,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketNa
 }
 
 func (c Client) putObjectMultipartStreamNoChecksum(ctx context.Context, bucketName, objectName string,
-	reader io.Reader, size int64, opts *PutObjectOptions) (n int64, err error) {
+	reader io.Reader, size int64, opts PutObjectOptions) (n int64, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -332,7 +332,7 @@ func (c Client) putObjectMultipartStreamNoChecksum(ctx context.Context, bucketNa
 
 // putObjectNoChecksum special function used Google Cloud Storage. This special function
 // is used for Google Cloud Storage since Google's multipart API is not S3 compatible.
-func (c Client) putObjectNoChecksum(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64, opts *PutObjectOptions) (n int64, err error) {
+func (c Client) putObjectNoChecksum(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64, opts PutObjectOptions) (n int64, err error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -370,7 +370,7 @@ func (c Client) putObjectNoChecksum(ctx context.Context, bucketName, objectName 
 
 // putObjectDo - executes the put object http operation.
 // NOTE: You must have WRITE permissions on a bucket to add an object to it.
-func (c Client) putObjectDo(ctx context.Context, bucketName, objectName string, reader io.Reader, md5Sum []byte, sha256Sum []byte, size int64, opts *PutObjectOptions) (ObjectInfo, error) {
+func (c Client) putObjectDo(ctx context.Context, bucketName, objectName string, reader io.Reader, md5Sum []byte, sha256Sum []byte, size int64, opts PutObjectOptions) (ObjectInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return ObjectInfo{}, err
@@ -379,7 +379,7 @@ func (c Client) putObjectDo(ctx context.Context, bucketName, objectName string, 
 		return ObjectInfo{}, err
 	}
 	// Set headers.
-	customHeader := opts.getMetadata()
+	customHeader := opts.Header()
 
 	// Populate request metadata.
 	reqMetadata := requestMetadata{

--- a/api-put-object_test.go
+++ b/api-put-object_test.go
@@ -1,0 +1,52 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package minio
+
+import (
+	"testing"
+)
+
+func TestPutObjectOptionsValidate(t *testing.T) {
+	testCases := []struct {
+		metadata   map[string]string
+		shouldPass bool
+	}{
+		{map[string]string{"Content-Type": "custom/content-type"}, false},
+		{map[string]string{"content-type": "custom/content-type"}, false},
+		{map[string]string{"Content-Encoding": "gzip"}, false},
+		{map[string]string{"Cache-Control": "blah"}, false},
+		{map[string]string{"Content-Disposition": "something"}, false},
+		{map[string]string{"my-custom-header": "blah"}, true},
+		{map[string]string{"X-Amz-Iv": "blah"}, false},
+		{map[string]string{"X-Amz-Key": "blah"}, false},
+		{map[string]string{"X-Amz-Key-prefixed-header": "blah"}, false},
+		{map[string]string{"custom-X-Amz-Key-middle": "blah"}, true},
+		{map[string]string{"my-custom-header-X-Amz-Key": "blah"}, true},
+		{map[string]string{"X-Amz-Matdesc": "blah"}, false},
+		{map[string]string{"blah-X-Amz-Matdesc": "blah"}, true},
+		{map[string]string{"X-Amz-MatDesc-suffix": "blah"}, true},
+		{map[string]string{"x-amz-meta-X-Amz-Iv": "blah"}, false},
+		{map[string]string{"x-amz-meta-X-Amz-Key": "blah"}, false},
+		{map[string]string{"x-amz-meta-X-Amz-Matdesc": "blah"}, false},
+	}
+	for i, testCase := range testCases {
+		err := PutObjectOptions{UserMetadata: testCase.metadata}.validate()
+
+		if testCase.shouldPass && err != nil {
+			t.Errorf("Test %d - output did not match with reference results", i+1)
+		}
+	}
+}

--- a/core.go
+++ b/core.go
@@ -55,11 +55,11 @@ func (c Core) ListObjectsV2(bucketName, objectPrefix, continuationToken string, 
 
 // PutObject - Upload object. Uploads using single PUT call.
 func (c Core) PutObject(bucket, object string, data io.Reader, size int64, md5Sum, sha256Sum []byte, metadata map[string]string) (ObjectInfo, error) {
-	return c.putObjectDo(context.Background(), bucket, object, data, md5Sum, sha256Sum, size, &PutObjectOptions{UserMetadata: metadata})
+	return c.putObjectDo(context.Background(), bucket, object, data, md5Sum, sha256Sum, size, PutObjectOptions{UserMetadata: metadata})
 }
 
 // NewMultipartUpload - Initiates new multipart upload and returns the new uploadID.
-func (c Core) NewMultipartUpload(bucket, object string, opts *PutObjectOptions) (uploadID string, err error) {
+func (c Core) NewMultipartUpload(bucket, object string, opts PutObjectOptions) (uploadID string, err error) {
 	result, err := c.initiateMultipartUpload(context.Background(), bucket, object, opts)
 	return result.UploadID, err
 }

--- a/core_test.go
+++ b/core_test.go
@@ -103,7 +103,7 @@ func TestGetObjectCore(t *testing.T) {
 
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
-	n, err := c.Client.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), &PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.Client.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
@@ -275,12 +275,10 @@ func TestGetObjectContentEncoding(t *testing.T) {
 
 	// Generate data more than 32K
 	buf := bytes.Repeat([]byte("3"), rand.Intn(1<<20)+32*1024)
-	m := make(map[string]string)
-	m["Content-Encoding"] = "gzip"
 
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
-	n, err := c.Client.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), &PutObjectOptions{UserMetadata: m, Progress: nil})
+	n, err := c.Client.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), PutObjectOptions{Progress: nil, ContentEncoding: "gzip"})
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}

--- a/docs/API.md
+++ b/docs/API.md
@@ -57,7 +57,7 @@ func main() {
 | [`BucketExists`](#BucketExists)                   | [`CopyObject`](#CopyObject)                         | [`GetEncryptedObject`](#GetEncryptedObject) | [`PresignedPostPolicy`](#PresignedPostPolicy) | [`ListBucketPolicies`](#ListBucketPolicies)                   | [`TraceOn`](#TraceOn)                                 |
 | [`RemoveBucket`](#RemoveBucket)                   | [`StatObject`](#StatObject)                         | [`PutEncryptedObject`](#PutEncryptedObject) |                                               | [`SetBucketNotification`](#SetBucketNotification)             | [`TraceOff`](#TraceOff)                               |
 | [`ListObjects`](#ListObjects)                     | [`RemoveObject`](#RemoveObject)                     | [`NewSSEInfo`](#NewSSEInfo)               |                                               | [`GetBucketNotification`](#GetBucketNotification)             | [`SetS3TransferAccelerate`](#SetS3TransferAccelerate) |
-| [`ListObjectsV2`](#ListObjectsV2)                 | [`RemoveObjects`](#RemoveObjects)                   |    |                                               | [`RemoveAllBucketNotification`](#RemoveAllBucketNotification) |                                                       |
+| [`ListObjectsV2`](#ListObjectsV2)                 | [`RemoveObjects`](#RemoveObjects)                   | [`FPutEncryptedObject`](#FPutEncryptedObject)    |                                               | [`RemoveAllBucketNotification`](#RemoveAllBucketNotification) |                                                       |
 | [`ListIncompleteUploads`](#ListIncompleteUploads) | [`RemoveIncompleteUpload`](#RemoveIncompleteUpload) |                                             |                                               | [`ListenBucketNotification`](#ListenBucketNotification)       |                                                       |
 |                                                   | [`FPutObject`](#FPutObject)                         |                                             |                                               |                                                               |                                                       |
 |                                                   | [`FGetObject`](#FGetObject)                         |                                             |                                               |                                                               |                                                       |
@@ -512,7 +512,7 @@ if err != nil {
 ```
 
 <a name="PutObject"></a>
-### PutObject(bucketName, objectName string, reader io.Reader, objectSize int64,opts *PutObjectOptions) (n int, err error)
+### PutObject(bucketName, objectName string, reader io.Reader, objectSize int64,opts PutObjectOptions) (n int, err error)
 
 Uploads objects that are less than 64MiB in a single PUT operation. For objects that are greater than 64MiB in size, PutObject seamlessly uploads the object as parts of 64MiB or more depending on the actual file size. The max upload size for an object is 5TB.
 
@@ -525,7 +525,7 @@ __Parameters__
 |`objectName` | _string_  |Name of the object   |
 |`reader` | _io.Reader_  |Any Go type that implements io.Reader |
 |`objectSize`| _int64_ |Size of the object being uploaded. Pass -1 if stream size is unknown |
-|`opts` | _*PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation. |
+|`opts` | _PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation. |
 
 
 __Example__
@@ -544,7 +544,7 @@ if err != nil {
     fmt.Println(err)
     return
 }
-n, err := minioClient.PutObject("mybucket", "myobject", file, fileStat.Size(), &PutObjectOptions{ContentType:"application/octet-stream"})
+n, err := minioClient.PutObject("mybucket", "myobject", file, fileStat.Size(), PutObjectOptions{ContentType:"application/octet-stream"})
 if err != nil {
     fmt.Println(err)
     return
@@ -553,7 +553,7 @@ if err != nil {
 API methods PutObjectWithSize, PutObjectWithMetadata, PutObjectStreaming, and PutObjectWithProgress available in minio-go SDK release v3.0.2 are replaced by the new PutObject call variant that accepts a pointer to PutObjectOptions struct.
 
 <a name="PutObjectWithContext"></a>
-### PutObjectWithContext(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64, opts *PutObjectOptions) (n int, err error)
+### PutObjectWithContext(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64, opts PutObjectOptions) (n int, err error)
 
 Identical to PutObject operation, but allows request cancellation.
 
@@ -567,7 +567,7 @@ __Parameters__
 |`objectName` | _string_  |Name of the object   |
 |`reader` | _io.Reader_  |Any Go type that implements io.Reader |
 |`objectSize`| _int64_ | size of the object being uploaded. Pass -1 if stream size is unknown |
-|`opts` | _*PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation. |
+|`opts` | _PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation. |
 
 
 
@@ -590,7 +590,7 @@ if err != nil {
     fmt.Println(err)
     return
 }
-n, err := minioClient.PutObjectWithContext(ctx, "mybucket", "myobject", file, fileStat.Size(), &PutObjectOptions{ContentType:"application/octet-stream"})
+n, err := minioClient.PutObjectWithContext(ctx, "mybucket", "myobject", file, fileStat.Size(), PutObjectOptions{ContentType:"application/octet-stream"})
 if err != nil {
     fmt.Println(err)
     return
@@ -774,7 +774,7 @@ dst, err := NewDecryptionInfo("bucket", "object", encKey, nil)
 
 
 <a name="FPutObject"></a>
-### FPutObject(bucketName, objectName, filePath, opts *PutObjectOptions) (length int64, err error)
+### FPutObject(bucketName, objectName, filePath, opts PutObjectOptions) (length int64, err error)
 
 Uploads contents from a file to objectName.
 
@@ -789,21 +789,21 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket  |
 |`objectName` | _string_  |Name of the object |
 |`filePath` | _string_  |Path to file to be uploaded |
-|`opts` | _*PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation.  |
+|`opts` | _PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation.  |
 
 
 __Example__
 
 
 ```go
-n, err := minioClient.FPutObject("mybucket", "myobject.csv", "/tmp/otherobject.csv", &PutObjectOptions{ContentType:"application/csv"})
+n, err := minioClient.FPutObject("mybucket", "myobject.csv", "/tmp/otherobject.csv", PutObjectOptions{ContentType:"application/csv"})
 if err != nil {
     fmt.Println(err)
     return
 }
 ```
 <a name="FPutObjectWithContext"></a>
-### FPutObjectWithContext(ctx context.Context, bucketName, objectName, filePath, opts *PutObjectOptions) (length int64, err error)
+### FPutObjectWithContext(ctx context.Context, bucketName, objectName, filePath, opts PutObjectOptions) (length int64, err error)
 
 Identical to FPutObject operation, but allows request cancellation.
 
@@ -816,7 +816,7 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket  |
 |`objectName` | _string_  |Name of the object |
 |`filePath` | _string_  |Path to file to be uploaded |
-|`opts` | _*PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation. |
+|`opts` | _PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation. |
 
 __Example__
 
@@ -824,7 +824,7 @@ __Example__
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 100 * time.Seconds)
 defer cancel()
-n, err := minioClient.FPutObjectWithContext(ctx, "mybucket", "myobject.csv", "/tmp/otherobject.csv", &PutObjectOptions{ContentType:"application/csv"})
+n, err := minioClient.FPutObjectWithContext(ctx, "mybucket", "myobject.csv", "/tmp/otherobject.csv", PutObjectOptions{ContentType:"application/csv"})
 if err != nil {
     fmt.Println(err)
     return
@@ -1065,10 +1065,8 @@ if _, err = io.Copy(localFile, object); err != nil {
 
 <a name="PutEncryptedObject"></a>
 
-### PutObject(bucketName, objectName string, reader io.Reader, objectSize int64, opts *PutObjectOptions) (n int, err error)
-
+### PutEncryptedObject(bucketName, objectName string, reader io.Reader, encryptMaterials minio.EncryptionMaterials) (n int, err error)
 Encrypt and upload an object.
-
 
 __Parameters__
 
@@ -1077,9 +1075,7 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket  |
 |`objectName` | _string_  |Name of the object   |
 |`reader` | _io.Reader_  |Any Go type that implements io.Reader |
-|`objectSize`| _int64_ | size of the object being uploaded. Pass -1 if stream size is unknown |
-|`opts` | _*PutObjectOptions_  |Pointer to struct that allows user to set optional custom metadata, content-type, content-encoding,content-disposition and cache-control headers, pass encryption module for encrypting objects, and optionally configure number of threads for multipart put operation. |
-
+|`encryptMaterials` | _minio.EncryptionMaterials_  | The module that encrypts data |
 
 __Example__
 
@@ -1116,24 +1112,61 @@ if err != nil {
 }
 defer file.Close()
 
-fileStat, err := fileReader.Stat()
-if err != nil {
-    log.Fatal(err)
-    return
-}
-opts := &PutObjectOptions{
-    EncryptMaterials: cbcMaterials,
-    Progress:nil,
-    UserMetadata: nil
-}
 // Upload the encrypted form of the file
-n, err := minioClient.PutObject("mybucket", "myobject", file, fileStat.Size(), opts)
+n, err := minioClient.PutEncryptedObject("mybucket", "myobject", file, encryptMaterials)
 if err != nil {
     fmt.Println(err)
     return
 }
 ```
+<a name="FPutEncryptedObject"></a>
+### FPutEncryptedObject(bucketName, objectName, filePath, encryptMaterials minio.EncryptionMaterials) (n int, err error)
 
+Encrypt and upload an object from a file.
+
+__Parameters__
+
+
+|Param   |Type   |Description   |
+|:---|:---| :---|
+|`bucketName`  | _string_  |Name of the bucket  |
+|`objectName` | _string_  |Name of the object |
+|`filePath` | _string_  |Path to file to be uploaded |
+|`encryptMaterials` | _minio.EncryptionMaterials_  | The module that encrypts data |
+
+__Example__
+
+
+```go
+// Load a private key
+privateKey, err := ioutil.ReadFile("private.key")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Load a public key
+publicKey, err := ioutil.ReadFile("public.key")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Build an asymmetric key
+key, err := NewAssymetricKey(privateKey, publicKey)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Build the CBC encryption module
+cbcMaterials, err := NewCBCSecureMaterials(key)
+if err != nil {
+    log.Fatal(err)
+}
+n, err := minioClient.FPutEncryptedObject("mybucket", "myobject.csv", "/tmp/otherobject.csv", cbcMaterials)
+if err != nil {
+    fmt.Println(err)
+    return
+}
+```
 <a name="NewSSEInfo"></a>
 
 ### NewSSEInfo(key []byte, algo string) SSEInfo

--- a/examples/s3/fputencrypted-object.go
+++ b/examples/s3/fputencrypted-object.go
@@ -1,7 +1,7 @@
 // +build ignore
 
 /*
- * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015 Minio, Inc.
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/encrypt"
@@ -40,12 +39,8 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Open a local file that we will upload
-	file, err := os.Open("my-testfile")
-	if err != nil {
-		log.Fatalln(err)
-	}
-	defer file.Close()
+	// Specify a local file that we will upload
+	filePath := "my-testfile"
 
 	//// Build an asymmetric key from private and public files
 	//
@@ -75,7 +70,7 @@ func main() {
 	}
 
 	// Encrypt file content and upload to the server
-	n, err := s3Client.PutEncryptedObject("my-bucketname", "my-objectname", file, cbcMaterials)
+	n, err := s3Client.FPutEncryptedObject("my-bucketname", "my-objectname", filePath, cbcMaterials)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/fputobject-context.go
+++ b/examples/s3/fputobject-context.go
@@ -45,7 +45,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	if _, err := s3Client.FPutObjectWithContext(ctx, "my-bucketname", "my-objectname", "my-filename.csv", &minio.PutObjectOptions{ContentType: "application/csv"}); err != nil {
+	if _, err := s3Client.FPutObjectWithContext(ctx, "my-bucketname", "my-objectname", "my-filename.csv", minio.PutObjectOptions{ContentType: "application/csv"}); err != nil {
 		log.Fatalln(err)
 	}
 	log.Println("Successfully uploaded my-filename.csv")

--- a/examples/s3/fputobject.go
+++ b/examples/s3/fputobject.go
@@ -38,7 +38,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	if _, err := s3Client.FPutObject("my-bucketname", "my-objectname", "my-filename.csv", &minio.PutObjectOptions{ContentType: "application/csv"}); err != nil {
+	if _, err := s3Client.FPutObject("my-bucketname", "my-objectname", "my-filename.csv", minio.PutObjectOptions{ContentType: "application/csv"}); err != nil {
 		log.Fatalln(err)
 	}
 	log.Println("Successfully uploaded my-filename.csv")

--- a/examples/s3/putobject-context.go
+++ b/examples/s3/putobject-context.go
@@ -57,7 +57,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	n, err := s3Client.PutObjectWithContext(ctx, "my-bucketname", "my-objectname", object, objectStat.Size(), &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	n, err := s3Client.PutObjectWithContext(ctx, "my-bucketname", "my-objectname", object, objectStat.Size(), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/putobject-getobject-sse.go
+++ b/examples/s3/putobject-getobject-sse.go
@@ -61,7 +61,7 @@ func main() {
 	}
 
 	// minioClient.TraceOn(os.Stderr) // Enable to debug.
-	_, err = minioClient.PutObject("mybucket", "my-encrypted-object.txt", content, 11, &minio.PutObjectOptions{UserMetadata: metadata})
+	_, err = minioClient.PutObject("mybucket", "my-encrypted-object.txt", content, 11, minio.PutObjectOptions{UserMetadata: metadata})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/putobject-progress.go
+++ b/examples/s3/putobject-progress.go
@@ -54,7 +54,7 @@ func main() {
 	// the Reads inside.
 	progress := pb.New64(objectInfo.Size)
 	progress.Start()
-	n, err := s3Client.PutObject("my-bucketname", "my-objectname-progress", reader, objectInfo.Size, &minio.PutObjectOptions{ContentType: "application/octet-stream", Progress: progress})
+	n, err := s3Client.PutObject("my-bucketname", "my-objectname-progress", reader, objectInfo.Size, minio.PutObjectOptions{ContentType: "application/octet-stream", Progress: progress})
 
 	if err != nil {
 		log.Fatalln(err)

--- a/examples/s3/putobject-s3-accelerate.go
+++ b/examples/s3/putobject-s3-accelerate.go
@@ -53,7 +53,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	n, err := s3Client.PutObject("my-bucketname", "my-objectname", object, objectStat.Size(), &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	n, err := s3Client.PutObject("my-bucketname", "my-objectname", object, objectStat.Size(), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/putobject-streaming.go
+++ b/examples/s3/putobject-streaming.go
@@ -45,7 +45,7 @@ func main() {
 	}
 	defer object.Close()
 
-	n, err := s3Client.PutObject("my-bucketname", "my-objectname", object, -1, &minio.PutObjectOptions{})
+	n, err := s3Client.PutObject("my-bucketname", "my-objectname", object, -1, minio.PutObjectOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/putobject.go
+++ b/examples/s3/putobject.go
@@ -49,7 +49,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	n, err := s3Client.PutObject("my-bucketname", "my-objectname", object, objectStat.Size(), &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	n, err := s3Client.PutObject("my-bucketname", "my-objectname", object, objectStat.Size(), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -303,7 +303,7 @@ func testMetadataSizeLimit() {
 	metadata["X-Amz-Meta-Mint-Test"] = string(bytes.Repeat([]byte("m"), 1+UserMetadataLimit-len("X-Amz-Meta-Mint-Test")))
 	args["metadata"] = fmt.Sprint(metadata)
 
-	_, err = c.PutObject(bucketName, objectName, bytes.NewReader(nil), 0, &minio.PutObjectOptions{UserMetadata: metadata})
+	_, err = c.PutObject(bucketName, objectName, bytes.NewReader(nil), 0, minio.PutObjectOptions{UserMetadata: metadata})
 	if err == nil {
 		failureLog(function, args, startTime, "", "Created object with user-defined metadata exceeding metadata size limits", nil).Fatal()
 	}
@@ -312,7 +312,7 @@ func testMetadataSizeLimit() {
 	metadata = make(map[string]string)
 	metadata["X-Amz-Mint-Test"] = string(bytes.Repeat([]byte("m"), 1+HeaderSizeLimit-len("X-Amz-Mint-Test")))
 	args["metadata"] = fmt.Sprint(metadata)
-	_, err = c.PutObject(bucketName, objectName, bytes.NewReader(nil), 0, &minio.PutObjectOptions{UserMetadata: metadata})
+	_, err = c.PutObject(bucketName, objectName, bytes.NewReader(nil), 0, minio.PutObjectOptions{UserMetadata: metadata})
 	if err == nil {
 		failureLog(function, args, startTime, "", "Created object with headers exceeding header size limits", nil).Fatal()
 	}
@@ -441,7 +441,7 @@ func testPutObjectReadAt() {
 	objectContentType := "binary/octet-stream"
 	args["objectContentType"] = objectContentType
 
-	n, err := c.PutObject(bucketName, objectName, reader, int64(sixtyFiveMiB), &minio.PutObjectOptions{ContentType: objectContentType})
+	n, err := c.PutObject(bucketName, objectName, reader, int64(sixtyFiveMiB), minio.PutObjectOptions{ContentType: objectContentType})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -494,7 +494,7 @@ func testPutObjectWithMetadata() {
 	args := map[string]interface{}{
 		"bucketName": "",
 		"objectName": "",
-		"opts":       "&minio.PutObjectOptions{UserMetadata: metadata, Progress: progress}",
+		"opts":       "minio.PutObjectOptions{UserMetadata: metadata, Progress: progress}",
 	}
 
 	if isQuickMode() {
@@ -548,7 +548,7 @@ func testPutObjectWithMetadata() {
 		"Content-Type": {customContentType},
 	}
 
-	n, err := c.PutObject(bucketName, objectName, reader, int64(sixtyFiveMiB), &minio.PutObjectOptions{
+	n, err := c.PutObject(bucketName, objectName, reader, int64(sixtyFiveMiB), minio.PutObjectOptions{
 		ContentType: customContentType})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
@@ -640,7 +640,7 @@ func testPutObjectStreaming() {
 
 	for _, size := range sizes {
 		data := bytes.Repeat([]byte("a"), int(size))
-		n, err := c.PutObject(bucketName, objectName, bytes.NewReader(data), int64(size), nil)
+		n, err := c.PutObject(bucketName, objectName, bytes.NewReader(data), int64(size), minio.PutObjectOptions{})
 		if err != nil {
 			failureLog(function, args, startTime, "", "PutObjectStreaming failed", err).Fatal()
 		}
@@ -724,7 +724,7 @@ func testListPartiallyUploaded() {
 	objectName := bucketName + "-resumable"
 	args["objectName"] = objectName
 
-	_, err = c.PutObject(bucketName, objectName, reader, int64(sixtyFiveMiB*2), &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	_, err = c.PutObject(bucketName, objectName, reader, int64(sixtyFiveMiB*2), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err == nil {
 		failureLog(function, args, startTime, "", "PutObject should fail", err).Fatal()
 	}
@@ -804,7 +804,7 @@ func testGetObjectSeekEnd() {
 		failureLog(function, args, startTime, "", "ReadAll failed", err).Fatal()
 	}
 
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -909,7 +909,7 @@ func testGetObjectClosedTwice() {
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 	args["objectName"] = objectName
 
-	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -1001,7 +1001,7 @@ func testRemoveMultipleObjects() {
 		// Upload objects and send them to objectsCh
 		for i := 0; i < nrObjects; i++ {
 			objectName := "sample" + strconv.Itoa(i) + ".txt"
-			_, err = c.PutObject(bucketName, objectName, r, 8, &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+			_, err = c.PutObject(bucketName, objectName, r, 8, minio.PutObjectOptions{ContentType: "application/octet-stream"})
 			if err != nil {
 				failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 				continue
@@ -1088,7 +1088,7 @@ func testRemovePartiallyUploaded() {
 	objectName := bucketName + "-resumable"
 	args["objectName"] = objectName
 
-	_, err = c.PutObject(bucketName, objectName, reader, 128*1024, &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	_, err = c.PutObject(bucketName, objectName, reader, 128*1024, minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err == nil {
 		failureLog(function, args, startTime, "", "PutObject should fail", err).Fatal()
 	}
@@ -1177,7 +1177,7 @@ func testFPutObjectMultipart() {
 	args["objectContentType"] = objectContentType
 
 	// Perform standard FPutObject with contentType provided (Expecting application/octet-stream)
-	n, err := c.FPutObject(bucketName, objectName, fileName, &minio.PutObjectOptions{ContentType: objectContentType})
+	n, err := c.FPutObject(bucketName, objectName, fileName, minio.PutObjectOptions{ContentType: objectContentType})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObject failed", err).Fatal()
 	}
@@ -1282,7 +1282,7 @@ func testFPutObject() {
 	args["objectName"] = objectName
 
 	// Perform standard FPutObject with contentType provided (Expecting application/octet-stream)
-	n, err := c.FPutObject(bucketName, objectName+"-standard", fName, &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	n, err := c.FPutObject(bucketName, objectName+"-standard", fName, minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObject failed", err).Fatal()
 	}
@@ -1291,7 +1291,7 @@ func testFPutObject() {
 	}
 
 	// Perform FPutObject with no contentType provided (Expecting application/octet-stream)
-	n, err = c.FPutObject(bucketName, objectName+"-Octet", fName, &minio.PutObjectOptions{})
+	n, err = c.FPutObject(bucketName, objectName+"-Octet", fName, minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "File close failed", err).Fatal()
 	}
@@ -1315,7 +1315,7 @@ func testFPutObject() {
 	}
 
 	// Perform FPutObject with no contentType provided (Expecting application/x-gtar)
-	n, err = c.FPutObject(bucketName, objectName+"-GTar", fName+".gtar", nil)
+	n, err = c.FPutObject(bucketName, objectName+"-GTar", fName+".gtar", minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObject failed", err).Fatal()
 	}
@@ -1446,14 +1446,14 @@ func testFPutObjectWithContext() {
 	defer cancel()
 
 	// Perform standard FPutObjectWithContext with contentType provided (Expecting application/octet-stream)
-	_, err = c.FPutObjectWithContext(ctx, bucketName, objectName+"-Shorttimeout", fName, &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	_, err = c.FPutObjectWithContext(ctx, bucketName, objectName+"-Shorttimeout", fName, minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err == nil {
 		failureLog(function, args, startTime, "", "Request context cancellation failed", err).Fatal()
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	// Perform FPutObjectWithContext with a long timeout. Expect the put object to succeed
-	n, err := c.FPutObjectWithContext(ctx, bucketName, objectName+"-Longtimeout", fName, nil)
+	n, err := c.FPutObjectWithContext(ctx, bucketName, objectName+"-Longtimeout", fName, minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObjectWithContext failed", err).Fatal()
 	}
@@ -1496,7 +1496,7 @@ func testFPutObjectWithContextV2() {
 	args := map[string]interface{}{
 		"bucketName": "",
 		"objectName": "",
-		"opts":       "&minio.PutObjectOptions{ContentType:objectContentType}",
+		"opts":       "minio.PutObjectOptions{ContentType:objectContentType}",
 	}
 	// Seed random based on current time.
 	rand.Seed(time.Now().Unix())
@@ -1560,14 +1560,14 @@ func testFPutObjectWithContextV2() {
 	defer cancel()
 
 	// Perform standard FPutObjectWithContext with contentType provided (Expecting application/octet-stream)
-	_, err = c.FPutObjectWithContext(ctx, bucketName, objectName+"-Shorttimeout", fName, &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	_, err = c.FPutObjectWithContext(ctx, bucketName, objectName+"-Shorttimeout", fName, minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err == nil {
 		failureLog(function, args, startTime, "", "FPutObjectWithContext with short timeout failed", err).Fatal()
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	// Perform FPutObjectWithContext with a long timeout. Expect the put object to succeed
-	n, err := c.FPutObjectWithContext(ctx, bucketName, objectName+"-Longtimeout", fName, nil)
+	n, err := c.FPutObjectWithContext(ctx, bucketName, objectName+"-Longtimeout", fName, minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObjectWithContext with long timeout failed", err).Fatal()
 	}
@@ -1613,7 +1613,7 @@ func testPutObjectWithContext() {
 	args := map[string]interface{}{
 		"bucketName": "",
 		"objectName": "",
-		"opts":       "&minio.PutObjectOptions{ContentType:objectContentType}",
+		"opts":       "minio.PutObjectOptions{ContentType:objectContentType}",
 	}
 	// Instantiate new minio client object.
 	c, err := minio.NewV4(
@@ -1647,7 +1647,7 @@ func testPutObjectWithContext() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObjectWithContext with short timeout failed", err).Fatal()
 	}
@@ -1656,7 +1656,7 @@ func testPutObjectWithContext() {
 	defer cancel()
 	reader = getDataReader("datafile-33-kB", bufSize)
 	defer reader.Close()
-	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObjectWithContext with long timeout failed", err).Fatal()
 	}
@@ -1725,7 +1725,7 @@ func testGetObjectReadSeekFunctional() {
 	}
 
 	// Save the data
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -1891,7 +1891,7 @@ func testGetObjectReadAtFunctional() {
 	}
 
 	// Save the data
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -2052,7 +2052,7 @@ func testPresignedPostPolicy() {
 	}
 
 	// Save the data
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -2158,7 +2158,7 @@ func testCopyObject() {
 
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
-	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -2375,10 +2375,6 @@ func testEncryptionPutGet() {
 		failureLog(function, args, startTime, "", "NewAsymmetricKey for symmetric Key generation failed", err).Fatal()
 	}
 
-	// Object custom metadata
-	customContentType := "custom/contenttype"
-	args["metadata"] = customContentType
-
 	testCases := []struct {
 		buf    []byte
 		encKey encrypt.Key
@@ -2417,9 +2413,7 @@ func testEncryptionPutGet() {
 		}
 
 		// Put encrypted data
-		_, err = c.PutObject(bucketName, objectName, bytes.NewReader(testCase.buf), int64(len(testCase.buf)), &minio.PutObjectOptions{EncryptMaterials: cbcMaterials, ContentType: customContentType})
-
-		//KPDEL	_, err = c.PutEncryptedObject(bucketName, objectName, bytes.NewReader(testCase.buf), cbcMaterials, map[string][]string{"Content-Type": {customContentType}}, nil)
+		_, err = c.PutEncryptedObject(bucketName, objectName, bytes.NewReader(testCase.buf), cbcMaterials)
 		if err != nil {
 			failureLog(function, args, startTime, "", "PutEncryptedObject failed", err).Fatal()
 		}
@@ -2461,6 +2455,189 @@ func testEncryptionPutGet() {
 	successLogger(function, args, startTime).Info()
 }
 
+// TestEncryptionFPut tests client side encryption
+func testEncryptionFPut() {
+	// initialize logging params
+	startTime := time.Now()
+	function := "FPutEncryptedObject(bucketName, objectName, filePath, contentType, cbcMaterials)"
+	args := map[string]interface{}{
+		"bucketName":   "",
+		"objectName":   "",
+		"filePath":     "",
+		"contentType":  "",
+		"cbcMaterials": "",
+	}
+	// Seed random based on current time.
+	rand.Seed(time.Now().Unix())
+
+	// Instantiate new minio client object
+	c, err := minio.NewV4(
+		os.Getenv(serverEndpoint),
+		os.Getenv(accessKey),
+		os.Getenv(secretKey),
+		mustParseBool(os.Getenv(enableHTTPS)),
+	)
+	if err != nil {
+		failureLog(function, args, startTime, "", "Minio client object creation failed", err).Fatal()
+	}
+
+	// Enable tracing, write to stderr.
+	// c.TraceOn(os.Stderr)
+
+	// Set user agent.
+	c.SetAppInfo("Minio-go-FunctionalTest", "0.1.0")
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()), "minio-go-test")
+	args["bucketName"] = bucketName
+
+	// Make a new bucket.
+	err = c.MakeBucket(bucketName, "us-east-1")
+	if err != nil {
+		failureLog(function, args, startTime, "", "MakeBucket failed", err).Fatal()
+	}
+
+	// Generate a symmetric key
+	symKey := encrypt.NewSymmetricKey([]byte("my-secret-key-00"))
+
+	// Generate an assymmetric key from predefine public and private certificates
+	privateKey, err := hex.DecodeString(
+		"30820277020100300d06092a864886f70d0101010500048202613082025d" +
+			"0201000281810087b42ea73243a3576dc4c0b6fa245d339582dfdbddc20c" +
+			"bb8ab666385034d997210c54ba79275c51162a1221c3fb1a4c7c61131ca6" +
+			"5563b319d83474ef5e803fbfa7e52b889e1893b02586b724250de7ac6351" +
+			"cc0b7c638c980acec0a07020a78eed7eaa471eca4b92071394e061346c06" +
+			"15ccce2f465dee2080a89e43f29b5702030100010281801dd5770c3af8b3" +
+			"c85cd18cacad81a11bde1acfac3eac92b00866e142301fee565365aa9af4" +
+			"57baebf8bb7711054d071319a51dd6869aef3848ce477a0dc5f0dbc0c336" +
+			"5814b24c820491ae2bb3c707229a654427e03307fec683e6b27856688f08" +
+			"bdaa88054c5eeeb773793ff7543ee0fb0e2ad716856f2777f809ef7e6fa4" +
+			"41024100ca6b1edf89e8a8f93cce4b98c76c6990a09eb0d32ad9d3d04fbf" +
+			"0b026fa935c44f0a1c05dd96df192143b7bda8b110ec8ace28927181fd8c" +
+			"d2f17330b9b63535024100aba0260afb41489451baaeba423bee39bcbd1e" +
+			"f63dd44ee2d466d2453e683bf46d019a8baead3a2c7fca987988eb4d565e" +
+			"27d6be34605953f5034e4faeec9bdb0241009db2cb00b8be8c36710aff96" +
+			"6d77a6dec86419baca9d9e09a2b761ea69f7d82db2ae5b9aae4246599bb2" +
+			"d849684d5ab40e8802cfe4a2b358ad56f2b939561d2902404e0ead9ecafd" +
+			"bb33f22414fa13cbcc22a86bdf9c212ce1a01af894e3f76952f36d6c904c" +
+			"bd6a7e0de52550c9ddf31f1e8bfe5495f79e66a25fca5c20b3af5b870241" +
+			"0083456232aa58a8c45e5b110494599bda8dbe6a094683a0539ddd24e19d" +
+			"47684263bbe285ad953d725942d670b8f290d50c0bca3d1dc9688569f1d5" +
+			"9945cb5c7d")
+
+	if err != nil {
+		failureLog(function, args, startTime, "", "DecodeString for symmetric Key generation failed", err).Fatal()
+	}
+
+	publicKey, err := hex.DecodeString("30819f300d06092a864886f70d010101050003818d003081890281810087" +
+		"b42ea73243a3576dc4c0b6fa245d339582dfdbddc20cbb8ab666385034d9" +
+		"97210c54ba79275c51162a1221c3fb1a4c7c61131ca65563b319d83474ef" +
+		"5e803fbfa7e52b889e1893b02586b724250de7ac6351cc0b7c638c980ace" +
+		"c0a07020a78eed7eaa471eca4b92071394e061346c0615ccce2f465dee20" +
+		"80a89e43f29b570203010001")
+	if err != nil {
+		failureLog(function, args, startTime, "", "DecodeString for symmetric Key generation failed", err).Fatal()
+	}
+
+	// Generate an asymmetric key
+	asymKey, err := encrypt.NewAsymmetricKey(privateKey, publicKey)
+	if err != nil {
+		failureLog(function, args, startTime, "", "NewAsymmetricKey for symmetric Key generation failed", err).Fatal()
+	}
+
+	// Object custom metadata
+	customContentType := "custom/contenttype"
+	args["metadata"] = customContentType
+
+	testCases := []struct {
+		buf    []byte
+		encKey encrypt.Key
+	}{
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 0)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 1)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 15)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 16)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 17)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 31)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 32)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 33)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 1024)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 1024*2)},
+		{encKey: symKey, buf: bytes.Repeat([]byte("F"), 1024*1024)},
+
+		{encKey: asymKey, buf: bytes.Repeat([]byte("F"), 0)},
+		{encKey: asymKey, buf: bytes.Repeat([]byte("F"), 1)},
+		{encKey: asymKey, buf: bytes.Repeat([]byte("F"), 16)},
+		{encKey: asymKey, buf: bytes.Repeat([]byte("F"), 32)},
+		{encKey: asymKey, buf: bytes.Repeat([]byte("F"), 1024)},
+		{encKey: asymKey, buf: bytes.Repeat([]byte("F"), 1024*1024)},
+	}
+
+	for i, testCase := range testCases {
+		// Generate a random object name
+		objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
+		args["objectName"] = objectName
+
+		// Secured object
+		cbcMaterials, err := encrypt.NewCBCSecureMaterials(testCase.encKey)
+		args["cbcMaterials"] = cbcMaterials
+
+		if err != nil {
+			failureLog(function, args, startTime, "", "NewCBCSecureMaterials failed", err).Fatal()
+		}
+		// Generate a random file name.
+		fileName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
+		file, err := os.Create(fileName)
+		if err != nil {
+			failureLog(function, args, startTime, "", "file create failed", err).Fatal()
+		}
+		_, err = file.Write(testCase.buf)
+		if err != nil {
+			failureLog(function, args, startTime, "", "file write failed", err).Fatal()
+		}
+		file.Close()
+		// Put encrypted data
+		if _, err = c.FPutEncryptedObject(bucketName, objectName, fileName, cbcMaterials); err != nil {
+			failureLog(function, args, startTime, "", "FPutEncryptedObject failed", err).Fatal()
+		}
+
+		// Read the data back
+		r, err := c.GetEncryptedObject(bucketName, objectName, cbcMaterials)
+		if err != nil {
+			failureLog(function, args, startTime, "", "GetEncryptedObject failed", err).Fatal()
+		}
+		defer r.Close()
+
+		// Compare the sent object with the received one
+		recvBuffer := bytes.NewBuffer([]byte{})
+		if _, err = io.Copy(recvBuffer, r); err != nil {
+			failureLog(function, args, startTime, "", "Test "+string(i+1)+", error: "+err.Error(), err).Fatal()
+		}
+		if recvBuffer.Len() != len(testCase.buf) {
+			failureLog(function, args, startTime, "", "Test "+string(i+1)+", Number of bytes of received object does not match, expected "+string(len(testCase.buf))+", got "+string(recvBuffer.Len()), err).Fatal()
+		}
+		if !bytes.Equal(testCase.buf, recvBuffer.Bytes()) {
+			failureLog(function, args, startTime, "", "Test "+string(i+1)+", Encrypted sent is not equal to decrypted, expected "+string(testCase.buf)+", got "+string(recvBuffer.Bytes()), err).Fatal()
+		}
+
+		// Remove test object
+		err = c.RemoveObject(bucketName, objectName)
+		if err != nil {
+			failureLog(function, args, startTime, "", "Test "+string(i+1)+", RemoveObject failed with: "+err.Error(), err).Fatal()
+		}
+		if err = os.Remove(fileName); err != nil {
+			failureLog(function, args, startTime, "", "File remove failed", err).Fatal()
+		}
+	}
+
+	// Remove test bucket
+	err = c.RemoveBucket(bucketName)
+	if err != nil {
+		err = c.RemoveBucket(bucketName)
+		failureLog(function, args, startTime, "", "RemoveBucket failed", err).Fatal()
+	}
+	successLogger(function, args, startTime).Info()
+}
 func testBucketNotification() {
 	// initialize logging params
 	startTime := time.Now()
@@ -2750,7 +2927,7 @@ func testFunctional() {
 		"contentType": "",
 	}
 
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), nil)
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -2765,7 +2942,7 @@ func testFunctional() {
 		"contentType": "binary/octet-stream",
 	}
 
-	n, err = c.PutObject(bucketName, objectName+"-nolength", bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err = c.PutObject(bucketName, objectName+"-nolength", bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -3099,7 +3276,7 @@ func testGetObjectObjectModified() {
 	// Upload an object.
 	objectName := "myobject"
 	content := "helloworld"
-	_, err = c.PutObject(bucketName, objectName, strings.NewReader(content), int64(len(content)), &minio.PutObjectOptions{ContentType: "application/text"})
+	_, err = c.PutObject(bucketName, objectName, strings.NewReader(content), int64(len(content)), minio.PutObjectOptions{ContentType: "application/text"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "Failed to upload "+objectName+", to bucket "+bucketName, err).Fatal()
 	}
@@ -3121,7 +3298,7 @@ func testGetObjectObjectModified() {
 
 	// Upload different contents to the same object while object is being read.
 	newContent := "goodbyeworld"
-	_, err = c.PutObject(bucketName, objectName, strings.NewReader(newContent), int64(len(newContent)), &minio.PutObjectOptions{ContentType: "application/text"})
+	_, err = c.PutObject(bucketName, objectName, strings.NewReader(newContent), int64(len(newContent)), minio.PutObjectOptions{ContentType: "application/text"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "Failed to upload "+objectName+", to bucket "+bucketName, err).Fatal()
 	}
@@ -3207,7 +3384,7 @@ func testPutObjectUploadSeekedObject() {
 		failureLog(function, args, startTime, "", "TempFile seek failed", err).Fatal()
 	}
 
-	n, err := c.PutObject(bucketName, objectName, tempfile, int64(length), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, tempfile, int64(length), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -3234,7 +3411,7 @@ func testPutObjectUploadSeekedObject() {
 		failureLog(function, args, startTime, "", "Invalid offset returned, expected "+string(int64(offset))+" got "+string(n), err).Fatal()
 	}
 
-	n, err = c.PutObject(bucketName, objectName+"getobject", obj, int64(length), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err = c.PutObject(bucketName, objectName+"getobject", obj, int64(length), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -3361,7 +3538,7 @@ func testGetObjectClosedTwiceV2() {
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 	args["objectName"] = objectName
 
-	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -3461,7 +3638,7 @@ func testRemovePartiallyUploadedV2() {
 	objectName := bucketName + "-resumable"
 	args["objectName"] = objectName
 
-	_, err = c.PutObject(bucketName, objectName, reader, -1, &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	_, err = c.PutObject(bucketName, objectName, reader, -1, minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err == nil {
 		failureLog(function, args, startTime, "", "PutObject should fail", err).Fatal()
 	}
@@ -3548,7 +3725,7 @@ func testFPutObjectV2() {
 	args["fileName"] = file.Name()
 
 	// Perform standard FPutObject with contentType provided (Expecting application/octet-stream)
-	n, err = c.FPutObject(bucketName, objectName+"-standard", file.Name(), &minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	n, err = c.FPutObject(bucketName, objectName+"-standard", file.Name(), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObject failed", err).Fatal()
 	}
@@ -3560,7 +3737,7 @@ func testFPutObjectV2() {
 	args["objectName"] = objectName + "-Octet"
 	args["contentType"] = ""
 
-	n, err = c.FPutObject(bucketName, objectName+"-Octet", file.Name(), nil)
+	n, err = c.FPutObject(bucketName, objectName+"-Octet", file.Name(), minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObject failed", err).Fatal()
 	}
@@ -3580,7 +3757,7 @@ func testFPutObjectV2() {
 	args["contentType"] = ""
 	args["fileName"] = fileName + ".gtar"
 
-	n, err = c.FPutObject(bucketName, objectName+"-GTar", fileName+".gtar", nil)
+	n, err = c.FPutObject(bucketName, objectName+"-GTar", fileName+".gtar", minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FPutObject failed", err).Fatal()
 	}
@@ -3758,7 +3935,7 @@ func testGetObjectReadSeekFunctionalV2() {
 	}
 
 	// Save the data.
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(thirtyThreeKiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(thirtyThreeKiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -3903,7 +4080,7 @@ func testGetObjectReadAtFunctionalV2() {
 	}
 
 	// Save the data
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(thirtyThreeKiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(thirtyThreeKiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -4052,7 +4229,7 @@ func testCopyObjectV2() {
 
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
-	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, reader, int64(thirtyThreeKiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -4215,7 +4392,7 @@ func testComposeObjectErrorCasesWrapper(c *minio.Client) {
 	// 1. Create the source object.
 	const badSrcSize = 5 * 1024 * 1024
 	buf := bytes.Repeat([]byte("1"), badSrcSize)
-	_, err = c.PutObject(bucketName, "badObject", bytes.NewReader(buf), int64(len(buf)), nil)
+	_, err = c.PutObject(bucketName, "badObject", bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -4276,7 +4453,7 @@ func testComposeMultipleSources(c *minio.Client) {
 	// Upload a small source object
 	const srcSize = 1024 * 1024 * 5
 	buf := bytes.Repeat([]byte("1"), srcSize)
-	_, err = c.PutObject(bucketName, "srcObject", bytes.NewReader(buf), int64(srcSize), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObject(bucketName, "srcObject", bytes.NewReader(buf), int64(srcSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -4360,7 +4537,7 @@ func testEncryptedCopyObjectWrapper(c *minio.Client) {
 	for k, v := range key1.GetSSEHeaders() {
 		metadata[k] = v
 	}
-	_, err = c.PutObject(bucketName, "srcObject", bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{UserMetadata: metadata, Progress: nil})
+	_, err = c.PutObject(bucketName, "srcObject", bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{UserMetadata: metadata, Progress: nil})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject call failed", err).Fatal()
 	}
@@ -4504,7 +4681,7 @@ func testUserMetadataCopyingWrapper(c *minio.Client) {
 	m := make(map[string]string)
 	m["x-amz-meta-myheader"] = "myvalue"
 	_, err = c.PutObject(bucketName, "srcObject",
-		bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{UserMetadata: m})
+		bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{UserMetadata: m})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObjectWithMetadata failed", err).Fatal()
 	}
@@ -4684,7 +4861,7 @@ func testPutObjectNoLengthV2() {
 	defer reader.Close()
 
 	// Upload an object.
-	n, err := c.PutObject(bucketName, objectName, reader, -1, &minio.PutObjectOptions{})
+	n, err := c.PutObject(bucketName, objectName, reader, -1, minio.PutObjectOptions{})
 
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObjectWithSize failed", err).Fatal()
@@ -4767,7 +4944,7 @@ func testPutObjectsUnknownV2() {
 		objectName := fmt.Sprintf("%sunique%d", bucketName, i)
 		args["objectName"] = objectName
 
-		n, err := c.PutObject(bucketName, objectName, rpipe, -1, nil)
+		n, err := c.PutObject(bucketName, objectName, rpipe, -1, minio.PutObjectOptions{})
 		if err != nil {
 			failureLog(function, args, startTime, "", "PutObjectStreaming failed", err).Fatal()
 		}
@@ -4835,7 +5012,7 @@ func testPutObject0ByteV2() {
 	objectName := bucketName + "unique"
 
 	// Upload an object.
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader([]byte("")), 0, &minio.PutObjectOptions{})
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader([]byte("")), 0, minio.PutObjectOptions{})
 
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObjectWithSize failed", err).Fatal()
@@ -4993,7 +5170,7 @@ func testFunctionalV2() {
 	// Generate data
 	buf := bytes.Repeat([]byte("n"), rand.Intn(1<<19))
 
-	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), nil)
+	n, err := c.PutObject(bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -5001,7 +5178,7 @@ func testFunctionalV2() {
 		failureLog(function, args, startTime, "", "Expected uploaded object length "+string(len(buf))+" got "+string(n), err).Fatal()
 	}
 
-	n, err = c.PutObject(bucketName, objectName+"-nolength", bytes.NewReader(buf), int64(len(buf)), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err = c.PutObject(bucketName, objectName+"-nolength", bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -5255,7 +5432,7 @@ func testGetObjectWithContext() {
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 
-	_, err = c.PutObject(bucketName, objectName, reader, int64(bufSize), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObject(bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 
@@ -5348,7 +5525,7 @@ func testFGetObjectWithContext() {
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 
-	_, err = c.PutObject(bucketName, objectName, reader, int64(oneMiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObject(bucketName, objectName, reader, int64(oneMiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -5396,7 +5573,7 @@ func testPutObjectWithContextV2() {
 	args := map[string]interface{}{
 		"bucketName": "",
 		"objectName": "",
-		"opts":       "&minio.PutObjectOptions{ContentType:objectContentType}",
+		"opts":       "minio.PutObjectOptions{ContentType:objectContentType}",
 	}
 	// Instantiate new minio client object.
 	c, err := minio.NewV2(
@@ -5431,7 +5608,7 @@ func testPutObjectWithContextV2() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObjectWithContext with short timeout failed", err).Fatal()
 	}
@@ -5440,7 +5617,7 @@ func testPutObjectWithContextV2() {
 	defer cancel()
 	reader = getDataReader("datafile-33-kB", bufSize)
 	defer reader.Close()
-	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObjectWithContext(ctx, bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObjectWithContext with long timeout failed", err).Fatal()
 	}
@@ -5501,7 +5678,7 @@ func testGetObjectWithContextV2() {
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 
-	_, err = c.PutObject(bucketName, objectName, reader, int64(bufSize), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObject(bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject call failed", err).Fatal()
 	}
@@ -5596,7 +5773,7 @@ func testFGetObjectWithContextV2() {
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 
-	_, err = c.PutObject(bucketName, objectName, reader, int64(oneMiB), &minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	_, err = c.PutObject(bucketName, objectName, reader, int64(oneMiB), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject call failed", err).Fatal()
 	}
@@ -5622,7 +5799,6 @@ func testFGetObjectWithContextV2() {
 
 	if err = os.Remove(fileName + "-fcontext"); err != nil {
 		failureLog(function, args, startTime, "", "Remove file failed", err).Fatal()
-
 	}
 	err = c.RemoveObject(bucketName, objectName)
 	if err != nil {
@@ -5693,6 +5869,7 @@ func main() {
 		testPresignedPostPolicy()
 		testCopyObject()
 		testEncryptionPutGet()
+		testEncryptionFPut()
 		testComposeObjectErrorCases()
 		testCompose10KSources()
 		testUserMetadataCopying()

--- a/utils.go
+++ b/utils.go
@@ -221,10 +221,30 @@ var supportedHeaders = []string{
 	// Add more supported headers here.
 }
 
-//isStandardHeader returns true if header is a supported header and not a custom header
+// cseHeaders is list of client side encryption headers
+var cseHeaders = []string{
+	"X-Amz-Iv",
+	"X-Amz-Key",
+	"X-Amz-Matdesc",
+}
+
+// isStandardHeader returns true if header is a supported header and not a custom header
 func isStandardHeader(headerKey string) bool {
 	for _, header := range supportedHeaders {
 		if strings.Compare(strings.ToLower(headerKey), header) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// isCSEHeader returns true if header is a client side encryption header.
+func isCSEHeader(headerKey string) bool {
+	key := strings.ToLower(headerKey)
+	for _, h := range cseHeaders {
+		header := strings.ToLower(h)
+		if (header == key) ||
+			(("x-amz-meta-" + header) == key) {
 			return true
 		}
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -313,3 +313,29 @@ func TestIsStandardHeader(t *testing.T) {
 	}
 
 }
+
+// Tests if header is client encryption header
+func TestIsCSEHeader(t *testing.T) {
+	testCases := []struct {
+		// Input.
+		header string
+		// Expected result.
+		expectedValue bool
+	}{
+		{"x-amz-iv", true},
+		{"x-amz-key", true},
+		{"x-amz-matdesc", true},
+		{"x-amz-meta-x-amz-iv", true},
+		{"x-amz-meta-x-amz-key", true},
+		{"x-amz-meta-x-amz-matdesc", true},
+		{"random-header", false},
+	}
+
+	for i, testCase := range testCases {
+		actual := isCSEHeader(testCase.header)
+		if actual != testCase.expectedValue {
+			t.Errorf("Test %d: Expected to pass, but failed", i+1)
+		}
+	}
+
+}


### PR DESCRIPTION
Partially fixes #819.  
- revive PutEncryptedObject call back, and add a FPutEncryptedObject
 variant.  Options struct is now passed in without a pointer.

Leaving the Get calls for @aead. 