### PR TITLE
Support redirect headers to sign again with new Host header.

### DIFF
--- a/api-notification.go
+++ b/api-notification.go
@@ -150,7 +150,7 @@ func (c Client) ListenBucketNotification(bucketName, prefix, suffix string, even
 		}
 
 		// Check ARN partition to verify if listening bucket is supported
-		if s3utils.IsAmazonEndpoint(c.endpointURL) || s3utils.IsGoogleEndpoint(c.endpointURL) {
+		if s3utils.IsAmazonEndpoint(*c.endpointURL) || s3utils.IsGoogleEndpoint(*c.endpointURL) {
 			notificationInfoCh <- NotificationInfo{
 				Err: ErrAPINotSupported("Listening for bucket notification is specific only to `minio` server endpoints"),
 			}

--- a/api-presigned.go
+++ b/api-presigned.go
@@ -148,7 +148,7 @@ func (c Client) PresignedPostPolicy(p *PostPolicy) (u *url.URL, formData map[str
 		policyBase64 := p.base64()
 		p.formData["policy"] = policyBase64
 		// For Google endpoint set this value to be 'GoogleAccessId'.
-		if s3utils.IsGoogleEndpoint(c.endpointURL) {
+		if s3utils.IsGoogleEndpoint(*c.endpointURL) {
 			p.formData["GoogleAccessId"] = accessKeyID
 		} else {
 			// For all other endpoints set this value to be 'AWSAccessKeyId'.

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -339,7 +339,7 @@ func (c Client) putObjectNoChecksum(ctx context.Context, bucketName, objectName 
 
 	// Size -1 is only supported on Google Cloud Storage, we error
 	// out in all other situations.
-	if size < 0 && !s3utils.IsGoogleEndpoint(c.endpointURL) {
+	if size < 0 && !s3utils.IsGoogleEndpoint(*c.endpointURL) {
 		return 0, ErrEntityTooSmall(size, bucketName, objectName)
 	}
 	if size > 0 {

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -133,7 +133,7 @@ func (c Client) putObjectCommon(ctx context.Context, bucketName, objectName stri
 	}
 
 	// NOTE: Streaming signature is not supported by GCS.
-	if s3utils.IsGoogleEndpoint(c.endpointURL) {
+	if s3utils.IsGoogleEndpoint(*c.endpointURL) {
 		// Do not compute MD5 for Google Cloud Storage.
 		return c.putObjectNoChecksum(ctx, bucketName, objectName, reader, size, opts)
 	}


### PR DESCRIPTION
This is a requirement if say an S3 API endpoint redirects to
a new location based on perhaps a redirect proxy between
two servers.

This is implemented to support bucket re-direction which
might be implemented in future by employing a redirect
proxy.

To this change please use redirector here -
 https://gist.github.com/harshavardhana/a135fafff0d97b31b25ee303ebf28d46