### PR TITLE
avoid sending SSE-S3 header during GET requests.

### DIFF
--- a/api-get-options.go
+++ b/api-get-options.go
@@ -44,7 +44,7 @@ func (o GetObjectOptions) Header() http.Header {
 	for k, v := range o.headers {
 		headers.Set(k, v)
 	}
-	if o.ServerSideEncryption != nil {
+	if o.ServerSideEncryption != nil && o.ServerSideEncryption.Type() != encrypt.S3 {
 		o.ServerSideEncryption.Marshal(headers)
 	}
 	return headers


### PR DESCRIPTION
AWS S3 does not accept the SSE-S3 header for GET requests - only
for PUT requests. This change avoids setting the SSE-S3 header.

Fixes #964