### PR TITLE
refactor GET object operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The full API Reference is available here.
 ### Full Examples : Encrypted Object Operations
 * [put-encrypted-object.go](https://github.com/minio/minio-go/blob/master/examples/s3/put-encrypted-object.go)
 * [get-encrypted-object.go](https://github.com/minio/minio-go/blob/master/examples/s3/get-encrypted-object.go)
+* [fput-encrypted-object.go](https://github.com/minio/minio-go/blob/master/examples/s3/fputencrypted-object.go)
 
 ### Full Examples : Presigned Operations
 * [presignedgetobject.go](https://github.com/minio/minio-go/blob/master/examples/s3/presignedgetobject.go)

--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -244,11 +244,11 @@ func (s *SourceInfo) getProps(c Client) (size int64, etag string, userMeta map[s
 	// Get object info - need size and etag here. Also, decryption
 	// headers are added to the stat request if given.
 	var objInfo ObjectInfo
-	rh := NewGetReqHeaders()
+	opts := StatObjectOptions{}
 	for k, v := range s.decryptKey.getSSEHeaders(false) {
-		rh.Set(k, v)
+		opts.Set(k, v)
 	}
-	objInfo, err = c.statObject(s.bucket, s.object, rh)
+	objInfo, err = c.statObject(s.bucket, s.object, opts)
 	if err != nil {
 		err = fmt.Errorf("Could not stat object - %s/%s: %v", s.bucket, s.object, err)
 	} else {

--- a/api-get-object-context.go
+++ b/api-get-object-context.go
@@ -19,6 +19,7 @@ package minio
 import "context"
 
 // GetObjectWithContext - returns an seekable, readable object.
-func (c Client) GetObjectWithContext(ctx context.Context, bucketName, objectName string) (*Object, error) {
-	return c.getObjectWithContext(ctx, bucketName, objectName)
+// The options can be used to specify the GET request further.
+func (c Client) GetObjectWithContext(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) (*Object, error) {
+	return c.getObjectWithContext(ctx, bucketName, objectName, opts)
 }

--- a/api-get-object-file.go
+++ b/api-get-object-file.go
@@ -21,23 +21,34 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/minio/minio-go/pkg/encrypt"
+
 	"context"
 
 	"github.com/minio/minio-go/pkg/s3utils"
 )
 
 // FGetObjectWithContext - download contents of an object to a local file.
-func (c Client) FGetObjectWithContext(ctx context.Context, bucketName, objectName, filePath string) error {
-	return c.fGetObjectWithContext(ctx, bucketName, objectName, filePath)
+// The options can be used to specify the GET request further.
+func (c Client) FGetObjectWithContext(ctx context.Context, bucketName, objectName, filePath string, opts GetObjectOptions) error {
+	return c.fGetObjectWithContext(ctx, bucketName, objectName, filePath, opts)
 }
 
 // FGetObject - download contents of an object to a local file.
-func (c Client) FGetObject(bucketName, objectName, filePath string) error {
-	return c.fGetObjectWithContext(context.Background(), bucketName, objectName, filePath)
+func (c Client) FGetObject(bucketName, objectName, filePath string, opts GetObjectOptions) error {
+	return c.fGetObjectWithContext(context.Background(), bucketName, objectName, filePath, opts)
+}
+
+// FGetEncryptedObject - Decrypt and store an object at filePath.
+func (c Client) FGetEncryptedObject(bucketName, objectName, filePath string, materials encrypt.Materials) error {
+	if materials == nil {
+		return ErrInvalidArgument("Unable to recognize empty encryption properties")
+	}
+	return c.FGetObject(bucketName, objectName, filePath, GetObjectOptions{Materials: materials})
 }
 
 // fGetObjectWithContext - fgetObject wrapper function with context
-func (c Client) fGetObjectWithContext(ctx context.Context, bucketName, objectName, filePath string) error {
+func (c Client) fGetObjectWithContext(ctx context.Context, bucketName, objectName, filePath string, opts GetObjectOptions) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -72,7 +83,7 @@ func (c Client) fGetObjectWithContext(ctx context.Context, bucketName, objectNam
 	}
 
 	// Gather md5sum.
-	objectStat, err := c.StatObject(bucketName, objectName)
+	objectStat, err := c.StatObject(bucketName, objectName, StatObjectOptions{opts})
 	if err != nil {
 		return err
 	}
@@ -94,13 +105,12 @@ func (c Client) fGetObjectWithContext(ctx context.Context, bucketName, objectNam
 
 	// Initialize get object request headers to set the
 	// appropriate range offsets to read from.
-	reqHeaders := NewGetReqHeaders()
 	if st.Size() > 0 {
-		reqHeaders.SetRange(st.Size(), 0)
+		opts.SetRange(st.Size(), 0)
 	}
 
 	// Seek to current position for incoming reader.
-	objectReader, objectStat, err := c.getObject(ctx, bucketName, objectName, reqHeaders)
+	objectReader, objectStat, err := c.getObject(ctx, bucketName, objectName, opts)
 	if err != nil {
 		return err
 	}

--- a/api-stat.go
+++ b/api-stat.go
@@ -81,7 +81,7 @@ func extractObjMetadata(header http.Header) http.Header {
 }
 
 // StatObject verifies if object exists and you have permission to access.
-func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
+func (c Client) StatObject(bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return ObjectInfo{}, err
@@ -89,23 +89,17 @@ func (c Client) StatObject(bucketName, objectName string) (ObjectInfo, error) {
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return ObjectInfo{}, err
 	}
-	reqHeaders := NewHeadReqHeaders()
-	return c.statObject(bucketName, objectName, reqHeaders)
+	return c.statObject(bucketName, objectName, opts)
 }
 
 // Lower level API for statObject supporting pre-conditions and range headers.
-func (c Client) statObject(bucketName, objectName string, reqHeaders RequestHeaders) (ObjectInfo, error) {
+func (c Client) statObject(bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return ObjectInfo{}, err
 	}
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return ObjectInfo{}, err
-	}
-
-	customHeader := make(http.Header)
-	for k, v := range reqHeaders.Header {
-		customHeader[k] = v
 	}
 
 	// Execute HEAD on objectName.
@@ -113,7 +107,7 @@ func (c Client) statObject(bucketName, objectName string, reqHeaders RequestHead
 		bucketName:         bucketName,
 		objectName:         objectName,
 		contentSHA256Bytes: emptySHA256,
-		customHeader:       customHeader,
+		customHeader:       opts.Header(),
 	})
 	defer closeResponse(resp)
 	if err != nil {

--- a/core.go
+++ b/core.go
@@ -111,12 +111,12 @@ func (c Core) PutBucketPolicy(bucket string, bucketPolicy policy.BucketAccessPol
 // GetObject is a lower level API implemented to support reading
 // partial objects and also downloading objects with special conditions
 // matching etag, modtime etc.
-func (c Core) GetObject(bucketName, objectName string, reqHeaders RequestHeaders) (io.ReadCloser, ObjectInfo, error) {
-	return c.getObject(context.Background(), bucketName, objectName, reqHeaders)
+func (c Core) GetObject(bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, error) {
+	return c.getObject(context.Background(), bucketName, objectName, opts)
 }
 
 // StatObject is a lower level API implemented to support special
 // conditions matching etag, modtime on a request.
-func (c Core) StatObject(bucketName, objectName string, reqHeaders RequestHeaders) (ObjectInfo, error) {
-	return c.statObject(bucketName, objectName, reqHeaders)
+func (c Core) StatObject(bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
+	return c.statObject(bucketName, objectName, opts)
 }

--- a/core_test.go
+++ b/core_test.go
@@ -112,8 +112,6 @@ func TestGetObjectCore(t *testing.T) {
 		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), n)
 	}
 
-	reqHeaders := NewGetReqHeaders()
-
 	offset := int64(2048)
 
 	// read directly
@@ -122,8 +120,9 @@ func TestGetObjectCore(t *testing.T) {
 	buf3 := make([]byte, n)
 	buf4 := make([]byte, 1)
 
-	reqHeaders.SetRange(offset, offset+int64(len(buf1))-1)
-	reader, objectInfo, err := c.GetObject(bucketName, objectName, reqHeaders)
+	opts := GetObjectOptions{}
+	opts.SetRange(offset, offset+int64(len(buf1))-1)
+	reader, objectInfo, err := c.GetObject(bucketName, objectName, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,8 +140,8 @@ func TestGetObjectCore(t *testing.T) {
 	}
 	offset += 512
 
-	reqHeaders.SetRange(offset, offset+int64(len(buf2))-1)
-	reader, objectInfo, err = c.GetObject(bucketName, objectName, reqHeaders)
+	opts.SetRange(offset, offset+int64(len(buf2))-1)
+	reader, objectInfo, err = c.GetObject(bucketName, objectName, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,8 +159,8 @@ func TestGetObjectCore(t *testing.T) {
 		t.Fatal("Error: Incorrect read between two GetObject from same offset.")
 	}
 
-	reqHeaders.SetRange(0, int64(len(buf3)))
-	reader, objectInfo, err = c.GetObject(bucketName, objectName, reqHeaders)
+	opts.SetRange(0, int64(len(buf3)))
+	reader, objectInfo, err = c.GetObject(bucketName, objectName, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,9 +179,9 @@ func TestGetObjectCore(t *testing.T) {
 		t.Fatal("Error: Incorrect data read in GetObject, than what was previously upoaded.")
 	}
 
-	reqHeaders = NewGetReqHeaders()
-	reqHeaders.SetMatchETag("etag")
-	_, _, err = c.GetObject(bucketName, objectName, reqHeaders)
+	opts = GetObjectOptions{}
+	opts.SetMatchETag("etag")
+	_, _, err = c.GetObject(bucketName, objectName, opts)
 	if err == nil {
 		t.Fatal("Unexpected GetObject should fail with mismatching etags")
 	}
@@ -190,9 +189,9 @@ func TestGetObjectCore(t *testing.T) {
 		t.Fatalf("Expected \"PreconditionFailed\" as code, got %s instead", errResp.Code)
 	}
 
-	reqHeaders = NewGetReqHeaders()
-	reqHeaders.SetMatchETagExcept("etag")
-	reader, objectInfo, err = c.GetObject(bucketName, objectName, reqHeaders)
+	opts = GetObjectOptions{}
+	opts.SetMatchETagExcept("etag")
+	reader, objectInfo, err = c.GetObject(bucketName, objectName, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,9 +209,9 @@ func TestGetObjectCore(t *testing.T) {
 		t.Fatal("Error: Incorrect data read in GetObject, than what was previously upoaded.")
 	}
 
-	reqHeaders = NewGetReqHeaders()
-	reqHeaders.SetRange(0, 0)
-	reader, objectInfo, err = c.GetObject(bucketName, objectName, reqHeaders)
+	opts = GetObjectOptions{}
+	opts.SetRange(0, 0)
+	reader, objectInfo, err = c.GetObject(bucketName, objectName, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,8 +286,7 @@ func TestGetObjectContentEncoding(t *testing.T) {
 		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), n)
 	}
 
-	reqHeaders := NewGetReqHeaders()
-	rwc, objInfo, err := c.GetObject(bucketName, objectName, reqHeaders)
+	rwc, objInfo, err := c.GetObject(bucketName, objectName, GetObjectOptions{})
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
@@ -427,7 +425,7 @@ func TestCorePutObject(t *testing.T) {
 	}
 
 	// Read the data back
-	r, err := c.Client.GetObject(bucketName, objectName)
+	r, err := c.Client.GetObject(bucketName, objectName, GetObjectOptions{})
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
@@ -498,8 +496,7 @@ func TestCoreGetObjectMetadata(t *testing.T) {
 		log.Fatalln(err)
 	}
 
-	reader, objInfo, err := core.GetObject(bucketName, "my-objectname",
-		RequestHeaders{})
+	reader, objInfo, err := core.GetObject(bucketName, "my-objectname", GetObjectOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/docs/API.md
+++ b/docs/API.md
@@ -371,7 +371,7 @@ for multiPartObject := range multiPartObjectCh {
 ## 3. Object operations
 
 <a name="GetObject"></a>
-### GetObject(bucketName, objectName string) (*Object, error)
+### GetObject(bucketName, objectName string, opts GetObjectOptions) (*Object, error)
 
 Returns a stream of the object data. Most of the common errors occur when reading the stream.
 
@@ -383,6 +383,7 @@ __Parameters__
 |:---|:---| :---|
 |`bucketName`  | _string_  |Name of the bucket  |
 |`objectName` | _string_  |Name of the object  |
+|`opts` | _GetObjectOptions_ | Options for GET requests specifying additional options like encryption, If-Match |
 
 
 __Return Value__
@@ -397,7 +398,7 @@ __Example__
 
 
 ```go
-object, err := minioClient.GetObject("mybucket", "photo.jpg")
+object, err := minioClient.GetObject("mybucket", "photo.jpg", GetObjectOptions{})
 if err != nil {
     fmt.Println(err)
     return
@@ -414,7 +415,7 @@ if _, err = io.Copy(localFile, object); err != nil {
 ```
 
 <a name="FGetObject"></a>
-### FGetObject(bucketName, objectName, filePath string) error
+### FGetObject(bucketName, objectName, filePath string, opts GetObjectOptions) error
  Downloads and saves the object as a file in the local filesystem.
 
 
@@ -426,20 +427,21 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket |
 |`objectName` | _string_  |Name of the object  |
 |`filePath` | _string_  |Path to download object to |
+|`opts` | _GetObjectOptions_ | Options for GET requests specifying additional options like encryption, If-Match |
 
 
 __Example__
 
 
 ```go
-err := minioClient.FGetObject("mybucket", "photo.jpg", "/tmp/photo.jpg")
+err := minioClient.FGetObject("mybucket", "photo.jpg", "/tmp/photo.jpg", GetObjectOptions{})
 if err != nil {
     fmt.Println(err)
     return
 }
 ```
 <a name="GetObjectWithContext"></a>
-### GetObjectWithContext(ctx context.Context, bucketName, objectName string) (*Object, error)
+### GetObjectWithContext(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) (*Object, error)
 
 Identical to GetObject operation, but accepts a context for request cancellation.
 
@@ -451,6 +453,7 @@ __Parameters__
 |`ctx`  | _context.Context_  |Request context  |
 |`bucketName`  | _string_  |Name of the bucket  |
 |`objectName` | _string_  |Name of the object  |
+|`opts` | _GetObjectOptions_ | Options for GET requests specifying additional options like encryption, If-Match |
 
 
 __Return Value__
@@ -467,7 +470,7 @@ __Example__
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 100 * time.Seconds)
 defer cancel()
-object, err := minioClient.GetObjectWithContext(ctx, "mybucket", "photo.jpg")
+object, err := minioClient.GetObjectWithContext(ctx, "mybucket", "photo.jpg", GetObjectOptions{})
 if err != nil {
     fmt.Println(err)
     return
@@ -484,7 +487,7 @@ if _, err = io.Copy(localFile, object); err != nil {
 ```
 
 <a name="FGetObjectWithContext"></a>
-### FGetObjectWithContext(ctx context.Context, bucketName, objectName, filePath string) error
+### FGetObjectWithContext(ctx context.Context, bucketName, objectName, filePath string, opts GetObjectOptions) error
     Identical to FGetObject operation, but allows request cancellation
 
 __Parameters__
@@ -496,6 +499,7 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket |
 |`objectName` | _string_  |Name of the object  |
 |`filePath` | _string_  |Path to download object to |
+|`opts` | _GetObjectOptions_ | Options for GET requests specifying additional options like encryption, If-Match |
 
 
 __Example__
@@ -504,7 +508,42 @@ __Example__
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 100 * time.Seconds)
 defer cancel()
-err := minioClient.FGetObjectWithContext(ctx, "mybucket", "photo.jpg", "/tmp/photo.jpg")
+err := minioClient.FGetObjectWithContext(ctx, "mybucket", "photo.jpg", "/tmp/photo.jpg", GetObjectOptions{})
+if err != nil {
+    fmt.Println(err)
+    return
+}
+```
+
+<a name="FGetEncryptedObject"></a>
+### FGetEncryptedObject(bucketName, objectName, filePath string, materials encrypt.Materials) error
+    Identical to FGetObject operation, but decrypts an encrypted request
+
+__Parameters__
+
+
+|Param   |Type   |Description   |
+|:---|:---| :---|
+|`bucketName`  | _string_  |Name of the bucket |
+|`objectName` | _string_  |Name of the object  |
+|`filePath` | _string_  |Path to download object to |
+|`materials` | _encrypt.Materials_ | The module to decrypt the object data |
+
+
+__Example__
+
+
+```go
+// Generate a master symmetric key
+key := minio.NewSymmetricKey("my-secret-key-00")
+
+// Build the CBC encryption material
+cbcMaterials, err := NewCBCSecureMaterials(key)
+if err != nil {
+    t.Fatal(err)
+}
+
+err = minioClient.FGetEncryptedObject("mybucket", "photo.jpg", "/tmp/photo.jpg", cbcMaterials)
 if err != nil {
     fmt.Println(err)
     return
@@ -831,7 +870,7 @@ if err != nil {
 }
 ```
 <a name="StatObject"></a>
-### StatObject(bucketName, objectName string) (ObjectInfo, error)
+### StatObject(bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error)
 
 Gets metadata of an object.
 
@@ -843,6 +882,7 @@ __Parameters__
 |:---|:---| :---|
 |`bucketName`  | _string_  |Name of the bucket  |
 |`objectName` | _string_  |Name of the object   |
+|`opts` | _StatObjectOptions_ | Options for GET info/stat requests specifying additional options like encryption, If-Match |
 
 
 __Return Value__
@@ -864,7 +904,7 @@ __Return Value__
 
 
 ```go
-objInfo, err := minioClient.StatObject("mybucket", "photo.jpg")
+objInfo, err := minioClient.StatObject("mybucket", "photo.jpg", GetObjectOptions{})
 if err != nil {
     fmt.Println(err)
     return

--- a/examples/s3/fgetobject-context.go
+++ b/examples/s3/fgetobject-context.go
@@ -45,7 +45,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	if err := s3Client.FGetObjectWithContext(ctx, "my-bucketname", "my-objectname", "my-filename.csv"); err != nil {
+	if err := s3Client.FGetObjectWithContext(ctx, "my-bucketname", "my-objectname", "my-filename.csv", minio.GetObjectOptions{}); err != nil {
 		log.Fatalln(err)
 	}
 	log.Println("Successfully saved my-filename.csv")

--- a/examples/s3/fgetobject.go
+++ b/examples/s3/fgetobject.go
@@ -38,7 +38,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	if err := s3Client.FGetObject("my-bucketname", "my-objectname", "my-filename.csv"); err != nil {
+	if err := s3Client.FGetObject("my-bucketname", "my-objectname", "my-filename.csv", minio.GetObjectOptions{}); err != nil {
 		log.Fatalln(err)
 	}
 	log.Println("Successfully saved my-filename.csv")

--- a/examples/s3/getobject-context.go
+++ b/examples/s3/getobject-context.go
@@ -47,7 +47,9 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	reader, err := s3Client.GetObjectWithContext(ctx, "my-bucketname", "my-objectname")
+	opts := minio.GetObjectOptions{}
+	opts.SetModified(time.Now().Round(10 * time.Minute)) // get object if was modified within the last 10 minutes
+	reader, err := s3Client.GetObjectWithContext(ctx, "my-bucketname", "my-objectname", opts)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/getobject.go
+++ b/examples/s3/getobject.go
@@ -40,7 +40,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	reader, err := s3Client.GetObject("my-bucketname", "my-objectname")
+	reader, err := s3Client.GetObject("my-bucketname", "my-objectname", minio.GetObjectOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/putobject-getobject-sse.go
+++ b/examples/s3/putobject-getobject-sse.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"io/ioutil"
 	"log"
-	"net/http"
 
 	minio "github.com/minio/minio-go"
 )
@@ -66,12 +65,12 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	var reqHeaders = minio.RequestHeaders{Header: http.Header{}}
+	opts := minio.GetObjectOptions{}
 	for k, v := range metadata {
-		reqHeaders.Set(k, v)
+		opts.Set(k, v)
 	}
 	coreClient := minio.Core{minioClient}
-	reader, _, err := coreClient.GetObject("mybucket", "my-encrypted-object.txt", reqHeaders)
+	reader, _, err := coreClient.GetObject("mybucket", "my-encrypted-object.txt", opts)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/putobject-progress.go
+++ b/examples/s3/putobject-progress.go
@@ -39,7 +39,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	reader, err := s3Client.GetObject("my-bucketname", "my-objectname")
+	reader, err := s3Client.GetObject("my-bucketname", "my-objectname", minio.GetObjectOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/statobject.go
+++ b/examples/s3/statobject.go
@@ -37,7 +37,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	stat, err := s3Client.StatObject("my-bucketname", "my-objectname")
+	stat, err := s3Client.StatObject("my-bucketname", "my-objectname", minio.StatObjectOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -451,7 +451,7 @@ func testPutObjectReadAt() {
 	}
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "Get Object failed", err).Fatal()
 	}
@@ -559,7 +559,7 @@ func testPutObjectWithMetadata() {
 	}
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -814,7 +814,7 @@ func testGetObjectSeekEnd() {
 	}
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -919,7 +919,7 @@ func testGetObjectClosedTwice() {
 	}
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -1185,7 +1185,7 @@ func testFPutObjectMultipart() {
 		failureLog(function, args, startTime, "", "FPutObject failed", err).Fatal()
 	}
 
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -1324,7 +1324,7 @@ func testFPutObject() {
 	}
 
 	// Check headers
-	rStandard, err := c.StatObject(bucketName, objectName+"-standard")
+	rStandard, err := c.StatObject(bucketName, objectName+"-standard", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -1332,7 +1332,7 @@ func testFPutObject() {
 		failureLog(function, args, startTime, "", "ContentType does not match, expected application/octet-stream, got "+rStandard.ContentType, err).Fatal()
 	}
 
-	rOctet, err := c.StatObject(bucketName, objectName+"-Octet")
+	rOctet, err := c.StatObject(bucketName, objectName+"-Octet", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -1340,7 +1340,7 @@ func testFPutObject() {
 		failureLog(function, args, startTime, "", "ContentType does not match, expected application/octet-stream, got "+rStandard.ContentType, err).Fatal()
 	}
 
-	rGTar, err := c.StatObject(bucketName, objectName+"-GTar")
+	rGTar, err := c.StatObject(bucketName, objectName+"-GTar", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -1461,7 +1461,7 @@ func testFPutObjectWithContext() {
 		failureLog(function, args, startTime, "", "Number of bytes does not match, expected "+string(totalSize)+", got "+string(n), err).Fatal()
 	}
 
-	_, err = c.StatObject(bucketName, objectName+"-Longtimeout")
+	_, err = c.StatObject(bucketName, objectName+"-Longtimeout", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -1575,7 +1575,7 @@ func testFPutObjectWithContextV2() {
 		failureLog(function, args, startTime, "", "Number of bytes does not match:wanted"+string(totalSize)+" got "+string(n), err).Fatal()
 	}
 
-	_, err = c.StatObject(bucketName, objectName+"-Longtimeout")
+	_, err = c.StatObject(bucketName, objectName+"-Longtimeout", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 
@@ -1746,7 +1746,7 @@ func testGetObjectReadSeekFunctional() {
 	}()
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -1901,7 +1901,7 @@ func testGetObjectReadAtFunctional() {
 	}
 
 	// read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}
@@ -2167,7 +2167,7 @@ func testCopyObject() {
 		failureLog(function, args, startTime, "", "Number of bytes does not match, expected "+string(int64(thirtyThreeKiB))+", got "+string(n), err).Fatal()
 	}
 
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -2223,13 +2223,13 @@ func testCopyObject() {
 	}
 
 	// Source object
-	r, err = c.GetObject(bucketName, objectName)
+	r, err = c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
 
 	// Destination object
-	readerCopy, err := c.GetObject(bucketName+"-copy", objectName+"-copy")
+	readerCopy, err := c.GetObject(bucketName+"-copy", objectName+"-copy", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -3013,7 +3013,7 @@ func testFunctional() {
 		failureLog(function, args, startTime, "", "Unexpected dangling incomplete upload found", err).Fatal()
 	}
 
-	newReader, err := c.GetObject(bucketName, objectName)
+	newReader, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	function = "GetObject(bucketName, objectName)"
 	args = map[string]interface{}{
 		"bucketName": bucketName,
@@ -3033,7 +3033,7 @@ func testFunctional() {
 		failureLog(function, args, startTime, "", "GetObject bytes mismatch", err).Fatal()
 	}
 
-	err = c.FGetObject(bucketName, objectName, fileName+"-f")
+	err = c.FGetObject(bucketName, objectName, fileName+"-f", minio.GetObjectOptions{})
 	function = "FGetObject(bucketName, objectName, fileName)"
 	args = map[string]interface{}{
 		"bucketName": bucketName,
@@ -3164,7 +3164,7 @@ func testFunctional() {
 		failureLog(function, args, startTime, "", "PresignedPutObject failed", err).Fatal()
 	}
 
-	newReader, err = c.GetObject(bucketName, objectName+"-presigned")
+	newReader, err = c.GetObject(bucketName, objectName+"-presigned", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject after PresignedPutObject failed", err).Fatal()
 	}
@@ -3283,7 +3283,7 @@ func testGetObjectObjectModified() {
 
 	defer c.RemoveObject(bucketName, objectName)
 
-	reader, err := c.GetObject(bucketName, objectName)
+	reader, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "Failed to GetObject "+objectName+", from bucket "+bucketName, err).Fatal()
 	}
@@ -3398,7 +3398,7 @@ func testPutObjectUploadSeekedObject() {
 
 	length = int(n)
 
-	obj, err := c.GetObject(bucketName, objectName)
+	obj, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -3548,7 +3548,7 @@ func testGetObjectClosedTwiceV2() {
 	}
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -3766,7 +3766,7 @@ func testFPutObjectV2() {
 	}
 
 	// Check headers
-	rStandard, err := c.StatObject(bucketName, objectName+"-standard")
+	rStandard, err := c.StatObject(bucketName, objectName+"-standard", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -3774,7 +3774,7 @@ func testFPutObjectV2() {
 		failureLog(function, args, startTime, "", "Content-Type headers mismatched, expected: application/octet-stream , got "+rStandard.ContentType, err).Fatal()
 	}
 
-	rOctet, err := c.StatObject(bucketName, objectName+"-Octet")
+	rOctet, err := c.StatObject(bucketName, objectName+"-Octet", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -3782,7 +3782,7 @@ func testFPutObjectV2() {
 		failureLog(function, args, startTime, "", "Content-Type headers mismatched, expected: application/octet-stream , got "+rOctet.ContentType, err).Fatal()
 	}
 
-	rGTar, err := c.StatObject(bucketName, objectName+"-GTar")
+	rGTar, err := c.StatObject(bucketName, objectName+"-GTar", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -3945,7 +3945,7 @@ func testGetObjectReadSeekFunctionalV2() {
 	}
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -4090,7 +4090,7 @@ func testGetObjectReadAtFunctionalV2() {
 	}
 
 	// Read the data back
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -4238,7 +4238,7 @@ func testCopyObjectV2() {
 		failureLog(function, args, startTime, "", "Number of bytes does not match, expected "+string(int64(thirtyThreeKiB))+" got "+string(n), err).Fatal()
 	}
 
-	r, err := c.GetObject(bucketName, objectName)
+	r, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -4294,12 +4294,12 @@ func testCopyObjectV2() {
 	}
 
 	// Source object
-	r, err = c.GetObject(bucketName, objectName)
+	r, err = c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
 	// Destination object
-	readerCopy, err := c.GetObject(bucketName+"-copy", objectName+"-copy")
+	readerCopy, err := c.GetObject(bucketName+"-copy", objectName+"-copy", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -4481,7 +4481,7 @@ func testComposeMultipleSources(c *minio.Client) {
 		failureLog(function, args, startTime, "", "ComposeObject failed", err).Fatal()
 	}
 
-	objProps, err := c.StatObject(bucketName, "dstObject")
+	objProps, err := c.StatObject(bucketName, "dstObject", minio.StatObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "StatObject failed", err).Fatal()
 	}
@@ -4555,12 +4555,12 @@ func testEncryptedCopyObjectWrapper(c *minio.Client) {
 	}
 
 	// 3. get copied object and check if content is equal
-	reqH := minio.NewGetReqHeaders()
+	opts := minio.GetObjectOptions{}
 	for k, v := range key2.GetSSEHeaders() {
-		reqH.Set(k, v)
+		opts.Set(k, v)
 	}
 	coreClient := minio.Core{c}
-	reader, _, err := coreClient.GetObject(bucketName, "dstObject", reqH)
+	reader, _, err := coreClient.GetObject(bucketName, "dstObject", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -4658,7 +4658,7 @@ func testUserMetadataCopyingWrapper(c *minio.Client) {
 	}
 
 	fetchMeta := func(object string) (h http.Header) {
-		objInfo, err := c.StatObject(bucketName, object)
+		objInfo, err := c.StatObject(bucketName, object, minio.StatObjectOptions{})
 		if err != nil {
 			failureLog(function, args, startTime, "", "Stat failed", err).Fatal()
 		}
@@ -5226,7 +5226,7 @@ func testFunctionalV2() {
 		failureLog(function, args, startTime, "", "Unexpected dangling incomplete upload found", err).Fatal()
 	}
 
-	newReader, err := c.GetObject(bucketName, objectName)
+	newReader, err := c.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -5240,7 +5240,7 @@ func testFunctionalV2() {
 		failureLog(function, args, startTime, "", "Bytes mismatch", err).Fatal()
 	}
 
-	err = c.FGetObject(bucketName, objectName, fileName+"-f")
+	err = c.FGetObject(bucketName, objectName, fileName+"-f", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FgetObject failed", err).Fatal()
 	}
@@ -5336,7 +5336,7 @@ func testFunctionalV2() {
 		failureLog(function, args, startTime, "", "HTTP request to PresignedPutObject URL failed", err).Fatal()
 	}
 
-	newReader, err = c.GetObject(bucketName, objectName+"-presigned")
+	newReader, err = c.GetObject(bucketName, objectName+"-presigned", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObject failed", err).Fatal()
 	}
@@ -5442,7 +5442,7 @@ func testGetObjectWithContext() {
 	defer cancel()
 
 	// Read the data back
-	r, err := c.GetObjectWithContext(ctx, bucketName, objectName)
+	r, err := c.GetObjectWithContext(ctx, bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObjectWithContext failed - request timeout not honored", err).Fatal()
 
@@ -5451,7 +5451,7 @@ func testGetObjectWithContext() {
 	defer cancel()
 
 	// Read the data back
-	r, err = c.GetObjectWithContext(ctx, bucketName, objectName)
+	r, err = c.GetObjectWithContext(ctx, bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObjectWithContext failed", err).Fatal()
 
@@ -5535,7 +5535,7 @@ func testFGetObjectWithContext() {
 
 	fileName := "tempfile-context"
 	// Read the data back
-	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-f")
+	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-f", minio.GetObjectOptions{})
 	if err == nil {
 		failureLog(function, args, startTime, "", "FGetObjectWithContext with short timeout failed", err).Fatal()
 	}
@@ -5543,7 +5543,7 @@ func testFGetObjectWithContext() {
 	defer cancel()
 
 	// Read the data back
-	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-fcontext")
+	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-fcontext", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FGetObjectWithContext with long timeout failed", err).Fatal()
 	}
@@ -5687,7 +5687,7 @@ func testGetObjectWithContextV2() {
 	defer cancel()
 
 	// Read the data back
-	r, err := c.GetObjectWithContext(ctx, bucketName, objectName)
+	r, err := c.GetObjectWithContext(ctx, bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObjectWithContext failed due to non-cancellation upon short timeout", err).Fatal()
 
@@ -5696,7 +5696,7 @@ func testGetObjectWithContextV2() {
 	defer cancel()
 
 	// Read the data back
-	r, err = c.GetObjectWithContext(ctx, bucketName, objectName)
+	r, err = c.GetObjectWithContext(ctx, bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "GetObjectWithContext failed due to non-cancellation upon long timeout", err).Fatal()
 
@@ -5783,7 +5783,7 @@ func testFGetObjectWithContextV2() {
 
 	fileName := "tempfile-context"
 	// Read the data back
-	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-f")
+	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-f", minio.GetObjectOptions{})
 	if err == nil {
 		failureLog(function, args, startTime, "", "FGetObjectWithContext call with short request timeout failed", err).Fatal()
 
@@ -5792,7 +5792,7 @@ func testFGetObjectWithContextV2() {
 	defer cancel()
 
 	// Read the data back
-	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-fcontext")
+	err = c.FGetObjectWithContext(ctx, bucketName, objectName, fileName+"-fcontext", minio.GetObjectOptions{})
 	if err != nil {
 		failureLog(function, args, startTime, "", "FGetObjectWithContext call with long request timeout failed", err).Fatal()
 	}

--- a/get-options_test.go
+++ b/get-options_test.go
@@ -40,17 +40,17 @@ func TestSetHeader(t *testing.T) {
 		{1, -5, fmt.Errorf("Invalid range specified: start=1 end=-5"), ""},
 	}
 	for i, testCase := range testCases {
-		rh := NewGetReqHeaders()
-		err := rh.SetRange(testCase.start, testCase.end)
+		opts := GetObjectOptions{}
+		err := opts.SetRange(testCase.start, testCase.end)
 		if err == nil && testCase.errVal != nil {
 			t.Errorf("Test %d: Expected to fail with '%v' but it passed",
 				i+1, testCase.errVal)
 		} else if err != nil && testCase.errVal.Error() != err.Error() {
 			t.Errorf("Test %d: Expected error '%v' but got error '%v'",
 				i+1, testCase.errVal, err)
-		} else if err == nil && rh.Get("Range") != testCase.expected {
+		} else if err == nil && opts.headers["Range"] != testCase.expected {
 			t.Errorf("Test %d: Expected range header '%s', but got '%s'",
-				i+1, testCase.expected, rh.Get("Range"))
+				i+1, testCase.expected, opts.headers["Range"])
 		}
 	}
 }


### PR DESCRIPTION
This change refactors get-object calls to take GetOptions.
This is required to use client and server side encryption within
minio-go.

Updates #823 