### PR TITLE
Filter Expires from user defined metadata

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -41,6 +41,7 @@ type ObjectInfo struct {
 	LastModified time.Time `json:"lastModified"` // Date and time the object was last modified.
 	Size         int64     `json:"size"`         // Size in bytes of the object.
 	ContentType  string    `json:"contentType"`  // A standard MIME type describing the format of the object data.
+	Expires      time.Time `json:"expires"`      // The date and time at which the object is no longer able to be cached.
 
 	// Collection of additional metadata on the object.
 	// eg: x-amz-meta-*, content-encoding etc.

--- a/api-stat.go
+++ b/api-stat.go
@@ -84,6 +84,7 @@ func extractObjMetadata(header http.Header) http.Header {
 		"Content-Length",
 		"Last-Modified",
 		"Content-Type",
+		"Expires",
 	}, defaultFilterKeys...)
 	return filterHeader(header, filterKeys)
 }
@@ -170,6 +171,11 @@ func (c Client) statObject(ctx context.Context, bucketName, objectName string, o
 		contentType = "application/octet-stream"
 	}
 
+	expiryStr := resp.Header.Get("Expires")
+	var expTime time.Time
+	if t, err := time.Parse(http.TimeFormat, expiryStr); err == nil {
+		expTime = t.UTC()
+	}
 	// Save object metadata info.
 	return ObjectInfo{
 		ETag:         md5sum,
@@ -177,6 +183,7 @@ func (c Client) statObject(ctx context.Context, bucketName, objectName string, o
 		Size:         size,
 		LastModified: date,
 		ContentType:  contentType,
+		Expires:      expTime,
 		// Extract only the relevant header keys describing the object.
 		// following function filters out a list of standard set of keys
 		// which are not part of object metadata.


### PR DESCRIPTION
Fixes : https://github.com/minio/mc/issues/2690
Currently minio server drops "Expires" header into user defined metadata which causes Copy failure when source has "Expires" http header. 

Repro: 
```
 aws s3api put-object --bucket tbucket11 --key e1  --body /home/kris/Downloads/smallfile  --expires "Wed, 21 Feb 2019 07:28:00 GMT" --endpoint-url http://localhost:9000
➜  minio mc cp mys3/tbucket11/e1 s3/tbucket11/e2
mc: <ERROR> Failed to copy `http://s3.amazonaws.com/tbucket11/e1`. Expires unsupported user defined metadata name
mc: <ERROR> Session safely terminated. To resume session `mc session resume IunnkPaw`
```
