### PR TITLE
Add new CopyObject API in Core client

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -266,6 +266,51 @@ func (s *SourceInfo) getProps(c Client) (size int64, etag string, userMeta map[s
 	return
 }
 
+// Low level implementation of CopyObject API, supports only upto 5GiB worth of copy.
+func (c Client) copyObjectDo(ctx context.Context, srcBucket, srcObject, destBucket, destObject string,
+	metadata map[string]string) (ObjectInfo, error) {
+
+	// Build headers.
+	headers := make(http.Header)
+
+	// Set all the metadata headers.
+	for k, v := range metadata {
+		headers.Set(k, v)
+	}
+
+	// Set the source header
+	headers.Set("x-amz-copy-source", s3utils.EncodePath(srcBucket+"/"+srcObject))
+
+	// Send upload-part-copy request
+	resp, err := c.executeMethod(ctx, "PUT", requestMetadata{
+		bucketName:   destBucket,
+		objectName:   destObject,
+		customHeader: headers,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+
+	// Check if we got an error response.
+	if resp.StatusCode != http.StatusOK {
+		return ObjectInfo{}, httpRespToErrorResponse(resp, srcBucket, srcObject)
+	}
+
+	cpObjRes := copyObjectResult{}
+	err = xmlDecoder(resp.Body, &cpObjRes)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+
+	objInfo := ObjectInfo{
+		Key:          destObject,
+		ETag:         strings.Trim(cpObjRes.ETag, "\""),
+		LastModified: cpObjRes.LastModified,
+	}
+	return objInfo, nil
+}
+
 // uploadPartCopy - helper function to create a part in a multipart
 // upload via an upload-part-copy request
 // https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -128,7 +128,7 @@ type initiator struct {
 // copyObjectResult container for copy object response.
 type copyObjectResult struct {
 	ETag         string
-	LastModified string // time string format "2006-01-02T15:04:05.000Z"
+	LastModified time.Time // time string format "2006-01-02T15:04:05.000Z"
 }
 
 // ObjectPart container for particular part of an object.


### PR DESCRIPTION
This PR also fixes the problem of PutObject
call not handling additional headers.

Refer original problem here https://github.com/minio/minio/pull/5000