### PR TITLE
Add grant information in GetObjectACL

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -88,6 +88,16 @@ type ObjectInfo struct {
 		ID          string `json:"id"`
 	} `json:"owner"`
 
+	// ACL grant.
+	Grant []struct {
+		Grantee struct {
+			ID          string `xml:"ID"`
+			DisplayName string `xml:"DisplayName"`
+			URI         string `xml:"URI"`
+		} `xml:"Grantee"`
+		Permission string `xml:"Permission"`
+	} `xml:"Grant"`
+
 	// The class of storage used to store the object.
 	StorageClass string `json:"storageClass"`
 

--- a/api-get-object-acl-context.go
+++ b/api-get-object-acl-context.go
@@ -72,9 +72,7 @@ func (c Client) GetObjectACLWithContext(ctx context.Context, bucketName, objectN
 	objInfo.Owner.DisplayName = res.Owner.DisplayName
 	objInfo.Owner.ID = res.Owner.ID
 
-	for _, g := range res.AccessControlList.Grant {
-		objInfo.Grant = append(objInfo.Grant, g)
-	}
+	objInfo.Grant = append(objInfo.Grant, res.AccessControlList.Grant...)
 
 	cannedACL := getCannedACL(res)
 	if cannedACL != "" {

--- a/api-get-object-acl-context.go
+++ b/api-get-object-acl-context.go
@@ -72,6 +72,10 @@ func (c Client) GetObjectACLWithContext(ctx context.Context, bucketName, objectN
 	objInfo.Owner.DisplayName = res.Owner.DisplayName
 	objInfo.Owner.ID = res.Owner.ID
 
+	for _, g := range res.AccessControlList.Grant {
+		objInfo.Grant = append(objInfo.Grant, g)
+	}
+
 	cannedACL := getCannedACL(res)
 	if cannedACL != "" {
 		objInfo.Metadata.Add("X-Amz-Acl", cannedACL)

--- a/examples/s3/getobjectacl.go
+++ b/examples/s3/getobjectacl.go
@@ -51,6 +51,16 @@ Display name: %q
 ID: %q
 `, objectInfo.Owner.DisplayName, objectInfo.Owner.ID)
 
+	//print object grant informations
+	for _, g := range objectInfo.Grant {
+		fmt.Printf(`Object grant:
+ - Display name: %q
+ - ID: %q
+ - URI: %q
+ - Permission: %q
+`, g.Grantee.DisplayName, g.Grantee.ID, g.Grantee.URI, g.Permission)
+	}
+
 	//print all value header (acl, metadata, standard header value...)
 	for k, v := range objectInfo.Metadata {
 		fmt.Println("key:", k)


### PR DESCRIPTION
This PR add the object grant information in the `ObjectInfo` returned by `GetObjectACL`.