### PR TITLE
Added a new method SetUserMetadata to the PostPolicy

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1348,6 +1348,9 @@ policy.SetContentType("image/png")
 // Only allow content size in range 1KB to 1MB.
 policy.SetContentLengthRange(1024, 1024*1024)
 
+// Add a user metadata using the key "custom" and value "user"
+policy.SetUserMetadata("custom", "user")
+
 // Get the POST form key/value object:
 
 url, formData, err := minioClient.PresignedPostPolicy(policy)

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -2052,6 +2052,8 @@ func testPresignedPostPolicy() {
 	defer reader.Close()
 
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
+	metadataKey := randString(60, rand.NewSource(time.Now().UnixNano()), "")
+	metadataValue := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 
 	buf, err := ioutil.ReadAll(reader)
 	if err != nil {
@@ -2088,12 +2090,16 @@ func testPresignedPostPolicy() {
 	if err := policy.SetContentLengthRange(1024*1024, 1024); err == nil {
 		failureLog(function, args, startTime, "", "SetContentLengthRange did not fail for invalid conditions", err).Fatal()
 	}
+	if err := policy.SetUserMetadata("", ""); err == nil {
+		failureLog(function, args, startTime, "", "SetUserMetadata did not fail for invalid conditions", err).Fatal()
+	}
 
 	policy.SetBucket(bucketName)
 	policy.SetKey(objectName)
 	policy.SetExpires(time.Now().UTC().AddDate(0, 0, 10)) // expires in 10 days
 	policy.SetContentType("image/png")
 	policy.SetContentLengthRange(1024, 1024*1024)
+	policy.SetUserMetadata(metadataKey, metadataValue)
 	args["policy"] = policy
 
 	_, _, err = c.PresignedPostPolicy(policy)

--- a/post-policy.go
+++ b/post-policy.go
@@ -167,6 +167,28 @@ func (p *PostPolicy) SetSuccessStatusAction(status string) error {
 	return nil
 }
 
+// SetUserMetadata - Set user metadata as a key/value couple.
+// Can be retrieved through a HEAD request or an event.
+func (p *PostPolicy) SetUserMetadata(key string, value string) error {
+	if strings.TrimSpace(key) == "" || key == "" {
+		return ErrInvalidArgument("Key is empty")
+	}
+	if strings.TrimSpace(value) == "" || value == "" {
+		return ErrInvalidArgument("Value is empty")
+	}
+	headerName := fmt.Sprintf("x-amz-meta-%s", key)
+	policyCond := policyCondition{
+		matchType: "eq",
+		condition: fmt.Sprintf("$%s", headerName),
+		value:     value,
+	}
+	if err := p.addNewPolicy(policyCond); err != nil {
+		return err
+	}
+	p.formData[headerName] = value
+	return nil
+}
+
 // addNewPolicy - internal helper to validate adding new policies.
 func (p *PostPolicy) addNewPolicy(policyCond policyCondition) error {
 	if policyCond.matchType == "" || policyCond.condition == "" || policyCond.value == "" {


### PR DESCRIPTION
Hi there,

here is a PR for a new feature I need for a project I am working on.

## Feature

`SetUserSpecifiedMetadata(key string, value string)` allows you to add user specified metadata following [this guide](http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html) which mention:

|key|Explanation|
|--|--|
|x-amz-meta-*|User-specified metadata.This condition supports exact matching and starts-with condition match type.|

## Contributing

I went through the contributing doc and ran `SERVER_ENDPOINT=xxx ACCESS_KEY=xxx SECRET_KEY=xxx go test -race ./...` successfuly and ran `go fmt`.

But I do not have any unit tests though as the file `post-policy.go` does not have any I am not sure how you guys would like it to be tested, if you could please provide me some pointers.

I tested the feature itself, it is working and being used in staging (the header is set properly and retrieved through the Minio event notification when the upload is completed, and through `HEAD` as well).