### PR TITLE
Retry errors caused by a timeout waiting for the server response

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -111,6 +111,9 @@ func isHTTPReqErrorRetryable(err error) bool {
 		} else if strings.Contains(err.Error(), "net/http: HTTP/1.x transport connection broken") {
 			// If error is transport connection broken, retry.
 			return true
+		} else if strings.Contains(err.Error(), "net/http: timeout awaiting response headers") {
+			// Retry errors due to server not sending the response before timeout
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
Adding to our matches for retriable errors.

Context in slack: https://minio.slack.com/archives/C3NDUB8UA/p1559138109140600