### PR TITLE
Fix handling of metadata headers in compose-object

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4670,6 +4670,10 @@ func testUserMetadataCopyingWrapper(c *minio.Client) {
 				}
 			}
 		}
+		// Also add content-type header
+		if objInfo.ContentType != "" {
+			h.Add("content-type", objInfo.ContentType)
+		}
 		return h
 	}
 
@@ -4692,7 +4696,11 @@ func testUserMetadataCopyingWrapper(c *minio.Client) {
 	// 2. create source
 	src := minio.NewSourceInfo(bucketName, "srcObject", nil)
 	// 2.1 create destination with metadata set
-	dst1, err := minio.NewDestinationInfo(bucketName, "dstObject-1", nil, map[string]string{"notmyheader": "notmyvalue"})
+	dst1, err := minio.NewDestinationInfo(bucketName, "dstObject-1", nil,
+		map[string]string{
+			"notmyheader":  "notmyvalue",
+			"content-type": "application/javascript",
+		})
 	if err != nil {
 		failureLog(function, args, startTime, "", "NewDestinationInfo failed", err).Fatal()
 	}
@@ -4709,6 +4717,7 @@ func testUserMetadataCopyingWrapper(c *minio.Client) {
 
 	expectedHeaders := make(http.Header)
 	expectedHeaders.Set("x-amz-meta-notmyheader", "notmyvalue")
+	expectedHeaders.Set("content-type", "application/javascript")
 	if !reflect.DeepEqual(expectedHeaders, fetchMeta("dstObject-1")) {
 		failureLog(function, args, startTime, "", "Metadata match failed", err).Fatal()
 	}


### PR DESCRIPTION
- Previously common headers such as `Content-Type` were not replaced
  on the copy of the object.

- This patch addresses a problem related to https://github.com/minio/minio/pull/5000