### PR TITLE
Omit empty CSV options for select api

### DIFF
--- a/api-select.go
+++ b/api-select.go
@@ -90,19 +90,19 @@ type ParquetInputOptions struct{}
 type CSVInputOptions struct {
 	FileHeaderInfo       CSVFileHeaderInfo
 	RecordDelimiter      string
-	FieldDelimiter       string
-	QuoteCharacter       string
-	QuoteEscapeCharacter string
-	Comments             string
+	FieldDelimiter       string `xml:",omitempty"`
+	QuoteCharacter       string `xml:",omitempty"`
+	QuoteEscapeCharacter string `xml:",omitempty"`
+	Comments             string `xml:",omitempty"`
 }
 
 // CSVOutputOptions csv output specific options
 type CSVOutputOptions struct {
-	QuoteFields          CSVQuoteFields
+	QuoteFields          CSVQuoteFields `xml:",omitempty"`
 	RecordDelimiter      string
-	FieldDelimiter       string
-	QuoteCharacter       string
-	QuoteEscapeCharacter string
+	FieldDelimiter       string `xml:",omitempty"`
+	QuoteCharacter       string `xml:",omitempty"`
+	QuoteEscapeCharacter string `xml:",omitempty"`
 }
 
 // JSONInputOptions json input specific options


### PR DESCRIPTION
w.r.t https://github.com/minio/mc/pull/2687 , select options sent to server need not marshal fields that are empty