### PR TITLE
Response header returned from getObject 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ matrix:
 
 before_install:
   - sudo apt-get install devscripts
-  - go get github.com/minio/minio
+  - mkdir /tmp/minio
+  - (cd /tmp/minio; GO111MODULE=on go get github.com/minio/minio)
   - sudo cp testcerts/public.crt /usr/local/share/ca-certificates/
   - sudo update-ca-certificates
   - MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123 ${GOPATH}/bin/minio server --compat --quiet --certs-dir testcerts data 2>&1 > minio.log &

--- a/api-get-object-file.go
+++ b/api-get-object-file.go
@@ -100,7 +100,7 @@ func (c Client) fGetObjectWithContext(ctx context.Context, bucketName, objectNam
 	}
 
 	// Seek to current position for incoming reader.
-	objectReader, objectStat, err := c.getObject(ctx, bucketName, objectName, opts)
+	objectReader, objectStat, _, err := c.getObject(ctx, bucketName, objectName, opts)
 	if err != nil {
 		return err
 	}

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -92,7 +92,7 @@ func (c Client) getObjectWithContext(ctx context.Context, bucketName, objectName
 						} else if req.Offset > 0 {
 							opts.SetRange(req.Offset, 0)
 						}
-						httpReader, objectInfo, err = c.getObject(ctx, bucketName, objectName, opts)
+						httpReader, objectInfo, _, err = c.getObject(ctx, bucketName, objectName, opts)
 						if err != nil {
 							resCh <- getResponse{Error: err}
 							return
@@ -173,7 +173,7 @@ func (c Client) getObjectWithContext(ctx context.Context, bucketName, objectName
 						} else if req.Offset > 0 { // Range is set with respect to the offset.
 							opts.SetRange(req.Offset, 0)
 						}
-						httpReader, objectInfo, err = c.getObject(ctx, bucketName, objectName, opts)
+						httpReader, objectInfo, _, err = c.getObject(ctx, bucketName, objectName, opts)
 						if err != nil {
 							resCh <- getResponse{
 								Error: err,
@@ -596,13 +596,13 @@ func newObject(reqCh chan<- getRequest, resCh <-chan getResponse, doneCh chan<- 
 //
 // For more information about the HTTP Range header.
 // go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.
-func (c Client) getObject(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, error) {
+func (c Client) getObject(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, http.Header, error) {
 	// Validate input arguments.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
-		return nil, ObjectInfo{}, err
+		return nil, ObjectInfo{}, nil, err
 	}
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
-		return nil, ObjectInfo{}, err
+		return nil, ObjectInfo{}, nil, err
 	}
 
 	// Execute GET on objectName.
@@ -613,11 +613,11 @@ func (c Client) getObject(ctx context.Context, bucketName, objectName string, op
 		contentSHA256Hex: emptySHA256Hex,
 	})
 	if err != nil {
-		return nil, ObjectInfo{}, err
+		return nil, ObjectInfo{}, nil, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-			return nil, ObjectInfo{}, httpRespToErrorResponse(resp, bucketName, objectName)
+			return nil, ObjectInfo{}, nil, httpRespToErrorResponse(resp, bucketName, objectName)
 		}
 	}
 
@@ -629,7 +629,7 @@ func (c Client) getObject(ctx context.Context, bucketName, objectName string, op
 	date, err := time.Parse(http.TimeFormat, resp.Header.Get("Last-Modified"))
 	if err != nil {
 		msg := "Last-Modified time format not recognized. " + reportIssue
-		return nil, ObjectInfo{}, ErrorResponse{
+		return nil, ObjectInfo{}, nil, ErrorResponse{
 			Code:      "InternalError",
 			Message:   msg,
 			RequestID: resp.Header.Get("x-amz-request-id"),
@@ -657,5 +657,5 @@ func (c Client) getObject(ctx context.Context, bucketName, objectName string, op
 	}
 
 	// do not close body here, caller will close
-	return resp.Body, objectStat, nil
+	return resp.Body, objectStat, resp.Header, nil
 }

--- a/core.go
+++ b/core.go
@@ -20,6 +20,7 @@ package minio
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/minio/minio-go/v6/pkg/encrypt"
@@ -176,14 +177,14 @@ func (c Core) PutBucketPolicy(bucket, bucketPolicy string) error {
 // GetObjectWithContext is a lower level API implemented to support reading
 // partial objects and also downloading objects with special conditions
 // matching etag, modtime etc.
-func (c Core) GetObjectWithContext(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, error) {
+func (c Core) GetObjectWithContext(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, http.Header, error) {
 	return c.getObject(ctx, bucketName, objectName, opts)
 }
 
 // GetObject is a lower level API implemented to support reading
 // partial objects and also downloading objects with special conditions
 // matching etag, modtime etc.
-func (c Core) GetObject(bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, error) {
+func (c Core) GetObject(bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, http.Header, error) {
 	return c.GetObjectWithContext(context.Background(), bucketName, objectName, opts)
 }
 

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -6245,7 +6245,7 @@ func testEncryptedCopyObjectWrapper(c *minio.Client, bucketName string, sseSrc, 
 	}
 	// 3. get copied object and check if content is equal
 	coreClient := minio.Core{c}
-	reader, _, err := coreClient.GetObject(bucketName, "dstObject", minio.GetObjectOptions{ServerSideEncryption: dstEncryption})
+	reader, _, _, err := coreClient.GetObject(bucketName, "dstObject", minio.GetObjectOptions{ServerSideEncryption: dstEncryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject failed", err)
 		return
@@ -6285,7 +6285,7 @@ func testEncryptedCopyObjectWrapper(c *minio.Client, bucketName string, sseSrc, 
 		}
 
 		// Get copied object and check if content is equal
-		reader, _, err = coreClient.GetObject(bucketName, "srcObject", minio.GetObjectOptions{ServerSideEncryption: newSSE})
+		reader, _, _, err = coreClient.GetObject(bucketName, "srcObject", minio.GetObjectOptions{ServerSideEncryption: newSSE})
 		if err != nil {
 			logError(testName, function, args, startTime, "", "GetObject failed", err)
 			return
@@ -6319,7 +6319,7 @@ func testEncryptedCopyObjectWrapper(c *minio.Client, bucketName string, sseSrc, 
 	}
 
 	// Get copied decrypted object and check if content is equal
-	reader, _, err = coreClient.GetObject(bucketName, "srcObject", minio.GetObjectOptions{})
+	reader, _, _, err = coreClient.GetObject(bucketName, "srcObject", minio.GetObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject failed", err)
 		return
@@ -6814,7 +6814,7 @@ func testSSECMultipartEncryptedToSSECCopyObjectPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{ServerSideEncryption: dstencryption}
 	getOpts.SetRange(0, 6*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -6828,7 +6828,7 @@ func testSSECMultipartEncryptedToSSECCopyObjectPart() {
 	}
 
 	getOpts.SetRange(6*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -6965,7 +6965,7 @@ func testSSECEncryptedToSSECCopyObjectPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{ServerSideEncryption: dstencryption}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -6979,7 +6979,7 @@ func testSSECEncryptedToSSECCopyObjectPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7115,7 +7115,7 @@ func testSSECEncryptedToUnencryptedCopyPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7129,7 +7129,7 @@ func testSSECEncryptedToUnencryptedCopyPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7267,7 +7267,7 @@ func testSSECEncryptedToSSES3CopyObjectPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7281,7 +7281,7 @@ func testSSECEncryptedToSSES3CopyObjectPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7416,7 +7416,7 @@ func testUnencryptedToSSECCopyObjectPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{ServerSideEncryption: dstencryption}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7430,7 +7430,7 @@ func testUnencryptedToSSECCopyObjectPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7562,7 +7562,7 @@ func testUnencryptedToUnencryptedCopyPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7576,7 +7576,7 @@ func testUnencryptedToUnencryptedCopyPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7711,7 +7711,7 @@ func testUnencryptedToSSES3CopyObjectPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7725,7 +7725,7 @@ func testUnencryptedToSSES3CopyObjectPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7860,7 +7860,7 @@ func testSSES3EncryptedToSSECCopyObjectPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{ServerSideEncryption: dstencryption}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -7874,7 +7874,7 @@ func testSSES3EncryptedToSSECCopyObjectPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -8007,7 +8007,7 @@ func testSSES3EncryptedToUnencryptedCopyPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -8021,7 +8021,7 @@ func testSSES3EncryptedToUnencryptedCopyPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -8157,7 +8157,7 @@ func testSSES3EncryptedToSSES3CopyObjectPart() {
 	// Now we read the data back
 	getOpts := minio.GetObjectOptions{}
 	getOpts.SetRange(0, 5*1024*1024-1)
-	r, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err := c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}
@@ -8171,7 +8171,7 @@ func testSSES3EncryptedToSSES3CopyObjectPart() {
 	}
 
 	getOpts.SetRange(5*1024*1024, 0)
-	r, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
+	r, _, _, err = c.GetObject(destBucketName, destObjectName, getOpts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObject call failed", err)
 	}


### PR DESCRIPTION
Closes #1106 

getObject returns the response headers which is exposed in Core.
``` 
func (c Core) GetObject(bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, http.Header, error) {
	return c.GetObjectWithContext(context.Background(), bucketName, objectName, opts)
}
 ```
The response headers are not exposed for client.
i.e. No change in the below code.
```
// GetObject - returns an seekable, readable object.
func (c Client) GetObject(bucketName, objectName string, opts GetObjectOptions) (*Object, error) {
	return c.getObjectWithContext(context.Background(), bucketName, objectName, opts)
}
```


