### PR TITLE
add `EndpointURL` method to S3 client

### DIFF
--- a/api.go
+++ b/api.go
@@ -187,6 +187,12 @@ func NewWithOptions(endpoint string, opts *Options) (*Client, error) {
 	return privateNew(endpoint, opts.Creds, opts.Secure, opts.Region, opts.BucketLookup)
 }
 
+// EndpointURL returns the URL of the S3 endpoint.
+func (c *Client) EndpointURL() *url.URL {
+	endpoint := *c.endpointURL // copy to prevent callers from modifying internal state
+	return &endpoint
+}
+
 // lockedRandSource provides protected rand source, implements rand.Source interface.
 type lockedRandSource struct {
 	lk  sync.Mutex


### PR DESCRIPTION
This commit adds an EndpointURL method to
the S3 client such that calling code can
get the S3 endpoint in all contexts.

Fixes #1134