### PR TITLE
fix error message for wrong content length on putobject

### DIFF
--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -285,7 +285,7 @@ func (s *StreamingReader) Read(buf []byte) (int, error) {
 					// bytes read from baseReader different than
 					// content length provided.
 					if s.bytesRead != s.contentLen {
-						return 0, io.ErrUnexpectedEOF
+						return 0, fmt.Errorf("http: ContentLength=%d with Body length %d", s.contentLen, s.bytesRead)
 					}
 
 					// Sign the chunk and write it to s.buf.


### PR DESCRIPTION
When putObject is called with bigger ContentLength than the actual
object size, Unexpected EOF error is thrown which is not clear.
This happens only with streaming signature.

Now the SteamingReader Read will return a specific error message
saying mismatch in content length, instead of Unexpected EOF.
For example "http: ContentLength=75444 with Body length 70444"

Fixes #1135