### PR TITLE
tests: Reduce context timeout to avoid false positives

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -249,7 +249,7 @@ func (s *SourceInfo) getProps(c Client) (size int64, etag string, userMeta map[s
 	for k, v := range s.decryptKey.getSSEHeaders(false) {
 		opts.Set(k, v)
 	}
-	objInfo, err = c.statObject(s.bucket, s.object, opts)
+	objInfo, err = c.statObject(context.Background(), s.bucket, s.object, opts)
 	if err != nil {
 		err = ErrInvalidArgument(fmt.Sprintf("Could not stat object - %s/%s: %v", s.bucket, s.object, err))
 	} else {

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -127,7 +127,7 @@ func (c Client) getObjectWithContext(ctx context.Context, bucketName, objectName
 					} else {
 						// First request is a Stat or Seek call.
 						// Only need to run a StatObject until an actual Read or ReadAt request comes through.
-						objectInfo, err = c.statObject(bucketName, objectName, StatObjectOptions{opts})
+						objectInfo, err = c.statObject(ctx, bucketName, objectName, StatObjectOptions{opts})
 						if err != nil {
 							resCh <- getResponse{
 								Error: err,
@@ -145,7 +145,7 @@ func (c Client) getObjectWithContext(ctx context.Context, bucketName, objectName
 					if etag != "" {
 						opts.SetMatchETag(etag)
 					}
-					objectInfo, err := c.statObject(bucketName, objectName, StatObjectOptions{opts})
+					objectInfo, err := c.statObject(ctx, bucketName, objectName, StatObjectOptions{opts})
 					if err != nil {
 						resCh <- getResponse{
 							Error: err,

--- a/api-stat.go
+++ b/api-stat.go
@@ -90,11 +90,11 @@ func (c Client) StatObject(bucketName, objectName string, opts StatObjectOptions
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return ObjectInfo{}, err
 	}
-	return c.statObject(bucketName, objectName, opts)
+	return c.statObject(context.Background(), bucketName, objectName, opts)
 }
 
 // Lower level API for statObject supporting pre-conditions and range headers.
-func (c Client) statObject(bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
+func (c Client) statObject(ctx context.Context, bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return ObjectInfo{}, err
@@ -104,7 +104,7 @@ func (c Client) statObject(bucketName, objectName string, opts StatObjectOptions
 	}
 
 	// Execute HEAD on objectName.
-	resp, err := c.executeMethod(context.Background(), "HEAD", requestMetadata{
+	resp, err := c.executeMethod(ctx, "HEAD", requestMetadata{
 		bucketName:       bucketName,
 		objectName:       objectName,
 		contentSHA256Hex: emptySHA256Hex,

--- a/core.go
+++ b/core.go
@@ -141,5 +141,5 @@ func (c Core) GetObject(bucketName, objectName string, opts GetObjectOptions) (i
 // StatObject is a lower level API implemented to support special
 // conditions matching etag, modtime on a request.
 func (c Core) StatObject(bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
-	return c.statObject(bucketName, objectName, opts)
+	return c.statObject(context.Background(), bucketName, objectName, opts)
 }


### PR DESCRIPTION
context timeout tests had long timeouts leading
to false positives in some cases when functional
tests are run against faster disks.

Reduce them such that the possibility of this
would never occur in future usage.

Fixes #880