### PR TITLE
Re-sign signature and follow redirects

### DIFF
--- a/api-presigned.go
+++ b/api-presigned.go
@@ -53,7 +53,7 @@ func (c Client) presignURL(method string, bucketName string, objectName string, 
 	// Instantiate a new request.
 	// Since expires is set newRequest will presign the request.
 	var req *http.Request
-	if req, err = c.newRequest(method, reqMetadata); err != nil {
+	if req, err = c.newRequest(&c.endpointURL, method, reqMetadata); err != nil {
 		return nil, err
 	}
 	return req.URL, nil
@@ -113,12 +113,12 @@ func (c Client) PresignedPostPolicy(p *PostPolicy) (u *url.URL, formData map[str
 
 	bucketName := p.formData["bucket"]
 	// Fetch the bucket location.
-	location, err := c.getBucketLocation(bucketName)
+	location, err := c.getBucketLocation(c.endpointURL.Host, bucketName)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	u, err = c.makeTargetURL(bucketName, "", location, nil)
+	u, err = c.makeTargetURL(&c.endpointURL, bucketName, "", location, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -234,7 +234,7 @@ func TestMakeTargetURL(t *testing.T) {
 	for i, testCase := range testCases {
 		// Initialize a Minio client
 		c, _ := New(testCase.addr, "foo", "bar", testCase.secure)
-		u, err := c.makeTargetURL(testCase.bucketName, testCase.objectName, testCase.bucketLocation, testCase.queryValues)
+		u, err := c.makeTargetURL(&c.endpointURL, testCase.bucketName, testCase.objectName, testCase.bucketLocation, testCase.queryValues)
 		// Check the returned error
 		if testCase.expectedErr == nil && err != nil {
 			t.Fatalf("Test %d: Should succeed but failed with err = %v", i+1, err)

--- a/bucket-cache_test.go
+++ b/bucket-cache_test.go
@@ -235,7 +235,7 @@ func TestGetBucketLocationRequest(t *testing.T) {
 			}
 		}
 
-		actualReq, err := client.getBucketLocationRequest(testCase.bucketName)
+		actualReq, err := client.getBucketLocationRequest(client.endpointURL.Host, testCase.bucketName)
 		if err != nil && testCase.shouldPass {
 			t.Errorf("Test %d: Expected to pass, but failed with: <ERROR> %s", i+1, err.Error())
 		}


### PR DESCRIPTION
On redirections (503), the default http client will retry the request on
the new Location.  However, the signature will be invalid since it
includes the original Host in the canonical string.

Retry the request after resigning with the new host.  This change
disables the default client retry mechanism and retries the request in
the executeMethod retry loop.  Unfortunately this incurs a retry delay
penalty.

Fixes #867 