### PR TITLE
increase max retry 

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -26,7 +26,7 @@ import (
 )
 
 // MaxRetry is the maximum number of retries before stopping.
-var MaxRetry = 5
+var MaxRetry = 10
 
 // MaxJitter will randomize over the full exponential backoff time
 const MaxJitter = 1.0


### PR DESCRIPTION
Fixes https://github.com/minio/mc/issues/2304

Increase max number of binomial retries to 10 so that long running uploads have a chance of completing in the event of connection timeout.