### PR TITLE
Fix errors in file when using the Asymmetrical ver

### DIFF
--- a/examples/s3/fputencrypted-object.go
+++ b/examples/s3/fputencrypted-object.go
@@ -20,10 +20,10 @@
 package main
 
 import (
-	"log"
-
+	//"io/ioutil"
 	"github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/encrypt"
+	"log"
 )
 
 func main() {
@@ -47,17 +47,17 @@ func main() {
 	//
 	// privateKey, err := ioutil.ReadFile("private.key")
 	// if err != nil {
-	//	t.Fatal(err)
+	// 	 log.Fatalln(err)
 	// }
 	//
 	// publicKey, err := ioutil.ReadFile("public.key")
 	// if err != nil {
-	//	t.Fatal(err)
+	//	log.Fatalln(err)
 	// }
-	//
+
 	// asymmetricKey, err := encrypt.NewAsymmetricKey(privateKey, publicKey)
 	// if err != nil {
-	//	t.Fatal(err)
+	// 	 log.Fatalln(err)
 	// }
 	////
 


### PR DESCRIPTION
The t.Fatal(err) will not compile, changed to log.Fatalln. Both symmetrical and asymmetrical versions now compile fine.