### PR TITLE
RemoveIncompleteUpload to remove all incomplete uploads

### DIFF
--- a/api-remove.go
+++ b/api-remove.go
@@ -233,18 +233,20 @@ func (c Client) RemoveIncompleteUpload(bucketName, objectName string) error {
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return err
 	}
-	// Find multipart upload id of the object to be aborted.
-	uploadID, err := c.findUploadID(bucketName, objectName)
+	// Find multipart upload ids of the object to be aborted.
+	uploadIDs, err := c.findUploadIDs(bucketName, objectName)
 	if err != nil {
 		return err
 	}
-	if uploadID != "" {
-		// Upload id found, abort the incomplete multipart upload.
+
+	for _, uploadID := range uploadIDs {
+		// abort incomplete multipart upload, based on the upload id passed.
 		err := c.abortMultipartUpload(context.Background(), bucketName, objectName, uploadID)
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Currently RemoveIncompleteUpload removes only the latest
incomplete upload for an object. Fix will remove all the
incomplete uploads available for an object.