### PR TITLE
replace t.Fatal with log.Fatalln

### DIFF
--- a/examples/s3/fputencrypted-object.go
+++ b/examples/s3/fputencrypted-object.go
@@ -47,17 +47,17 @@ func main() {
 	//
 	// privateKey, err := ioutil.ReadFile("private.key")
 	// if err != nil {
-	//	t.Fatal(err)
+	//	log.Fatalln(err)
 	// }
 	//
 	// publicKey, err := ioutil.ReadFile("public.key")
 	// if err != nil {
-	//	t.Fatal(err)
+	//	log.Fatalln(err)
 	// }
 	//
 	// asymmetricKey, err := encrypt.NewAsymmetricKey(privateKey, publicKey)
 	// if err != nil {
-	//	t.Fatal(err)
+	//	log.Fatalln(err)
 	// }
 	////
 


### PR DESCRIPTION
Code would not build with t.Fatal, changed to log.Fatalln to keep consistency with the rest of the code.