### PR TITLE
set encoding type to url in listobjects API

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -192,6 +192,9 @@ func (c Client) listObjectsV2Query(bucketName, objectPrefix, continuationToken s
 	// Always set list-type in ListObjects V2
 	urlValues.Set("list-type", "2")
 
+	// Always set encoding-type in ListObjects V2
+	urlValues.Set("encoding-type", "url")
+
 	// Set object prefix, prefix value to be set to empty is okay.
 	urlValues.Set("prefix", objectPrefix)
 
@@ -396,6 +399,9 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 	}
 	// Set max keys.
 	urlValues.Set("max-keys", fmt.Sprintf("%d", maxkeys))
+
+	// Always set encoding-type
+	urlValues.Set("encoding-type", "url")
 
 	// Execute GET on bucket to list objects.
 	resp, err := c.executeMethod(context.Background(), "GET", requestMetadata{

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -8603,7 +8603,7 @@ func testStorageClassMetadataCopyObject() {
 	src := minio.NewSourceInfo(bucketName, "srcObjectRRSClass", nil)
 	dst, err := minio.NewDestinationInfo(bucketName, "srcObjectRRSClassCopy", nil, nil)
 	if err = c.CopyObject(dst, src); err != nil {
-		logError(testName,function,args,startTime,"", "CopyObject failed on RRS", err)
+		logError(testName, function, args, startTime, "", "CopyObject failed on RRS", err)
 	}
 
 	// Get the returned metadata


### PR DESCRIPTION
This will fix issues seen like the one in https://github.com/minio/mc/issues/2899
Also fix formatting in functional tests