### PR TITLE
Allow sse-s3, sse-kms headers in Put, Get and Copy operations

### DIFF
--- a/api-get-options.go
+++ b/api-get-options.go
@@ -44,7 +44,7 @@ func (o GetObjectOptions) Header() http.Header {
 	for k, v := range o.headers {
 		headers.Set(k, v)
 	}
-	if o.ServerSideEncryption != nil && o.ServerSideEncryption.Type() != encrypt.S3 {
+	if o.ServerSideEncryption != nil && o.ServerSideEncryption.Type() == encrypt.SSEC {
 		o.ServerSideEncryption.Marshal(headers)
 	}
 	return headers

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -259,7 +259,7 @@ func (c Client) uploadPart(ctx context.Context, bucketName, objectName, uploadID
 
 	// Set encryption headers, if any.
 	customHeader := make(http.Header)
-	if sse != nil && sse.Type() != encrypt.S3 && sse.Type() != encrypt.KMS {
+	if sse != nil {
 		sse.Marshal(customHeader)
 	}
 


### PR DESCRIPTION
Encryption headers for SSE-S3, SSE-KMS are not being passed by the sdk for Get/Put/Copy calls. This PR allows encryption headers to be marshalled for SSE-S3,SSE-KMS in addition to SSE-C