### PR TITLE
Reduced the number of files in testRemoveMultipleObjects test

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -1147,7 +1147,7 @@ func testRemoveMultipleObjects() {
 	r := bytes.NewReader(bytes.Repeat([]byte("a"), 8))
 
 	// Multi remove of 1100 objects
-	nrObjects := 1100
+	nrObjects := 200
 
 	objectsCh := make(chan string)
 


### PR DESCRIPTION
Introduced change is to stop gcs server failing with "We encountered an internal error, please try again." when dealing with many files more than it can handle. 
Fixes #887