### PR TITLE
Allow to upload empty files in stream based uploads

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -208,7 +208,7 @@ func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName
 		if rErr == io.EOF && partNumber > 1 {
 			break
 		}
-		if rErr != nil && rErr != io.ErrUnexpectedEOF {
+		if rErr != nil && rErr != io.ErrUnexpectedEOF && rErr != io.EOF {
 			return 0, rErr
 		}
 		// Update progress reader appropriately to the latest offset


### PR DESCRIPTION
With the current implementation of streams you can't upload an empty file like this.

```go
s3cli.PutObject("test-bucket", "0-bytes-file.txt", bytes.NewReader([]byte{}), -1, options)
```

Basically there is a check in the end of the `putObjectMultipartStreamNoLength`
function that is never reached, because we filter any io.EOF error before that.
Is needed to let it pass when the partNumber is 1 to allow 0 bytes files to be
uploaded.