### PR TITLE
Fix stream SSE uploads with S3 encrypt type

### DIFF
--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -259,7 +259,7 @@ func (c Client) uploadPart(ctx context.Context, bucketName, objectName, uploadID
 
 	// Set encryption headers, if any.
 	customHeader := make(http.Header)
-	if sse != nil && sse.Type() != encrypt.S3 {
+	if sse != nil && sse.Type() != encrypt.S3 && sse.Type() != encrypt.KMS {
 		sse.Marshal(customHeader)
 	}
 

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -259,7 +259,7 @@ func (c Client) uploadPart(ctx context.Context, bucketName, objectName, uploadID
 
 	// Set encryption headers, if any.
 	customHeader := make(http.Header)
-	if sse != nil {
+	if sse != nil && sse.Type() != encrypt.S3 {
 		sse.Marshal(customHeader)
 	}
 


### PR DESCRIPTION
When you try to upload files stream based with encryption activated, minio-go
try to upload the parts using the ServerSideEncryption header, but it isn't
supported for uploadPart with encrypt type S3, only is needed for customer
keys. For S3 encryption we simply add the header at the creation, and in the
following uploadPart we don't pass the header.

I'm not sure, but maybe we need to exclude the encrypt KMS type too (I'm not
sure).

Here is an example of it failing before the patch, and working after it.

```go
package main

import (
	"log"
	"os"

	minio "github.com/minio/minio-go"
	"github.com/minio/minio-go/pkg/encrypt"
)

func main() {
	s3Client, err := minio.New("s3.amazonaws.com", "API_KEY", "API_SECRET", true)
	if err != nil {
		log.Fatalln(err)
	}

	object, err := os.Open("test.txt")
	if err != nil {
		log.Fatalln(err)
	}
	defer object.Close()

	options := minio.PutObjectOptions{ServerSideEncryption: encrypt.NewSSE()}

	n, err := s3Client.PutObject("my-bucket", "my-objectname", object, -1, options)
	if err != nil {
		log.Fatalln(err)
	}

	log.Println("Uploaded", "my-objectname", " of size: ", n, "Successfully.")
}
```