### PR TITLE
Doc has incorrect description in RemoveObjects API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -945,7 +945,7 @@ __Parameters__
 |Param   |Type   |Description   |
 |:---|:---| :---|
 |`bucketName`  | _string_  |Name of the bucket  |
-|`objectsCh` | _chan string_  | Prefix of objects to be removed   |
+|`objectsCh` | _chan string_  | Channel of objects to be removed   |
 
 
 __Return Values__


### PR DESCRIPTION
Description for parameter objectsCh in the RemoveObjects API
is incorrect.

It is being changed from "Prefix of objects to be removed" to
"List of objects to be removed".

Fixes #845