### PR TITLE
Honor file pointer set in PutObject method

### DIFF
--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -343,7 +343,12 @@ func (c Client) putObjectNoChecksum(ctx context.Context, bucketName, objectName 
 	}
 	if size > 0 {
 		if isReadAt(reader) && !isObject(reader) {
-			reader = io.NewSectionReader(reader.(io.ReaderAt), 0, size)
+			seeker, _ := reader.(io.Seeker)
+			offset, err := seeker.Seek(0, io.SeekCurrent)
+			if err != nil {
+				return 0, ErrInvalidArgument(err.Error())
+			}
+			reader = io.NewSectionReader(reader.(io.ReaderAt), offset, size)
 		}
 	}
 

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -3477,7 +3477,7 @@ func testPutObjectUploadSeekedObject() {
 		failureLog(function, args, startTime, "", "TempFile seek failed", err).Fatal()
 	}
 
-	n, err := c.PutObject(bucketName, objectName, tempfile, int64(length), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	n, err := c.PutObject(bucketName, objectName, tempfile, int64(length-offset), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		failureLog(function, args, startTime, "", "PutObject failed", err).Fatal()
 	}


### PR DESCRIPTION
Create a sectionreader by honoring the file pointer already set on the file.

Fixes #855