### PR TITLE
Pass Etag back in core CompleteMultipartUpload call

### DIFF
--- a/core.go
+++ b/core.go
@@ -117,11 +117,11 @@ func (c Core) ListObjectParts(bucket, object, uploadID string, partNumberMarker 
 }
 
 // CompleteMultipartUpload - Concatenate uploaded parts and commit to an object.
-func (c Core) CompleteMultipartUpload(bucket, object, uploadID string, parts []CompletePart) error {
-	_, err := c.completeMultipartUpload(context.Background(), bucket, object, uploadID, completeMultipartUpload{
+func (c Core) CompleteMultipartUpload(bucket, object, uploadID string, parts []CompletePart) (string, error) {
+	res, err := c.completeMultipartUpload(context.Background(), bucket, object, uploadID, completeMultipartUpload{
 		Parts: parts,
 	})
-	return err
+	return res.ETag, err
 }
 
 // AbortMultipartUpload - Abort an incomplete upload.

--- a/core_test.go
+++ b/core_test.go
@@ -565,7 +565,7 @@ func TestCoreCopyObjectPart(t *testing.T) {
 	}
 
 	// Complete the multipart upload
-	err = c.CompleteMultipartUpload(destBucketName, destObjectName, uploadID, []CompletePart{fstPart, sndPart, lstPart})
+	_, err = c.CompleteMultipartUpload(destBucketName, destObjectName, uploadID, []CompletePart{fstPart, sndPart, lstPart})
 	if err != nil {
 		t.Fatal("Error:", err, destBucketName, destObjectName)
 	}


### PR DESCRIPTION
core.go needs to be enhanced to pass back ETag in CompleteMultipartUpload call.  

This is required by server to pass back correct ETag in the response for a CompleteMultipartOperation specifically for the case of an SSE-C encrypted object at the gateway backend (i.e pass through encryption). 

HEAD calls require SSE-C headers whereas the CompleteMultipartUpload operation does not. This change passes back ETag sent in the CompleteMultipartUpload result , so that the server can set correct ETag in the response. 

related to : https://github.com/minio/minio/issues/6323