### PR TITLE
Strip 80/443 in getBucketLocationRequest

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -18,6 +18,7 @@
 package minio
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -162,6 +163,14 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 
 	// Set get bucket location always as path style.
 	targetURL := c.endpointURL
+	
+	// as it works in makeTargetURL method from api.go file
+	if h, p, err := net.SplitHostPort(targetURL.Host); err == nil {
+		if targetURL.Scheme == "http" && p == "80" || targetURL.Scheme == "https" && p == "443" {
+			targetURL.Host = h
+		}
+	}
+	
 	targetURL.Path = path.Join(bucketName, "") + "/"
 	targetURL.RawQuery = urlValues.Encode()
 

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -163,14 +163,14 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 
 	// Set get bucket location always as path style.
 	targetURL := c.endpointURL
-	
+
 	// as it works in makeTargetURL method from api.go file
 	if h, p, err := net.SplitHostPort(targetURL.Host); err == nil {
 		if targetURL.Scheme == "http" && p == "80" || targetURL.Scheme == "https" && p == "443" {
 			targetURL.Host = h
 		}
 	}
-	
+
 	targetURL.Path = path.Join(bucketName, "") + "/"
 	targetURL.RawQuery = urlValues.Encode()
 


### PR DESCRIPTION
There was the PR #709 with it, but works only partly. 
Currently it works only with workaround by specifying `us-east-1` region (`minio.NewWithRegion(...)`)
With this patch you can just do `minio.New(...)` and all will work flawlessly.