### PR TITLE
Implemented support for Scaleway object storage endpoints

### DIFF
--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -53,6 +53,12 @@ func (c Client) makeBucket(bucketName string, location string, objectLockEnabled
 			location = c.region
 		}
 	}
+	// For Scaleway endpoints, always us the custom region
+	if s3utils.IsScalewayEndpoint(*c.endpointURL) {
+		if c.region != "" {
+			location = c.region
+		}
+	}
 	// PUT bucket request metadata.
 	reqMetadata := requestMetadata{
 		bucketName:     bucketName,

--- a/api.go
+++ b/api.go
@@ -165,6 +165,10 @@ func New(endpoint, accessKeyID, secretAccessKey string, secure bool) (*Client, e
 	if s3utils.IsAmazonEndpoint(*clnt.endpointURL) {
 		clnt.overrideSignerType = credentials.SignatureV4
 	}
+	// If Scaleway object storage set to signature v4.
+	if s3utils.IsScalewayEndpoint(*clnt.endpointURL) {
+		clnt.overrideSignerType = credentials.SignatureV4
+	}
 	return clnt, nil
 }
 

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -95,8 +95,21 @@ var amazonS3HostDot = regexp.MustCompile(`^s3\.(.*?)\.amazonaws\.com$`)
 // amazonS3ChinaHost - regular expression used to determine if the arg is s3 china host.
 var amazonS3ChinaHost = regexp.MustCompile(`^s3\.(cn.*?)\.amazonaws\.com\.cn$`)
 
+// scalewayS3HostDot - regular expression used to determine if an arg is s3 host in . style.
+var scalewayS3HostDot = regexp.MustCompile(`^s3\.(.*?)\.scw\.cloud$`)
+
 // GetRegionFromURL - returns a region from url host.
 func GetRegionFromURL(endpointURL url.URL) string {
+
+	parts := scalewayS3HostDot.FindStringSubmatch(endpointURL.Host)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return GetAWSRegionFromURL(endpointURL)
+}
+
+// GetAWSRegionFromURL - returns a AWS region from url host.
+func GetAWSRegionFromURL(endpointURL url.URL) string {
 	if endpointURL == sentinelURL {
 		return ""
 	}
@@ -130,7 +143,7 @@ func IsAmazonEndpoint(endpointURL url.URL) bool {
 	if endpointURL.Host == "s3-external-1.amazonaws.com" || endpointURL.Host == "s3.amazonaws.com" {
 		return true
 	}
-	return GetRegionFromURL(endpointURL) != ""
+	return GetAWSRegionFromURL(endpointURL) != ""
 }
 
 // IsAmazonGovCloudEndpoint - Match if it is exactly Amazon S3 GovCloud endpoint.
@@ -185,6 +198,14 @@ func IsGoogleEndpoint(endpointURL url.URL) bool {
 		return false
 	}
 	return endpointURL.Host == "storage.googleapis.com"
+}
+
+// IsScalewayEndpoint - Match if it is exactly Scaleway object storage endpoint.
+func IsScalewayEndpoint(endpointURL url.URL) bool {
+	if endpointURL == sentinelURL {
+		return false
+	}
+	return endpointURL.Host == "s3.nl-ams.scw.cloud" || endpointURL.Host == "s3.fr-par.scw.cloud"
 }
 
 // Expects ascii encoded strings - from output of urlEncodePath

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -73,6 +73,14 @@ func TestGetRegionFromURL(t *testing.T) {
 			u:              url.URL{Host: "s3-external-1.amazonaws.com"},
 			expectedRegion: "",
 		},
+		{
+			u:              url.URL{Host: "s3.nl-ams.scw.cloud"},
+			expectedRegion: "nl-ams",
+		},
+		{
+			u:              url.URL{Host: "s3.fr-par.scw.cloud"},
+			expectedRegion: "fr-par",
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -186,6 +194,8 @@ func TestIsAmazonEndpoint(t *testing.T) {
 		{"https://s3..amazonaws.com", false},
 		{"https://s3.dualstack.us-west-1.amazonaws.com.cn", false},
 		{"https://s3..us-west-1.amazonaws.com.cn", false},
+		{"https://s3.nl-ams.scw.cloud", false},
+		{"https://s3.fr-par.scw.cloud", false},
 		// valid inputs.
 		{"https://s3.amazonaws.com", true},
 		{"https://s3-external-1.amazonaws.com", true},
@@ -223,6 +233,8 @@ func TestIsGoogleEndpoint(t *testing.T) {
 		{"https://s3.cn-north-1.amazonaws.com.cn", false},
 		{"-192.168.1.1", false},
 		{"260.192.1.1", false},
+		{"https://s3.nl-ams.scw.cloud", false},
+		{"https://s3.fr-par.scw.cloud", false},
 		// valid inputs.
 		{"http://storage.googleapis.com", true},
 		{"https://storage.googleapis.com", true},
@@ -236,6 +248,41 @@ func TestIsGoogleEndpoint(t *testing.T) {
 		result := IsGoogleEndpoint(*u)
 		if testCase.result != result {
 			t.Errorf("Test %d: Expected isGoogleEndpoint to be '%v' for input \"%s\", but found it to be '%v' instead", i+1, testCase.result, testCase.url, result)
+		}
+	}
+
+}
+
+// Tests validate Google Cloud end point validator.
+func TestIsScalewayEndpointEndpoint(t *testing.T) {
+	testCases := []struct {
+		url string
+		// Expected result.
+		result bool
+	}{
+		{"192.168.1.1", false},
+		{"https://192.168.1.1", false},
+		{"s3.amazonaws.com", false},
+		{"http://s3.amazonaws.com", false},
+		{"https://s3.amazonaws.com", false},
+		{"https://s3.cn-north-1.amazonaws.com.cn", false},
+		{"-192.168.1.1", false},
+		{"260.192.1.1", false},
+		{"http://storage.googleapis.com", false},
+		{"https://storage.googleapis.com", false},
+		// valid inputs.
+		{"https://s3.nl-ams.scw.cloud", true},
+		{"https://s3.fr-par.scw.cloud", true},
+	}
+
+	for i, testCase := range testCases {
+		u, err := url.Parse(testCase.url)
+		if err != nil {
+			t.Errorf("Test %d: Expected to pass, but failed with: <ERROR> %s", i+1, err)
+		}
+		result := IsScalewayEndpoint(*u)
+		if testCase.result != result {
+			t.Errorf("Test %d: Expected isScalewayEndpoint to be '%v' for input \"%s\", but found it to be '%v' instead", i+1, testCase.result, testCase.url, result)
 		}
 	}
 


### PR DESCRIPTION
I'm using the Scaleway object storage (https://www.scaleway.com/en/docs/object-storage-feature/) which is a S3 compatible storage provider. It uses regions, but no common endpoint, so I added support for this provider which automatically sets correct region based on endpoint URL.

My main reason is to use restic and minio-client (mc), since restic doesn't allow to set regions manually. I built and tested both tools against my modified sdk and both work fine.
Without these changes, the requests fail due to wrong region in the SigV4 header (defaults to us-east-1).

I also included tests and ran the included test suite.