### PR TITLE
Retry on AccessDenied only in restricted cases

### DIFF
--- a/api.go
+++ b/api.go
@@ -668,8 +668,15 @@ func (c Client) executeMethod(ctx context.Context, method string, metadata reque
 					}
 				} else {
 					// Most probably for ListBuckets()
-					metadata.bucketLocation = errResponse.Region
-					continue // Retry
+					if errResponse.Region != metadata.bucketLocation {
+						// Retry if the error
+						// response has a
+						// different region
+						// than the request we
+						// just made.
+						metadata.bucketLocation = errResponse.Region
+						continue // Retry
+					}
 				}
 			}
 		}


### PR DESCRIPTION
List buckets should be retried on an AccessDenied error only if the
region in the reponse is only different from the region in the request
just made.