### PR TITLE
Add user metadata headers into ObjectInfo

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -47,6 +47,9 @@ type ObjectInfo struct {
 	// eg: x-amz-meta-*, content-encoding etc.
 	Metadata http.Header `json:"metadata" xml:"-"`
 
+	// x-amz-meta-* headers stripped "x-amz-meta-" prefix containing the first value.
+	UserMetadata map[string]string `json:"userMetadata" xml:"-"`
+
 	// Owner name.
 	Owner struct {
 		DisplayName string `json:"name"`


### PR DESCRIPTION
Now StatObject calls returns ObjectInfo contains user metadata which
is stripped "x-amz-meta-" prefix with first value.

Fixes #1145