### PR TITLE
add support of x-amz-acl header for v2 acl (ceph server, aws s3 v2)

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"runtime/debug"
 	"sort"
-	"strings"
 
 	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/minio/minio-go/pkg/s3utils"
@@ -79,7 +78,7 @@ func (opts PutObjectOptions) Header() (header http.Header) {
 		header[amzHeaderMatDesc] = []string{opts.EncryptMaterials.GetDesc()}
 	}
 	for k, v := range opts.UserMetadata {
-		if !strings.HasPrefix(strings.ToLower(k), "x-amz-meta-") && !isStandardHeader(k) && !isSSEHeader(k) {
+		if !isAmzHeader(k) && !isStandardHeader(k) && !isSSEHeader(k) {
 			header["X-Amz-Meta-"+k] = []string{v}
 		} else {
 			header[k] = []string{v}

--- a/utils.go
+++ b/utils.go
@@ -283,9 +283,5 @@ func isSSEHeader(headerKey string) bool {
 func isAmzHeader(headerKey string) bool {
 	key := strings.ToLower(headerKey)
 
-	if strings.HasPrefix(key, "x-amz-meta-") || key == "x-amz-acl" {
-		return true
-	}
-
-	return false
+	return strings.HasPrefix(key, "x-amz-meta-") || key == "x-amz-acl"
 }

--- a/utils.go
+++ b/utils.go
@@ -278,3 +278,14 @@ func isSSEHeader(headerKey string) bool {
 	}
 	return false
 }
+
+// isAmzHeader returns true if header is a x-amz-meta-* or x-amz-acl header.
+func isAmzHeader(headerKey string) bool {
+	key := strings.ToLower(headerKey)
+
+	if strings.HasPrefix(key, "x-amz-meta-") || key == "x-amz-acl" {
+		return true
+	}
+
+	return false
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -366,3 +366,30 @@ func TestIsCSEHeader(t *testing.T) {
 	}
 
 }
+
+// Tests if header is x-amz-meta or x-amz-acl
+func TestIsAmzHeader(t *testing.T) {
+	testCases := []struct {
+		// Input.
+		header string
+		// Expected result.
+		expectedValue bool
+	}{
+		{"x-amz-iv", false},
+		{"x-amz-key", false},
+		{"x-amz-matdesc", false},
+		{"x-amz-meta-x-amz-iv", true},
+		{"x-amz-meta-x-amz-key", true},
+		{"x-amz-meta-x-amz-matdesc", true},
+		{"x-amz-acl", true},
+		{"random-header", false},
+	}
+
+	for i, testCase := range testCases {
+		actual := isAmzHeader(testCase.header)
+		if actual != testCase.expectedValue {
+			t.Errorf("Test %d: Expected to pass, but failed", i+1)
+		}
+	}
+
+}


### PR DESCRIPTION
We use CEPH server for store object. CEPH has old protocol (v2) and use special header for set ACl for object. Also AWS S3 v2 use this header
1. http://docs.ceph.com/docs/jewel/radosgw/s3/objectops/#put-object
2. http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationExamples-6

I added support of this header and add test for this method