### PR TITLE
Credentials: Support assuming role via WebIdentityTokenFile

### DIFF
--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -54,40 +55,9 @@ type IAM struct {
 const (
 	defaultIAMRoleEndpoint      = "http://169.254.169.254"
 	defaultECSRoleEndpoint      = "http://169.254.170.2"
+	defaultSTSRoleEndpoint      = "https://sts.amazonaws.com"
 	defaultIAMSecurityCredsPath = "/latest/meta-data/iam/security-credentials/"
 )
-
-// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
-func getEndpoint(endpoint string) (string, bool, error) {
-	ecsFullURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
-	ecsURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
-
-	if endpoint != "" {
-		return endpoint, ecsURI != "" || ecsFullURI != "", nil
-	}
-	if ecsFullURI != "" {
-		u, err := url.Parse(ecsFullURI)
-		if err != nil {
-			return "", false, err
-		}
-		host := u.Hostname()
-		if host == "" {
-			return "", false, fmt.Errorf("can't parse host from uri: %s", ecsFullURI)
-		}
-
-		if loopback, err := isLoopback(host); loopback {
-			return ecsFullURI, true, nil
-		} else if err != nil {
-			return "", false, err
-		} else {
-			return "", false, fmt.Errorf("host is not on a loopback address: %s", host)
-		}
-	}
-	if ecsURI != "" {
-		return fmt.Sprintf("%s%s", defaultECSRoleEndpoint, ecsURI), true, nil
-	}
-	return defaultIAMRoleEndpoint, false, nil
-}
 
 // NewIAM returns a pointer to a new Credentials object wrapping the IAM.
 func NewIAM(endpoint string) *Credentials {
@@ -107,16 +77,61 @@ func (m *IAM) Retrieve() (Value, error) {
 	var roleCreds ec2RoleCredRespBody
 	var err error
 
-	endpoint, isEcsTask, err := getEndpoint(m.endpoint)
-	if err != nil {
-		return Value{}, err
-	}
+	endpoint := m.endpoint
+	switch {
+	case len(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")) > 0:
+		if len(endpoint) == 0 {
+			if len(os.Getenv("AWS_REGION")) > 0 {
+				endpoint = "sts." + os.Getenv("AWS_REGION") + ".amazonaws.com"
+			} else {
+				endpoint = defaultSTSRoleEndpoint
+			}
+		}
 
-	if isEcsTask {
+		creds := &STSWebIdentity{
+			Client:          m.Client,
+			stsEndpoint:     endpoint,
+			roleARN:         os.Getenv("AWS_ROLE_ARN"),
+			roleSessionName: os.Getenv("AWS_ROLE_SESSION_NAME"),
+			getWebIDTokenExpiry: func() (*WebIdentityToken, error) {
+				token, err := ioutil.ReadFile(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
+				if err != nil {
+					return nil, err
+				}
+
+				return &WebIdentityToken{Token: string(token)}, nil
+			},
+		}
+
+		return creds.Retrieve()
+
+	case len(os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")) > 0:
+		if len(endpoint) == 0 {
+			endpoint = fmt.Sprintf("%s%s", defaultECSRoleEndpoint,
+				os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"))
+		}
+
 		roleCreds, err = getEcsTaskCredentials(m.Client, endpoint)
-	} else {
+
+	case len(os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")) > 0:
+		if len(endpoint) == 0 {
+			endpoint = os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+
+			var ok bool
+			if ok, err = isLoopback(endpoint); !ok {
+				if err == nil {
+					err = fmt.Errorf("uri host is not a loopback address: %s", endpoint)
+				}
+				break
+			}
+		}
+
+		roleCreds, err = getEcsTaskCredentials(m.Client, endpoint)
+
+	default:
 		roleCreds, err = getCredentials(m.Client, endpoint)
 	}
+
 	if err != nil {
 		return Value{}, err
 	}
@@ -276,8 +291,18 @@ func getCredentials(client *http.Client, endpoint string) (ec2RoleCredRespBody, 
 	return respCreds, nil
 }
 
-// isLoopback identifies if a host is on a loopback address
-func isLoopback(host string) (bool, error) {
+// isLoopback identifies if a uri's host is on a loopback address
+func isLoopback(uri string) (bool, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return false, err
+	}
+
+	host := u.Hostname()
+	if len(host) == 0 {
+		return false, fmt.Errorf("can't parse host from uri: %s", uri)
+	}
+
 	ips, err := net.LookupHost(host)
 	if err != nil {
 		return false, err

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -21,6 +21,7 @@ package credentials
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,6 +51,27 @@ const credsRespEcsTaskTmpl = `{
 	"Token" : "token",
 	"Expiration" : "%s"
 }`
+
+const credsRespStsImpl = `<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<AssumeRoleWithWebIdentityResult>
+  <SubjectFromWebIdentityToken>amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A</SubjectFromWebIdentityToken>
+  <Audience>client.5498841531868486423.1548@apps.example.com</Audience>
+  <AssumedRoleUser>
+	<Arn>arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1</Arn>
+	<AssumedRoleId>AROACLKWSDQRAOEXAMPLE:app1</AssumedRoleId>
+  </AssumedRoleUser>
+  <Credentials>
+	<SessionToken>token</SessionToken>
+	<SecretAccessKey>secret</SecretAccessKey>
+	<Expiration>%s</Expiration>
+	<AccessKeyId>accessKey</AccessKeyId>
+  </Credentials>
+  <Provider>www.amazon.com</Provider>
+</AssumeRoleWithWebIdentityResult>
+<ResponseMetadata>
+  <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+</ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`
 
 func initTestFailServer() *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -86,6 +108,22 @@ func initTestServer(expireOn string, failAssume bool) *httptest.Server {
 func initEcsTaskTestServer(expireOn string) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, credsRespEcsTaskTmpl, expireOn)
+	}))
+
+	return server
+}
+
+func initStsTestServer(expireOn string) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		required := []string{"RoleArn", "RoleSessionName", "WebIdentityToken", "Version"}
+		for _, field := range required {
+			if _, ok := r.URL.Query()[field]; !ok {
+				http.Error(w, fmt.Sprintf("%s missing", field), http.StatusBadRequest)
+				return
+			}
+		}
+
+		fmt.Fprintf(w, credsRespStsImpl, expireOn)
 	}))
 
 	return server
@@ -254,6 +292,47 @@ func TestEcsTaskFullURI(t *testing.T) {
 		fmt.Sprintf("%s%s", server.URL, "/v2/credentials?id=task_credential_id"))
 	creds, err := p.Retrieve()
 	os.Unsetenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+	if err != nil {
+		t.Errorf("Unexpected failure %s", err)
+	}
+	if "accessKey" != creds.AccessKeyID {
+		t.Errorf("Expected \"accessKey\", got %s", creds.AccessKeyID)
+	}
+
+	if "secret" != creds.SecretAccessKey {
+		t.Errorf("Expected \"secret\", got %s", creds.SecretAccessKey)
+	}
+
+	if "token" != creds.SessionToken {
+		t.Errorf("Expected \"token\", got %s", creds.SessionToken)
+	}
+
+	if !p.IsExpired() {
+		t.Error("Expected creds to be expired.")
+	}
+}
+
+func TestSts(t *testing.T) {
+	server := initStsTestServer("2014-12-16T01:51:37Z")
+	defer server.Close()
+	p := &IAM{
+		Client:   http.DefaultClient,
+		endpoint: server.URL,
+	}
+
+	f, err := ioutil.TempFile("", "minio-go")
+	if err != nil {
+		t.Errorf("Unexpected failure %s", err)
+	}
+	defer os.Remove(f.Name())
+	f.Write([]byte("token"))
+	f.Close()
+
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", f.Name())
+	os.Setenv("AWS_ROLE_ARN", "arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1")
+	creds, err := p.Retrieve()
+	os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+	os.Unsetenv("AWS_ROLE_ARN")
 	if err != nil {
 		t.Errorf("Unexpected failure %s", err)
 	}

--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -121,7 +121,9 @@ func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSession
 		v.Set("RoleSessionName", roleSessionName)
 	}
 	v.Set("WebIdentityToken", idToken.Token)
-	v.Set("DurationSeconds", fmt.Sprintf("%d", idToken.Expiry))
+	if idToken.Expiry > 0 {
+		v.Set("DurationSeconds", fmt.Sprintf("%d", idToken.Expiry))
+	}
 	v.Set("Version", "2011-06-15")
 
 	u, err := url.Parse(endpoint)

--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -75,6 +76,13 @@ type STSWebIdentity struct {
 	// this token.
 	// This is a customer provided function and is mandatory.
 	getWebIDTokenExpiry func() (*WebIdentityToken, error)
+
+	// roleARN is the Amazon Resource Name (ARN) of the role that the caller is
+	// assuming.
+	roleARN string
+
+	// roleSessionName is the identifier for the assumed role session.
+	roleSessionName string
 }
 
 // NewSTSWebIdentity returns a pointer to a new
@@ -95,7 +103,7 @@ func NewSTSWebIdentity(stsEndpoint string, getWebIDTokenExpiry func() (*WebIdent
 	}), nil
 }
 
-func getWebIdentityCredentials(clnt *http.Client, endpoint string,
+func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSessionName string,
 	getWebIDTokenExpiry func() (*WebIdentityToken, error)) (AssumeRoleWithWebIdentityResponse, error) {
 	idToken, err := getWebIDTokenExpiry()
 	if err != nil {
@@ -104,6 +112,14 @@ func getWebIdentityCredentials(clnt *http.Client, endpoint string,
 
 	v := url.Values{}
 	v.Set("Action", "AssumeRoleWithWebIdentity")
+	if len(roleARN) > 0 {
+		v.Set("RoleArn", roleARN)
+
+		if len(roleSessionName) == 0 {
+			roleSessionName = strconv.FormatInt(time.Now().UnixNano(), 10)
+		}
+		v.Set("RoleSessionName", roleSessionName)
+	}
 	v.Set("WebIdentityToken", idToken.Token)
 	v.Set("DurationSeconds", fmt.Sprintf("%d", idToken.Expiry))
 	v.Set("Version", "2011-06-15")
@@ -141,7 +157,7 @@ func getWebIdentityCredentials(clnt *http.Client, endpoint string,
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
 func (m *STSWebIdentity) Retrieve() (Value, error) {
-	a, err := getWebIdentityCredentials(m.Client, m.stsEndpoint, m.getWebIDTokenExpiry)
+	a, err := getWebIdentityCredentials(m.Client, m.stsEndpoint, m.roleARN, m.roleSessionName, m.getWebIDTokenExpiry)
 	if err != nil {
 		return Value{}, err
 	}


### PR DESCRIPTION
This supports the new `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` environment variables that allow exchanging OIDC tokens given to pods in EKS for access tokens.

I haven't introduced any new API for this, as I figured the use-case for this will be solely EKS. So this privately extends the existing `STSWebIdentity` credential provider for AWS use and is only activated when the correct environment variables are provided. Calling NewIAM() is all that is required.

I haven't actually tested this in an AWS environment yet, but figured it was worth opening for discussion early.

@barryib You requested this in #1156 - are you able to test in an AWS environment?