### PR TITLE
Set Content-Encoding for sigv4-streaming uploads

### DIFF
--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -96,6 +96,12 @@ func buildChunkStringToSign(t time.Time, region, previousSig string, chunkData [
 func prepareStreamingRequest(req *http.Request, sessionToken string, dataLen int64, timestamp time.Time) {
 	// Set x-amz-content-sha256 header.
 	req.Header.Set("X-Amz-Content-Sha256", streamingSignAlgorithm)
+	var encoding = req.Header.Get("Content-Encoding")
+	if encoding == "" {
+		req.Header.Set("Content-Encoding", "aws-chunked")
+	} else {
+		req.Header.Set("Content-Encoding", "aws-chunked, "+encoding)
+	}
 	if sessionToken != "" {
 		req.Header.Set("X-Amz-Security-Token", sessionToken)
 	}


### PR DESCRIPTION
[According to AWS's docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html), "you must include the following headers" when performing a streaming upload:

- `x-amz-content-sha256`
- `Content-Encoding`
- `x-amz-decoded-content-length`
- `Content-Length`

Previously, we omitted `Content-Encoding`; now it will be included like the others. If a `Content-Encoding` is already provided, `aws-chunked` will be prepended.