### PR TITLE
Add PartSize to be configurable as part of PutObjectOptions

### DIFF
--- a/api-put-object-context.go
+++ b/api-put-object-context.go
@@ -24,8 +24,7 @@ import (
 // PutObjectWithContext - Identical to PutObject call, but accepts context to facilitate request cancellation.
 func (c Client) PutObjectWithContext(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64,
 	opts PutObjectOptions) (n int64, err error) {
-	err = opts.validate()
-	if err != nil {
+	if err = opts.validate(); err != nil {
 		return 0, err
 	}
 	if opts.EncryptMaterials != nil {

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -74,6 +74,10 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 		return 0, err
 	}
 
+	if 0 < int64(opts.PartSize) && int64(opts.PartSize) < partSize {
+		partSize = int64(opts.PartSize)
+	}
+
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -106,6 +106,10 @@ func (c Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketNa
 		return 0, err
 	}
 
+	if 0 < int64(opts.PartSize) && int64(opts.PartSize) < partSize {
+		partSize = int64(opts.PartSize)
+	}
+
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {
@@ -248,6 +252,11 @@ func (c Client) putObjectMultipartStreamNoChecksum(ctx context.Context, bucketNa
 	if err != nil {
 		return 0, err
 	}
+
+	if 0 < int64(opts.PartSize) && int64(opts.PartSize) < partSize {
+		partSize = int64(opts.PartSize)
+	}
+
 	// Initiates a new multipart request
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {

--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -189,13 +189,13 @@ func TestPartSize(t *testing.T) {
 		t.Fatal("Error:", err)
 	}
 	if totalPartsCount != 9103 {
-		t.Fatalf("Error: expecting total parts count of 9987: got %v instead", totalPartsCount)
+		t.Fatalf("Error: expecting total parts count of 9103: got %v instead", totalPartsCount)
 	}
 	if partSize != 603979776 {
-		t.Fatalf("Error: expecting part size of 550502400: got %v instead", partSize)
+		t.Fatalf("Error: expecting part size of 603979776: got %v instead", partSize)
 	}
 	if lastPartSize != 134217728 {
-		t.Fatalf("Error: expecting last part size of 241172480: got %v instead", lastPartSize)
+		t.Fatalf("Error: expecting last part size of 134217728: got %v instead", lastPartSize)
 	}
 }
 

--- a/constants.go
+++ b/constants.go
@@ -22,6 +22,10 @@ package minio
 // a part in a multipart upload may not be uploaded.
 const absMinPartSize = 1024 * 1024 * 5
 
+// Optimal max part size required to upload 5TiB object, with
+// least number of parts.
+const optimalMaxPartSize = 1024 * 1024 * 576 // 576MiB
+
 // minPartSize - minimum part size 64MiB per object after which
 // putObject behaves internally as multipart.
 const minPartSize = 1024 * 1024 * 64


### PR DESCRIPTION
This is done to ensure that caller can control the amount of
memory being used when uploading a stream without knowing
prior length.

Fixes #848