### PR TITLE
Add storage class support

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -65,3 +65,6 @@ const (
 	amzHeaderKey     = "X-Amz-Meta-X-Amz-Key"
 	amzHeaderMatDesc = "X-Amz-Meta-X-Amz-Matdesc"
 )
+
+// Storage class header constant.
+const amzStorageClass = "X-Amz-Storage-Class"

--- a/docs/API.md
+++ b/docs/API.md
@@ -575,7 +575,7 @@ __minio.PutObjectOptions__
 | `opts.ContentDisposition` | _string_ | Content disposition of object, "inline" |
 | `opts.CacheControl` | _string_ | Used to specify directives for caching mechanisms in both requests and responses e.g "max-age=600"|
 | `opts.EncryptMaterials` | _encrypt.Materials_ | Interface provided by `encrypt` package to encrypt a stream of data (For more information see https://godoc.org/github.com/minio/minio-go) |
-
+| `opts.StorageClass` | _string_ | Specify storage class for the object. Supported values for Minio server are `MINIO_STORAGE_CLASS_RRS` and `MINIO_STORAGE_CLASS_STANDARD` |
 
 __Example__
 

--- a/utils.go
+++ b/utils.go
@@ -234,6 +234,11 @@ var cseHeaders = []string{
 	"X-Amz-Matdesc",
 }
 
+// isStorageClassHeader returns true if the header is a supported storage class header
+func isStorageClassHeader(headerKey string) bool {
+	return strings.ToLower(amzStorageClass) == strings.ToLower(headerKey)
+}
+
 // isStandardHeader returns true if header is a supported header and not a custom header
 func isStandardHeader(headerKey string) bool {
 	key := strings.ToLower(headerKey)


### PR DESCRIPTION
This enables `x-amz-storage-class` support in `minio-go`. This is
required as Minio server is adding storage class support.

See https://github.com/minio/minio/issues/4997