### PR TITLE
pkg/policy: detect single statement policies

### DIFF
--- a/pkg/policy/bucket-policy.go
+++ b/pkg/policy/bucket-policy.go
@@ -557,7 +557,6 @@ func GetPolicy(statements []Statement, bucketName string, prefix string) BucketP
 		} else {
 			matchedObjResources = s.Resources.FuncMatch(resourceMatch, objectResource)
 		}
-
 		if !matchedObjResources.IsEmpty() {
 			readOnly, writeOnly := getObjectPolicy(s)
 			for resource := range matchedObjResources {
@@ -571,7 +570,8 @@ func GetPolicy(statements []Statement, bucketName string, prefix string) BucketP
 					matchedResource = resource
 				}
 			}
-		} else if s.Resources.Contains(bucketResource) {
+		}
+		if s.Resources.Contains(bucketResource) {
 			commonFound, readOnly, writeOnly := getBucketPolicy(s, prefix)
 			bucketCommonFound = bucketCommonFound || commonFound
 			bucketReadOnly = bucketReadOnly || readOnly
@@ -605,6 +605,7 @@ func GetPolicies(statements []Statement, bucketName, prefix string) map[string]B
 			}
 		}
 	}
+
 	// Pretend that policy resource as an actual object and fetch its policy
 	for r := range objResources {
 		// Put trailing * if exists in asterisk
@@ -613,7 +614,10 @@ func GetPolicies(statements []Statement, bucketName, prefix string) map[string]B
 			r = r[:len(r)-1]
 			asterisk = "*"
 		}
-		objectPath := r[len(awsResourcePrefix+bucketName)+1:]
+		var objectPath string
+		if len(r) >= len(awsResourcePrefix+bucketName)+1 {
+			objectPath = r[len(awsResourcePrefix+bucketName)+1:]
+		}
 		p := GetPolicy(statements, bucketName, objectPath)
 		policyRules[bucketName+"/"+objectPath+asterisk] = p
 	}

--- a/pkg/policy/bucket-policy_test.go
+++ b/pkg/policy/bucket-policy_test.go
@@ -1592,6 +1592,7 @@ func TestListBucketPolicies(t *testing.T) {
 	downloadUploadCondKeyMap.Add("s3:prefix", set.CreateStringSet("both"))
 	downloadUploadCondMap.Add("StringEquals", downloadUploadCondKeyMap)
 
+	commonSetActions := commonBucketActions.Union(readOnlyBucketActions)
 	testCases := []struct {
 		statements     []Statement
 		bucketName     string
@@ -1630,6 +1631,13 @@ func TestListBucketPolicies(t *testing.T) {
 				Principal: User{AWS: set.CreateStringSet("*")},
 				Resources: set.CreateStringSet("arn:aws:s3:::mybucket/download*"),
 			}}, "mybucket", "", map[string]BucketPolicy{"mybucket/download*": BucketPolicyReadOnly}},
+		{[]Statement{
+			{
+				Actions:   commonSetActions.Union(readOnlyObjectActions),
+				Effect:    "Allow",
+				Principal: User{AWS: set.CreateStringSet("*")},
+				Resources: set.CreateStringSet("arn:aws:s3:::mybucket", "arn:aws:s3:::mybucket/*"),
+			}}, "mybucket", "", map[string]BucketPolicy{"mybucket/*": BucketPolicyReadOnly}},
 		// Write Only
 		{[]Statement{
 			{


### PR DESCRIPTION
Some times AWS S3 can have single statement policies
where all actions and resources are combined into a
a single statement. In general we handle multiple
statements properly, handle single statement with
bucket and object actions in the same statement
properly.