### PR TITLE
Provide AWS S3 Dual-Stack Endpoints

### DIFF
--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -42,9 +42,9 @@ func TestValidBucketLocation(t *testing.T) {
 		bucketLocation string
 		endpoint       string
 	}{
-		{"us-east-1", "s3.amazonaws.com"},
-		{"unknown", "s3.amazonaws.com"},
-		{"ap-southeast-1", "s3-ap-southeast-1.amazonaws.com"},
+		{"us-east-1", "s3.dualstack.us-east-1.amazonaws.com"},
+		{"unknown", "s3.dualstack.us-east-1.amazonaws.com"},
+		{"ap-southeast-1", "s3.dualstack.ap-southeast-1.amazonaws.com"},
 	}
 	for _, s3Host := range s3Hosts {
 		endpoint := getS3Endpoint(s3Host.bucketLocation)
@@ -176,7 +176,7 @@ func TestMakeTargetURL(t *testing.T) {
 		// Test 4, testing against google storage API
 		{"storage.googleapis.com", true, "mybucket", "", "", nil, url.URL{Host: "mybucket.storage.googleapis.com", Scheme: "https", Path: "/"}, nil},
 		// Test 5, testing against AWS S3 API
-		{"s3.amazonaws.com", true, "mybucket", "myobject", "", nil, url.URL{Host: "mybucket.s3.amazonaws.com", Scheme: "https", Path: "/myobject"}, nil},
+		{"s3.amazonaws.com", true, "mybucket", "myobject", "", nil, url.URL{Host: "mybucket.s3.dualstack.us-east-1.amazonaws.com", Scheme: "https", Path: "/myobject"}, nil},
 		// Test 6
 		{"localhost:9000", false, "mybucket", "myobject", "", nil, url.URL{Host: "localhost:9000", Scheme: "http", Path: "/mybucket/myobject"}, nil},
 		// Test 7, testing with query

--- a/s3-endpoints.go
+++ b/s3-endpoints.go
@@ -19,22 +19,22 @@ package minio
 
 // awsS3EndpointMap Amazon S3 endpoint map.
 var awsS3EndpointMap = map[string]string{
-	"us-east-1":      "s3.amazonaws.com",
-	"us-east-2":      "s3-us-east-2.amazonaws.com",
-	"us-west-2":      "s3-us-west-2.amazonaws.com",
-	"us-west-1":      "s3-us-west-1.amazonaws.com",
-	"ca-central-1":   "s3-ca-central-1.amazonaws.com",
-	"eu-west-1":      "s3-eu-west-1.amazonaws.com",
-	"eu-west-2":      "s3-eu-west-2.amazonaws.com",
-	"eu-west-3":      "s3-eu-west-3.amazonaws.com",
-	"eu-central-1":   "s3-eu-central-1.amazonaws.com",
-	"ap-south-1":     "s3-ap-south-1.amazonaws.com",
-	"ap-southeast-1": "s3-ap-southeast-1.amazonaws.com",
-	"ap-southeast-2": "s3-ap-southeast-2.amazonaws.com",
-	"ap-northeast-1": "s3-ap-northeast-1.amazonaws.com",
-	"ap-northeast-2": "s3-ap-northeast-2.amazonaws.com",
-	"sa-east-1":      "s3-sa-east-1.amazonaws.com",
-	"us-gov-west-1":  "s3-us-gov-west-1.amazonaws.com",
+	"us-east-1":      "s3.dualstack.us-east-1.amazonaws.com",
+	"us-east-2":      "s3.dualstack.us-east-2.amazonaws.com",
+	"us-west-2":      "s3.dualstack.us-west-2.amazonaws.com",
+	"us-west-1":      "s3.dualstack.us-west-1.amazonaws.com",
+	"ca-central-1":   "s3.dualstack.ca-central-1.amazonaws.com",
+	"eu-west-1":      "s3.dualstack.eu-west-1.amazonaws.com",
+	"eu-west-2":      "s3.dualstack.eu-west-2.amazonaws.com",
+	"eu-west-3":      "s3.dualstack.eu-west-3.amazonaws.com",
+	"eu-central-1":   "s3.dualstack.eu-central-1.amazonaws.com",
+	"ap-south-1":     "s3.dualstack.ap-south-1.amazonaws.com",
+	"ap-southeast-1": "s3.dualstack.ap-southeast-1.amazonaws.com",
+	"ap-southeast-2": "s3.dualstack.ap-southeast-2.amazonaws.com",
+	"ap-northeast-1": "s3.dualstack.ap-northeast-1.amazonaws.com",
+	"ap-northeast-2": "s3.dualstack.ap-northeast-2.amazonaws.com",
+	"sa-east-1":      "s3.dualstack.sa-east-1.amazonaws.com",
+	"us-gov-west-1":  "s3.dualstack.us-gov-west-1.amazonaws.com",
 	"cn-north-1":     "s3.cn-north-1.amazonaws.com.cn",
 	"cn-northwest-1": "s3.cn-northwest-1.amazonaws.com.cn",
 }
@@ -43,8 +43,8 @@ var awsS3EndpointMap = map[string]string{
 func getS3Endpoint(bucketLocation string) (s3Endpoint string) {
 	s3Endpoint, ok := awsS3EndpointMap[bucketLocation]
 	if !ok {
-		// Default to 's3.amazonaws.com' endpoint.
-		s3Endpoint = "s3.amazonaws.com"
+		// Default to 's3.dualstack.us-east-1.amazonaws.com' endpoint.
+		s3Endpoint = "s3.dualstack.us-east-1.amazonaws.com"
 	}
 	return s3Endpoint
 }


### PR DESCRIPTION
The [S3 dual-stack endpoints][1] map against both A and AAAA records,
allowing the client to connect using either IPv4 or IPv6, depending on
what is locally available.

At this point there appear to be no IPv6 support for the China regions.

Related to restic/restic#2129.

[1]: https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html