### PR TITLE
Added support for the start-after parameter when performing a List Objects V2 query

### DIFF
--- a/core.go
+++ b/core.go
@@ -48,9 +48,9 @@ func (c Core) ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
 }
 
 // ListObjectsV2 - Lists all the objects at a prefix, similar to ListObjects() but uses
-// continuationToken instead of marker to further filter the results.
-func (c Core) ListObjectsV2(bucketName, objectPrefix, continuationToken string, fetchOwner bool, delimiter string, maxkeys int) (ListBucketV2Result, error) {
-	return c.listObjectsV2Query(bucketName, objectPrefix, continuationToken, fetchOwner, delimiter, maxkeys)
+// continuationToken instead of marker to support iteration over the results.
+func (c Core) ListObjectsV2(bucketName, objectPrefix, continuationToken string, fetchOwner bool, delimiter string, maxkeys int, startAfter string) (ListBucketV2Result, error) {
+	return c.listObjectsV2Query(bucketName, objectPrefix, continuationToken, fetchOwner, delimiter, maxkeys, startAfter)
 }
 
 // CopyObject - copies an object from source object to destination object on server side.


### PR DESCRIPTION
When making a List Objects V2 query against Amazon S3, an object key cannot be used as a continuation-token.  Amazon S3 continuation tokens are opaque and attempting to use an object key as a continuation-token will result in an error response.

If you want to start listing objects after a particular object key, the start-after parameter needs to be used.  This pull request adds support for setting the start-after parameter when making a List Objects V2 request.

Relates to minio/minio#6032