### PR TITLE
Fix preSign signature calculation to honor resource lists.

### DIFF
--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -76,7 +76,7 @@ func PreSignV2(req http.Request, accessKeyID, secretAccessKey string, expires in
 	}
 
 	// Get presigned string to sign.
-	stringToSign := preStringifyHTTPReq(req)
+	stringToSign := preStringToSignV2(req)
 	hm := hmac.New(sha1.New, []byte(secretAccessKey))
 	hm.Write([]byte(stringToSign))
 
@@ -145,7 +145,7 @@ func SignV2(req http.Request, accessKeyID, secretAccessKey string) *http.Request
 	}
 
 	// Calculate HMAC for secretAccessKey.
-	stringToSign := stringifyHTTPReq(req)
+	stringToSign := stringToSignV2(req)
 	hm := hmac.New(sha1.New, []byte(secretAccessKey))
 	hm.Write([]byte(stringToSign))
 
@@ -170,15 +170,14 @@ func SignV2(req http.Request, accessKeyID, secretAccessKey string) *http.Request
 //	 Expires + "\n" +
 //	 CanonicalizedProtocolHeaders +
 //	 CanonicalizedResource;
-func preStringifyHTTPReq(req http.Request) string {
+func preStringToSignV2(req http.Request) string {
 	buf := new(bytes.Buffer)
 	// Write standard headers.
 	writePreSignV2Headers(buf, req)
 	// Write canonicalized protocol headers if any.
 	writeCanonicalizedHeaders(buf, req)
 	// Write canonicalized Query resources if any.
-	isPreSign := true
-	writeCanonicalizedResource(buf, req, isPreSign)
+	writeCanonicalizedResource(buf, req)
 	return buf.String()
 }
 
@@ -198,15 +197,14 @@ func writePreSignV2Headers(buf *bytes.Buffer, req http.Request) {
 //	 Date + "\n" +
 //	 CanonicalizedProtocolHeaders +
 //	 CanonicalizedResource;
-func stringifyHTTPReq(req http.Request) string {
+func stringToSignV2(req http.Request) string {
 	buf := new(bytes.Buffer)
 	// Write standard headers.
 	writeSignV2Headers(buf, req)
 	// Write canonicalized protocol headers if any.
 	writeCanonicalizedHeaders(buf, req)
 	// Write canonicalized Query resources if any.
-	isPreSign := false
-	writeCanonicalizedResource(buf, req, isPreSign)
+	writeCanonicalizedResource(buf, req)
 	return buf.String()
 }
 
@@ -253,17 +251,27 @@ func writeCanonicalizedHeaders(buf *bytes.Buffer, req http.Request) {
 	}
 }
 
-// The following list is already sorted and should always be, otherwise we could
-// have signature-related issues
+// AWS S3 Signature V2 calculation rule is give here:
+// http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationStringToSign
+
+// Whitelist resource list that will be used in query string for signature-V2 calculation.
+// The list should be alphabetically sorted
 var resourceList = []string{
 	"acl",
 	"delete",
+	"lifecycle",
 	"location",
 	"logging",
 	"notification",
 	"partNumber",
 	"policy",
 	"requestPayment",
+	"response-cache-control",
+	"response-content-disposition",
+	"response-content-encoding",
+	"response-content-language",
+	"response-content-type",
+	"response-expires",
 	"torrent",
 	"uploadId",
 	"uploads",
@@ -278,22 +286,11 @@ var resourceList = []string{
 // CanonicalizedResource = [ "/" + Bucket ] +
 // 	  <HTTP-Request-URI, from the protocol name up to the query string> +
 // 	  [ sub-resource, if present. For example "?acl", "?location", "?logging", or "?torrent"];
-func writeCanonicalizedResource(buf *bytes.Buffer, req http.Request, isPreSign bool) {
+func writeCanonicalizedResource(buf *bytes.Buffer, req http.Request) {
 	// Save request URL.
 	requestURL := req.URL
 	// Get encoded URL path.
-	path := encodeURL2Path(requestURL)
-	if isPreSign {
-		// Get encoded URL path.
-		if len(requestURL.Query()) > 0 {
-			// Keep the usual queries unescaped for string to sign.
-			query, _ := url.QueryUnescape(s3utils.QueryEncode(requestURL.Query()))
-			path = path + "?" + query
-		}
-		buf.WriteString(path)
-		return
-	}
-	buf.WriteString(path)
+	buf.WriteString(encodeURL2Path(requestURL))
 	if requestURL.RawQuery != "" {
 		var n int
 		vals, _ := url.ParseQuery(requestURL.RawQuery)


### PR DESCRIPTION
Currenlty we used to sign all the query parameters, this
is not in accordance with AWS S3 spec. We should only
canonicalize query params which are present in resouce list.

Fixes #825