### PR TITLE
Update Travis CI build settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,14 @@ env:
 
 go:
 - 1.7.4
-- 1.8
-- 1.9
+- 1.8.x
+- 1.9.x
+- tip
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - go: tip
 
 script:
 - diff -au <(gofmt -d .) <(printf "")


### PR DESCRIPTION
* Test latest point releases of Go 1.8 and 1.9 (without the .x suffix,
  1.8.0 and 1.9.0 are used instead of the latest releases)
* Test with Go tip but allow failures
* Mark the build as failed immediately if any jobs fail

Remarks:

* `gofmt` is failing on `tip` (golang 1.10) and the diff output is difficult to read
* We're building with Go 1.7.4 instead of 1.7.x (latest fix release is 1.7.6); is this intentional?
* I believe only the last two versions (1.8 and 1.9) are supported by Go upstream; is 1.7 support still required?