### PR TITLE
Fix copyobject failure for empty files

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -476,8 +476,8 @@ func (c Client) ComposeObject(dst DestinationInfo, srcs []SourceInfo) error {
 
 	// Single source object case (i.e. when only one source is
 	// involved, it is being copied wholly and at most 5GiB in
-	// size).
-	if totalParts == 1 && srcs[0].start == -1 && totalSize <= maxPartSize {
+	// size, emptyfiles are also supported).
+	if (totalParts == 1 && srcs[0].start == -1 && totalSize <= maxPartSize) || (totalSize == 0) {
 		h := srcs[0].Headers
 		// Add destination encryption headers
 		for k, v := range dst.encryption.getSSEHeaders(false) {


### PR DESCRIPTION
Fix CopyObject API to do a single part put object s3 api call, if
the source object is an empty file.

Required fix for https://github.com/minio/mc/issues/2384