### PR TITLE
Avoid returning security related header when stating an object

### DIFF
--- a/api-stat.go
+++ b/api-stat.go
@@ -66,6 +66,9 @@ var defaultFilterKeys = []string{
 	"x-amz-bucket-region",
 	"x-amz-request-id",
 	"x-amz-id-2",
+	"Content-Security-Policy",
+	"X-Xss-Protection",
+
 	// Add new headers to be ignored.
 }
 


### PR DESCRIPTION
After adding some http security related headers in Minio server, we need to filter them when stat object, since no needed for users & applications.

Fixes https://github.com/minio/mc/issues/2436