### PR TITLE
Add Content-Md5 header only if length of md5 passed is greater than zero

### DIFF
--- a/api.go
+++ b/api.go
@@ -730,7 +730,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	}
 
 	// set md5Sum for content protection.
-	if metadata.contentMD5Bytes != nil {
+	if len(metadata.contentMD5Bytes) > 0 {
 		req.Header.Set("Content-Md5", base64.StdEncoding.EncodeToString(metadata.contentMD5Bytes))
 	}
 


### PR DESCRIPTION
As HTTP headers do not differentiate between value not set and value
set to (""), minio-go should not differentiate between empty byte arrays ("")
and nil byte arrays, add Content-Md5 header only if length of []byte is
greater than zero

See: https://github.com/minio/minio-java/issues/615, & https://github.com/minio/minio/pull/4972#issuecomment-332408083