### PR TITLE
Ignore Metadata field in xml encode/decode

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -44,7 +44,7 @@ type ObjectInfo struct {
 
 	// Collection of additional metadata on the object.
 	// eg: x-amz-meta-*, content-encoding etc.
-	Metadata http.Header `json:"metadata"`
+	Metadata http.Header `json:"metadata" xml:"-"`
 
 	// Owner name.
 	Owner struct {


### PR DESCRIPTION
I would like to use minio-go datatypes in my program, although it's problematic unless s3 api does not specify Metadata property for ObjectInfo. Also XML encoder cannot serialize any map type while it does not provide items order, which is significant in XML. Ignoring this property while marshalling solves problem