### PR TITLE
New way to update ObjectACL or Header or Meta data

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -101,7 +101,11 @@ func (d *DestinationInfo) getUserMetaHeadersMap(withCopyDirectiveHeader bool) ma
 		r["x-amz-metadata-directive"] = "REPLACE"
 	}
 	for k, v := range d.userMetadata {
-		r["x-amz-meta-"+k] = v
+		if isAmzHeader(k) || isStandardHeader(k) || isStorageClassHeader(k) {
+			r[k] = v
+		} else {
+			r["x-amz-meta-"+k] = v
+		}
 	}
 	return r
 }

--- a/api-compose-object_test.go
+++ b/api-compose-object_test.go
@@ -127,6 +127,7 @@ func TestGetUserMetaHeadersMap(t *testing.T) {
 		"x-amz-acl":           "public-read-write",
 		"content-type":        "application/binary",
 		"X-Amz-Storage-Class": "rrs",
+		"x-amz-grant-write":   "test@exo.ch",
 	}
 
 	destInfo := &DestinationInfo{"bucket", "object", nil, userMetadata}

--- a/api-compose-object_test.go
+++ b/api-compose-object_test.go
@@ -18,6 +18,7 @@ package minio
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -115,6 +116,39 @@ func TestCalculateEvenSplits(t *testing.T) {
 		resStart, resEnd := calculateEvenSplits(testCase.size, testCase.src)
 		if !reflect.DeepEqual(testCase.starts, resStart) || !reflect.DeepEqual(testCase.ends, resEnd) {
 			t.Errorf("Test %d - output did not match with reference results, Expected %d/%d, got %d/%d", i+1, testCase.starts, testCase.ends, resStart, resEnd)
+		}
+	}
+}
+
+func TestGetUserMetaHeadersMap(t *testing.T) {
+
+	userMetadata := map[string]string{
+		"test":                "test",
+		"x-amz-acl":           "public-read-write",
+		"content-type":        "application/binary",
+		"X-Amz-Storage-Class": "rrs",
+	}
+
+	destInfo := &DestinationInfo{"bucket", "object", nil, userMetadata}
+
+	r := destInfo.getUserMetaHeadersMap(true)
+
+	i := 0
+
+	if _, ok := r["x-amz-metadata-directive"]; !ok {
+		t.Errorf("Test %d - metadata directive was expected but is missing", i)
+		i++
+	}
+
+	for k := range r {
+		if strings.HasSuffix(k, "test") && !strings.HasPrefix(k, "x-amz-meta-") {
+			t.Errorf("Test %d - meta %q was expected as an x amz meta", i, k)
+			i++
+		}
+
+		if !strings.HasSuffix(k, "test") && strings.HasPrefix(k, "x-amz-meta-") {
+			t.Errorf("Test %d - an amz/standard/storageClass Header was expected but got an x amz meta data", i)
+			i++
 		}
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -267,5 +267,5 @@ func isSSEHeader(headerKey string) bool {
 func isAmzHeader(headerKey string) bool {
 	key := strings.ToLower(headerKey)
 
-	return strings.HasPrefix(key, "x-amz-meta-") || key == "x-amz-acl"
+	return strings.HasPrefix(key, "x-amz-meta-") || strings.HasPrefix(key, "x-amz-grant-") || key == "x-amz-acl"
 }


### PR DESCRIPTION
If you Put an object with nothing (no acl, meta...) and you want to update with ObjectACL it's not possible. And you don't want to use bucket policies to make it alternatively

this is an example to update a canned acl:
```Golang
src := minio.NewSourceInfo("bucketName", "object", nil)

meta := map[string]string{
	"x-amz-acl": "public-read-write",
}

// Destination object
dst, err := minio.NewDestinationInfo("bucketName", "object", nil, meta)
if err != nil {
	return err
}

// Copy object call
err = minioClient.CopyObject(dst, src)
if err != nil {
	return err
}
```

this source code copy object on itself and can update ACL, userMetaData or Header