### PR TITLE
Support HTTP 2.0 in DefaultTransport for TLS requests

### DIFF
--- a/api-put-object-common.go
+++ b/api-put-object-common.go
@@ -34,26 +34,25 @@ func isObject(reader io.Reader) (ok bool) {
 
 // Verify if reader is a generic ReaderAt
 func isReadAt(reader io.Reader) (ok bool) {
-	_, ok = reader.(io.ReaderAt)
+	var v *os.File
+	v, ok = reader.(*os.File)
 	if ok {
-		var v *os.File
-		v, ok = reader.(*os.File)
-		if ok {
-			// Stdin, Stdout and Stderr all have *os.File type
-			// which happen to also be io.ReaderAt compatible
-			// we need to add special conditions for them to
-			// be ignored by this function.
-			for _, f := range []string{
-				"/dev/stdin",
-				"/dev/stdout",
-				"/dev/stderr",
-			} {
-				if f == v.Name() {
-					ok = false
-					break
-				}
+		// Stdin, Stdout and Stderr all have *os.File type
+		// which happen to also be io.ReaderAt compatible
+		// we need to add special conditions for them to
+		// be ignored by this function.
+		for _, f := range []string{
+			"/dev/stdin",
+			"/dev/stdout",
+			"/dev/stderr",
+		} {
+			if f == v.Name() {
+				ok = false
+				break
 			}
 		}
+	} else {
+		_, ok = reader.(io.ReaderAt)
 	}
 	return
 }

--- a/api.go
+++ b/api.go
@@ -295,10 +295,15 @@ func privateNew(endpoint string, creds *credentials.Credentials, secure bool, re
 	// Save endpoint URL, user agent for future uses.
 	clnt.endpointURL = endpointURL
 
+	transport, err := DefaultTransport(secure)
+	if err != nil {
+		return nil, err
+	}
+
 	// Instantiate http client and bucket location cache.
 	clnt.httpClient = &http.Client{
 		Jar:           jar,
-		Transport:     DefaultTransport,
+		Transport:     transport,
 		CheckRedirect: clnt.redirectHeaders,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c // indirect
 	golang.org/x/crypto v0.0.0-20190128193316-c7b33c32a30b
-	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
+	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd
 	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e // indirect
 	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/ini.v1 v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c h1:Ho+uVpke
 github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
 golang.org/x/crypto v0.0.0-20190128193316-c7b33c32a30b h1:Ib/yptP38nXZFMwqWSip+OKuMP9OkyDe3p+DssP8n9w=
 golang.org/x/crypto v0.0.0-20190128193316-c7b33c32a30b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
-golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e h1:3GIlrlVLfkoipSReOMNAgApI0ajnalyLa/EZHHca/XI=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/transport.go
+++ b/transport.go
@@ -20,31 +20,63 @@
 package minio
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"net/http"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
 // DefaultTransport - this default transport is similar to
 // http.DefaultTransport but with additional param  DisableCompression
 // is set to true to avoid decompressing content with 'gzip' encoding.
-var DefaultTransport http.RoundTripper = &http.Transport{
-	Proxy: http.ProxyFromEnvironment,
-	DialContext: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		DualStack: true,
-	}).DialContext,
-	MaxIdleConns:          100,
-	MaxIdleConnsPerHost:   100,
-	IdleConnTimeout:       90 * time.Second,
-	TLSHandshakeTimeout:   10 * time.Second,
-	ExpectContinueTimeout: 1 * time.Second,
-	// Set this value so that the underlying transport round-tripper
-	// doesn't try to auto decode the body of objects with
-	// content-encoding set to `gzip`.
-	//
-	// Refer:
-	//    https://golang.org/src/net/http/transport.go?h=roundTrip#L1843
-	DisableCompression: true,
+var DefaultTransport = func(secure bool) (http.RoundTripper, error) {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          1024,
+		MaxIdleConnsPerHost:   1024,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		// Set this value so that the underlying transport round-tripper
+		// doesn't try to auto decode the body of objects with
+		// content-encoding set to `gzip`.
+		//
+		// Refer:
+		//    https://golang.org/src/net/http/transport.go?h=roundTrip#L1843
+		DisableCompression: true,
+	}
+
+	if secure {
+		rootCAs, _ := x509.SystemCertPool()
+		if rootCAs == nil {
+			// In some systems (like Windows) system cert pool is
+			// not supported or no certificates are present on the
+			// system - so we create a new cert pool.
+			rootCAs = x509.NewCertPool()
+		}
+
+		// Keep TLS config.
+		tlsConfig := &tls.Config{
+			RootCAs: rootCAs,
+			// Can't use SSLv3 because of POODLE and BEAST
+			// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+			// Can't use TLSv1.1 because of RC4 cipher usage
+			MinVersion: tls.VersionTLS12,
+		}
+		tr.TLSClientConfig = tlsConfig
+
+		// Because we create a custom TLSClientConfig, we have to opt-in to HTTP/2.
+		// See https://github.com/golang/go/issues/14275
+		if err := http2.ConfigureTransport(tr); err != nil {
+			return nil, err
+		}
+	}
+	return tr, nil
 }


### PR DESCRIPTION
This fixes the unit tests failure in the master branch