### PR TITLE
fix s3signer to use req.Host header

### DIFF
--- a/pkg/s3signer/request-signature-streaming_test.go
+++ b/pkg/s3signer/request-signature-streaming_test.go
@@ -33,7 +33,7 @@ func TestGetSeedSignature(t *testing.T) {
 
 	req := NewRequest("PUT", "/examplebucket/chunkObject.txt", body)
 	req.Header.Set("x-amz-storage-class", "REDUCED_REDUNDANCY")
-	req.URL.Host = "s3.amazonaws.com"
+	req.Host = "s3.amazonaws.com"
 
 	reqTime, err := time.Parse("20060102T150405Z", "20130524T000000Z")
 	if err != nil {
@@ -69,6 +69,7 @@ func TestSetStreamingAuthorization(t *testing.T) {
 
 	req := NewRequest("PUT", "/examplebucket/chunkObject.txt", nil)
 	req.Header.Set("x-amz-storage-class", "REDUCED_REDUNDANCY")
+	req.Host = ""
 	req.URL.Host = "s3.amazonaws.com"
 
 	dataLen := int64(65 * 1024)
@@ -93,6 +94,7 @@ func TestStreamingReader(t *testing.T) {
 	req := NewRequest("PUT", "/examplebucket/chunkObject.txt", nil)
 	req.Header.Set("x-amz-storage-class", "REDUCED_REDUNDANCY")
 	req.ContentLength = 65 * 1024
+	req.Host = ""
 	req.URL.Host = "s3.amazonaws.com"
 
 	baseReader := ioutil.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), 65*1024)))

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -40,22 +40,23 @@ const (
 )
 
 // Encode input URL path to URL encoded path.
-func encodeURL2Path(u *url.URL) (path string) {
+func encodeURL2Path(req *http.Request) (path string) {
+	reqHost := getHostAddr(req)
 	// Encode URL path.
-	if isS3, _ := filepath.Match("*.s3*.amazonaws.com", u.Host); isS3 {
-		bucketName := u.Host[:strings.LastIndex(u.Host, ".s3")]
+	if isS3, _ := filepath.Match("*.s3*.amazonaws.com", reqHost); isS3 {
+		bucketName := reqHost[:strings.LastIndex(reqHost, ".s3")]
 		path = "/" + bucketName
-		path += u.Path
+		path += req.URL.Path
 		path = s3utils.EncodePath(path)
 		return
 	}
-	if strings.HasSuffix(u.Host, ".storage.googleapis.com") {
-		path = "/" + strings.TrimSuffix(u.Host, ".storage.googleapis.com")
-		path += u.Path
+	if strings.HasSuffix(reqHost, ".storage.googleapis.com") {
+		path = "/" + strings.TrimSuffix(reqHost, ".storage.googleapis.com")
+		path += req.URL.Path
 		path = s3utils.EncodePath(path)
 		return
 	}
-	path = s3utils.EncodePath(u.Path)
+	path = s3utils.EncodePath(req.URL.Path)
 	return
 }
 
@@ -86,7 +87,7 @@ func PreSignV2(req http.Request, accessKeyID, secretAccessKey string, expires in
 
 	query := req.URL.Query()
 	// Handle specially for Google Cloud Storage.
-	if strings.Contains(req.URL.Host, ".storage.googleapis.com") {
+	if strings.Contains(getHostAddr(&req), ".storage.googleapis.com") {
 		query.Set("GoogleAccessId", accessKeyID)
 	} else {
 		query.Set("AWSAccessKeyId", accessKeyID)
@@ -291,7 +292,7 @@ func writeCanonicalizedResource(buf *bytes.Buffer, req http.Request) {
 	// Save request URL.
 	requestURL := req.URL
 	// Get encoded URL path.
-	buf.WriteString(encodeURL2Path(requestURL))
+	buf.WriteString(encodeURL2Path(&req))
 	if requestURL.RawQuery != "" {
 		var n int
 		vals, _ := url.ParseQuery(requestURL.RawQuery)

--- a/pkg/s3signer/request-signature-v4.go
+++ b/pkg/s3signer/request-signature-v4.go
@@ -144,7 +144,7 @@ func getCanonicalHeaders(req http.Request, ignoredHeaders map[string]bool) strin
 		buf.WriteByte(':')
 		switch {
 		case k == "host":
-			buf.WriteString(req.URL.Host)
+			buf.WriteString(getHostAddr(&req))
 			fallthrough
 		default:
 			for idx, v := range vals[k] {

--- a/pkg/s3signer/request-signature-v4_test.go
+++ b/pkg/s3signer/request-signature-v4_test.go
@@ -1,0 +1,50 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3signer
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRequestHost(t *testing.T) {
+	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
+	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
+	req.Host = "myhost"
+	canonicalHeaders := getCanonicalHeaders(*req, v4IgnoredHeaders)
+
+	if !strings.Contains(canonicalHeaders, "host:"+req.Host) {
+		t.Errorf("canonical host header invalid")
+	}
+}
+
+func buildRequest(serviceName, region, body string) (*http.Request, io.ReadSeeker) {
+	endpoint := "https://" + serviceName + "." + region + ".amazonaws.com"
+	reader := strings.NewReader(body)
+	req, _ := http.NewRequest("POST", endpoint, reader)
+	req.URL.Opaque = "//example.org/bucket/key-._~,!@#$%^&*()"
+	req.Header.Add("X-Amz-Target", "prefix.Operation")
+	req.Header.Add("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Add("Content-Length", string(len(body)))
+	req.Header.Add("X-Amz-Meta-Other-Header", "some-value=!@#$%^&* (+)")
+	req.Header.Add("X-Amz-Meta-Other-Header_With_Underscore", "some-value=!@#$%^&* (+)")
+	req.Header.Add("X-amz-Meta-Other-Header_With_Underscore", "some-value=!@#$%^&* (+)")
+	return req, reader
+}

--- a/pkg/s3signer/utils.go
+++ b/pkg/s3signer/utils.go
@@ -20,6 +20,7 @@ package s3signer
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"net/http"
 )
 
 // unsignedPayload - value to be set to X-Amz-Content-Sha256 header when
@@ -37,4 +38,12 @@ func sumHMAC(key []byte, data []byte) []byte {
 	hash := hmac.New(sha256.New, key)
 	hash.Write(data)
 	return hash.Sum(nil)
+}
+
+// getHostAddr returns host header if available, otherwise returns host from URL
+func getHostAddr(req *http.Request) string {
+	if req.Host != "" {
+		return req.Host
+	}
+	return req.URL.Host
 }

--- a/pkg/s3signer/utils_test.go
+++ b/pkg/s3signer/utils_test.go
@@ -19,6 +19,7 @@ package s3signer
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 )
@@ -66,7 +67,7 @@ func TestEncodeURL2Path(t *testing.T) {
 			t.Fatal("Error:", err)
 		}
 		urlPath := "/" + bucketName + "/" + o.encodedObjName
-		if urlPath != encodeURL2Path(u) {
+		if urlPath != encodeURL2Path(&http.Request{URL: u}) {
 			t.Fatal("Error")
 		}
 	}


### PR DESCRIPTION
s3signer module should use req.Host and only if it's not set it should fall back to req.URL.Host. The documentation specifies that HTTP Host header(req.Host) should be used to create canonical request (http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html). However in aws-sdk there is a fallback to a host from the URL req.URL.Host.

This change fix support for signing requests without absolute path in URI, for example:
GET /resource HTTP/1.1
Host: example.com