### PR TITLE
Set prefix, delimiter params even when empty

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -192,17 +192,15 @@ func (c Client) listObjectsV2Query(bucketName, objectPrefix, continuationToken s
 	// Always set list-type in ListObjects V2
 	urlValues.Set("list-type", "2")
 
-	// Set object prefix.
-	if objectPrefix != "" {
-		urlValues.Set("prefix", objectPrefix)
-	}
+	// Set object prefix, prefix value to be set to empty is okay.
+	urlValues.Set("prefix", objectPrefix)
+
+	// Set delimiter, delimiter value to be set to empty is okay.
+	urlValues.Set("delimiter", delimiter)
+
 	// Set continuation token
 	if continuationToken != "" {
 		urlValues.Set("continuation-token", continuationToken)
-	}
-	// Set delimiter.
-	if delimiter != "" {
-		urlValues.Set("delimiter", delimiter)
 	}
 
 	// Fetch owner when listing
@@ -380,17 +378,16 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 	// Get resources properly escaped and lined up before
 	// using them in http request.
 	urlValues := make(url.Values)
-	// Set object prefix.
-	if objectPrefix != "" {
-		urlValues.Set("prefix", objectPrefix)
-	}
+
+	// Set object prefix, prefix value to be set to empty is okay.
+	urlValues.Set("prefix", objectPrefix)
+
+	// Set delimiter, delimiter value to be set to empty is okay.
+	urlValues.Set("delimiter", delimiter)
+
 	// Set object marker.
 	if objectMarker != "" {
 		urlValues.Set("marker", objectMarker)
-	}
-	// Set delimiter.
-	if delimiter != "" {
-		urlValues.Set("delimiter", delimiter)
 	}
 
 	// maxkeys should default to 1000 or less.
@@ -563,14 +560,12 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 	if uploadIDMarker != "" {
 		urlValues.Set("upload-id-marker", uploadIDMarker)
 	}
-	// Set prefix marker.
-	if prefix != "" {
-		urlValues.Set("prefix", prefix)
-	}
-	// Set delimiter.
-	if delimiter != "" {
-		urlValues.Set("delimiter", delimiter)
-	}
+
+	// Set object prefix, prefix value to be set to empty is okay.
+	urlValues.Set("prefix", prefix)
+
+	// Set delimiter, delimiter value to be set to empty is okay.
+	urlValues.Set("delimiter", delimiter)
 
 	// maxUploads should be 1000 or less.
 	if maxUploads == 0 || maxUploads > 1000 {


### PR DESCRIPTION
We have never set values which are empty on the request
because they are perhaps not useful in the List query,
but this assumption is wrong when there are restricted
policies for a given user, because empty is actually
a valid value in IAM or Bucket policy conditions.

For example, the following condition would never work with our
ListObjects API and AWS cli would work fine.
```json
            "Condition": {
                "StringEquals": {
                    "s3:prefix": [
                        "",
                        "data/",
                        "data"
                    ],
                    "s3:delimiter": [
                        "/",
                        ""
                    ]
                }
            }
```

The reason is empty or not `prefix` and `delimiter` should be
added to the query param in List operation, such that server
can use the value to validate the policies for the incoming
request.

Fixes https://github.com/minio/mc/issues/2647