### PR TITLE
improve Quick Start Example - File Uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ func main() {
 		} else {
 			log.Fatalln(err)
 		}
+	} else {
+		log.Printf("Successfully created %s\n", bucketName)
 	}
-	log.Printf("Successfully created %s\n", bucketName)
 
 	// Upload the zip file
 	objectName := "golden-oldies.zip"

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ func main() {
 	n, err := minioClient.FPutObject(bucketName, objectName, filePath, minio.PutObjectOptions{ContentType:contentType})
 	if err != nil {
 		log.Fatalln(err)
+	} else {
+		log.Printf("Successfully uploaded %s of size %d\n", objectName, n)
 	}
-
-	log.Printf("Successfully uploaded %s of size %d\n", objectName, n)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+
 	log.Printf("Successfully uploaded %s of size %d\n", objectName, n)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -98,9 +98,8 @@ func main() {
 	n, err := minioClient.FPutObject(bucketName, objectName, filePath, minio.PutObjectOptions{ContentType:contentType})
 	if err != nil {
 		log.Fatalln(err)
-	} else {
-		log.Printf("Successfully uploaded %s of size %d\n", objectName, n)
 	}
+	log.Printf("Successfully uploaded %s of size %d\n", objectName, n)
 }
 ```
 


### PR DESCRIPTION
The example of FileUploader.go logs "Successfully created bucket" after each rerun.

It should probably only log this when it actually creates the bucket.