### PR TITLE
fix version naming convention to have 'v' prefix

### DIFF
--- a/api.go
+++ b/api.go
@@ -99,7 +99,7 @@ type Options struct {
 // Global constants.
 const (
 	libraryName    = "minio-go"
-	libraryVersion = "6.0.2"
+	libraryVersion = "v6.0.2"
 )
 
 // User Agent should always following the below style.


### PR DESCRIPTION
This change is needed to follow `vgo` guidelines
put forth by Go community.

https://github.com/golang/vgo/blob/master/vendor/cmd/go/internal/semver/semver.go#L6

> // semantic version strings must begin with a leading "v"

Supported format style

https://github.com/golang/vgo/blob/master/vendor/cmd/go/internal/semver/semver.go#L11

> //	vMAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]

Fixes #985