### PR TITLE
Fix retrying retryable http requests errors

### DIFF
--- a/api.go
+++ b/api.go
@@ -599,8 +599,8 @@ func (c Client) executeMethod(ctx context.Context, method string, metadata reque
 		// Initiate the request.
 		res, err = c.do(req)
 		if err != nil {
-			// For supported network errors verify.
-			if isNetErrorRetryable(err) {
+			// For supported http requests errors verify.
+			if isHTTPReqErrorRetryable(err) {
 				continue // Retry.
 			}
 			// For other errors, return here no need to retry.

--- a/retry.go
+++ b/retry.go
@@ -85,36 +85,32 @@ func (c Client) newRetryTimer(maxRetry int, unit time.Duration, cap time.Duratio
 	return attemptCh
 }
 
-// isNetErrorRetryable - is network error retryable.
-func isNetErrorRetryable(err error) bool {
+// isHTTPReqErrorRetryable - is http requests error retryable, such
+// as i/o timeout, connection broken etc..
+func isHTTPReqErrorRetryable(err error) bool {
 	if err == nil {
 		return false
 	}
-	switch err.(type) {
-	case net.Error:
-		switch err.(type) {
+	switch e := err.(type) {
+	case *url.Error:
+		switch e.Err.(type) {
 		case *net.DNSError, *net.OpError, net.UnknownNetworkError:
 			return true
-		case *url.Error:
-			// For a URL error, where it replies back "connection closed"
-			// retry again.
-			if strings.Contains(err.Error(), "Connection closed by foreign host") {
-				return true
-			}
-		default:
-			if strings.Contains(err.Error(), "net/http: TLS handshake timeout") {
-				// If error is - tlsHandshakeTimeoutError, retry.
-				return true
-			} else if strings.Contains(err.Error(), "i/o timeout") {
-				// If error is - tcp timeoutError, retry.
-				return true
-			} else if strings.Contains(err.Error(), "connection timed out") {
-				// If err is a net.Dial timeout, retry.
-				return true
-			} else if strings.Contains(err.Error(), "net/http: HTTP/1.x transport connection broken") {
-				// If error is transport connection broken, retry.
-				return true
-			}
+		}
+		if strings.Contains(err.Error(), "Connection closed by foreign host") {
+			return true
+		} else if strings.Contains(err.Error(), "net/http: TLS handshake timeout") {
+			// If error is - tlsHandshakeTimeoutError, retry.
+			return true
+		} else if strings.Contains(err.Error(), "i/o timeout") {
+			// If error is - tcp timeoutError, retry.
+			return true
+		} else if strings.Contains(err.Error(), "connection timed out") {
+			// If err is a net.Dial timeout, retry.
+			return true
+		} else if strings.Contains(err.Error(), "net/http: HTTP/1.x transport connection broken") {
+			// If error is transport connection broken, retry.
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
HTTP requests errors, such as i/o timeout and transport connection broken
were not retried at all. Golang's http.Client{}.Do() always returns
*url.Error{} error.