### PR TITLE
Fix bucket policy tests to avoid verbatim match for policies

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -3474,15 +3474,13 @@ func testFunctional() {
 	function = "SetBucketPolicy(bucketName, readOnlyPolicy)"
 	functionAll += ", " + function
 
-	readOnlyPolicy := `{"Version":"2012-10-17","Statement":[{"Action":["s3:ListBucket"],"Effect":"Allow","Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::` + bucketName + `"],"Sid":""}]}`
-
+	readOnlyPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:ListBucket"],"Resource":["arn:aws:s3:::` + bucketName + `"]}]}`
 	args = map[string]interface{}{
 		"bucketName":   bucketName,
 		"bucketPolicy": readOnlyPolicy,
 	}
 
 	err = c.SetBucketPolicy(bucketName, readOnlyPolicy)
-
 	if err != nil {
 		logError(testName, function, args, startTime, "", "SetBucketPolicy failed", err)
 		return
@@ -3494,14 +3492,12 @@ func testFunctional() {
 		"bucketName": bucketName,
 	}
 	readOnlyPolicyRet, err := c.GetBucketPolicy(bucketName)
-
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetBucketPolicy failed", err)
 		return
 	}
-
-	if strings.Compare(readOnlyPolicyRet, readOnlyPolicy) != 0 {
-		logError(testName, function, args, startTime, "", "policy should be set to readonly", err)
+	if readOnlyPolicyRet == "" {
+		logError(testName, function, args, startTime, "", "policy should be set", err)
 		return
 	}
 
@@ -3509,8 +3505,7 @@ func testFunctional() {
 	function = "SetBucketPolicy(bucketName, writeOnlyPolicy)"
 	functionAll += ", " + function
 
-	writeOnlyPolicy := `{"Version":"2012-10-17","Statement":[{"Action":["s3:ListBucketMultipartUploads"],"Effect":"Allow","Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::` + bucketName + `"],"Sid":""}]}`
-
+	writeOnlyPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:ListBucketMultipartUploads"],"Resource":["arn:aws:s3:::` + bucketName + `"]}]}`
 	args = map[string]interface{}{
 		"bucketName":   bucketName,
 		"bucketPolicy": writeOnlyPolicy,
@@ -3534,8 +3529,8 @@ func testFunctional() {
 		return
 	}
 
-	if strings.Compare(writeOnlyPolicyRet, writeOnlyPolicy) != 0 {
-		logError(testName, function, args, startTime, "", "policy should be set to writeonly", err)
+	if writeOnlyPolicyRet == "" {
+		logError(testName, function, args, startTime, "", "policy should be set", err)
 		return
 	}
 
@@ -3543,7 +3538,7 @@ func testFunctional() {
 	function = "SetBucketPolicy(bucketName, readWritePolicy)"
 	functionAll += ", " + function
 
-	readWritePolicy := `{"Version":"2012-10-17","Statement":[{"Action":["s3:ListBucket","s3:ListBucketMultipartUploads"],"Effect":"Allow","Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::` + bucketName + `"],"Sid":""}]}`
+	readWritePolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:ListBucket","s3:ListBucketMultipartUploads"],"Resource":["arn:aws:s3:::` + bucketName + `"]}]}`
 
 	args = map[string]interface{}{
 		"bucketName":   bucketName,
@@ -3567,8 +3562,8 @@ func testFunctional() {
 		return
 	}
 
-	if strings.Compare(readWritePolicyRet, readWritePolicy) != 0 {
-		logError(testName, function, args, startTime, "", "policy should be set to readwrite", err)
+	if readWritePolicyRet == "" {
+		logError(testName, function, args, startTime, "", "policy should be set", err)
 		return
 	}
 
@@ -6497,7 +6492,7 @@ func testFunctionalV2() {
 	function = "SetBucketPolicy(bucketName, bucketPolicy)"
 	functionAll += ", " + function
 
-	readWritePolicy := `{"Version": "2012-10-17","Statement": [{"Action": ["s3:ListBucketMultipartUploads,s3:ListBucket"],"Effect": "Allow","Principal": {"AWS": ["*"]},"Resource": ["arn:aws:s3:::` + bucketName + `/*"],"Sid": ""}]}`
+	readWritePolicy := `{"Version": "2012-10-17","Statement": [{"Action": ["s3:ListBucketMultipartUploads", "s3:ListBucket"],"Effect": "Allow","Principal": {"AWS": ["*"]},"Resource": ["arn:aws:s3:::` + bucketName + `"],"Sid": ""}]}`
 
 	args = map[string]interface{}{
 		"bucketName":   bucketName,
@@ -6558,9 +6553,9 @@ func testFunctionalV2() {
 		return
 	}
 
-	objectName_noLength := objectName + "-nolength"
-	args["objectName"] = objectName_noLength
-	n, err = c.PutObject(bucketName, objectName_noLength, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	objectNameNoLength := objectName + "-nolength"
+	args["objectName"] = objectNameNoLength
+	n, err = c.PutObject(bucketName, objectNameNoLength, bytes.NewReader(buf), int64(len(buf)), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PutObject failed", err)
 		return


### PR DESCRIPTION
Bucket policy once set on the server may not represent
the same policy string exactly. Server upon parsing and
verification saves the policy is a more trimmed form
this is similar in behavior to AWS S3.

Avoid such checks since they fail even on AWS S3.