### PR TITLE
Support for Context on Bucket Operations

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -39,8 +39,23 @@ import (
 //   }
 //
 func (c Client) ListBuckets() ([]BucketInfo, error) {
+	return c.ListBucketsWithContext(context.Background())
+}
+
+// ListBucketsWithContext list all buckets owned by this authenticated user,
+// accepts a context for facilitate cancellation.
+//
+// This call requires explicit authentication, no anonymous requests are
+// allowed for listing buckets.
+//
+//   api := client.New(....)
+//   for message := range api.ListBucketsWithContext(context.Background()) {
+//       fmt.Println(message)
+//   }
+//
+func (c Client) ListBucketsWithContext(ctx context.Context) ([]BucketInfo, error) {
 	// Execute GET on service.
-	resp, err := c.executeMethod(context.Background(), "GET", requestMetadata{contentSHA256Hex: emptySHA256Hex})
+	resp, err := c.executeMethod(ctx, "GET", requestMetadata{contentSHA256Hex: emptySHA256Hex})
 	defer closeResponse(resp)
 	if err != nil {
 		return nil, err

--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -108,7 +108,7 @@ func (c Client) MakeBucket(bucketName string, location string) (err error) {
 	return c.MakeBucketWithContext(context.Background(), bucketName, location)
 }
 
-// MakeBucket creates a new bucket with bucketName.
+// MakeBucketWithContext creates a new bucket with bucketName with a context to control cancellations and timeouts.
 //
 // Location is an optional argument, by default all buckets are
 // created in US Standard Region.
@@ -130,8 +130,8 @@ func (c Client) MakeBucketWithObjectLock(bucketName string, location string) (er
 	return c.MakeBucketWithObjectLockWithContext(context.Background(), bucketName, location)
 }
 
-// MakeBucketWithObjectLock creates a object lock enabled new bucket with bucketName with a context to control
-// cancellations and timeouts.
+// MakeBucketWithObjectLockWithContext creates a object lock enabled new bucket with bucketName with a context to
+// control cancellations and timeouts.
 //
 // Location is an optional argument, by default all buckets are
 // created in US Standard Region.
@@ -147,7 +147,7 @@ func (c Client) SetBucketPolicy(bucketName, policy string) error {
 	return c.SetBucketPolicyWithContext(context.Background(), bucketName, policy)
 }
 
-// SetBucketPolicy set the access permissions on an existing bucket.
+// SetBucketPolicyWithContext set the access permissions on an existing bucket.
 func (c Client) SetBucketPolicyWithContext(ctx context.Context, bucketName, policy string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
@@ -232,7 +232,7 @@ func (c Client) SetBucketLifecycle(bucketName, lifecycle string) error {
 	return c.SetBucketLifecycleWithContext(context.Background(), bucketName, lifecycle)
 }
 
-// SetBucketLifecycle set the lifecycle on an existing bucket with a context to control cancellations and timeouts.
+// SetBucketLifecycleWithContext set the lifecycle on an existing bucket with a context to control cancellations and timeouts.
 func (c Client) SetBucketLifecycleWithContext(ctx context.Context, bucketName, lifecycle string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
@@ -416,7 +416,7 @@ func (c Client) EnableVersioning(bucketName string) error {
 	return c.EnableVersioningWithContext(context.Background(), bucketName)
 }
 
-// EnableVersioning - Enable object versioning in given bucket with a context to control cancellations and timeouts.
+// EnableVersioningWithContext - Enable object versioning in given bucket with a context to control cancellations and timeouts.
 func (c Client) EnableVersioningWithContext(ctx context.Context, bucketName string) error {
 	return c.setVersioning(ctx, bucketName, versionEnableConfig, versionEnableConfigLen, versionEnableConfigMD5Sum, versionEnableConfigSHA256)
 }
@@ -426,7 +426,7 @@ func (c Client) DisableVersioning(bucketName string) error {
 	return c.DisableVersioningWithContext(context.Background(), bucketName)
 }
 
-// DisableVersioning - Disable object versioning in given bucket with a context to control cancellations and timeouts.
+// DisableVersioningWithContext - Disable object versioning in given bucket with a context to control cancellations and timeouts.
 func (c Client) DisableVersioningWithContext(ctx context.Context, bucketName string) error {
 	return c.setVersioning(ctx, bucketName, versionDisableConfig, versionDisableConfigLen, versionDisableConfigMD5Sum, versionDisableConfigSHA256)
 }

--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -31,7 +31,7 @@ import (
 
 /// Bucket operations
 
-func (c Client) makeBucket(bucketName string, location string, objectLockEnabled bool) (err error) {
+func (c Client) makeBucket(ctx context.Context, bucketName string, location string, objectLockEnabled bool) (err error) {
 	defer func() {
 		// Save the location into cache on a successful makeBucket response.
 		if err == nil {
@@ -81,7 +81,7 @@ func (c Client) makeBucket(bucketName string, location string, objectLockEnabled
 	}
 
 	// Execute PUT to create a new bucket.
-	resp, err := c.executeMethod(context.Background(), "PUT", reqMetadata)
+	resp, err := c.executeMethod(ctx, "PUT", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -105,7 +105,18 @@ func (c Client) makeBucket(bucketName string, location string, objectLockEnabled
 // For Amazon S3 for more supported regions - http://docs.aws.amazon.com/general/latest/gr/rande.html
 // For Google Cloud Storage for more supported regions - https://cloud.google.com/storage/docs/bucket-locations
 func (c Client) MakeBucket(bucketName string, location string) (err error) {
-	return c.makeBucket(bucketName, location, false)
+	return c.MakeBucketWithContext(context.Background(), bucketName, location)
+}
+
+// MakeBucket creates a new bucket with bucketName.
+//
+// Location is an optional argument, by default all buckets are
+// created in US Standard Region.
+//
+// For Amazon S3 for more supported regions - http://docs.aws.amazon.com/general/latest/gr/rande.html
+// For Google Cloud Storage for more supported regions - https://cloud.google.com/storage/docs/bucket-locations
+func (c Client) MakeBucketWithContext(ctx context.Context, bucketName string, location string) (err error) {
+	return c.makeBucket(ctx, bucketName, location, false)
 }
 
 // MakeBucketWithObjectLock creates a object lock enabled new bucket with bucketName.
@@ -116,11 +127,28 @@ func (c Client) MakeBucket(bucketName string, location string) (err error) {
 // For Amazon S3 for more supported regions - http://docs.aws.amazon.com/general/latest/gr/rande.html
 // For Google Cloud Storage for more supported regions - https://cloud.google.com/storage/docs/bucket-locations
 func (c Client) MakeBucketWithObjectLock(bucketName string, location string) (err error) {
-	return c.makeBucket(bucketName, location, true)
+	return c.MakeBucketWithObjectLockWithContext(context.Background(), bucketName, location)
+}
+
+// MakeBucketWithObjectLock creates a object lock enabled new bucket with bucketName with a context to control
+// cancellations and timeouts.
+//
+// Location is an optional argument, by default all buckets are
+// created in US Standard Region.
+//
+// For Amazon S3 for more supported regions - http://docs.aws.amazon.com/general/latest/gr/rande.html
+// For Google Cloud Storage for more supported regions - https://cloud.google.com/storage/docs/bucket-locations
+func (c Client) MakeBucketWithObjectLockWithContext(ctx context.Context, bucketName string, location string) (err error) {
+	return c.makeBucket(ctx, bucketName, location, true)
 }
 
 // SetBucketPolicy set the access permissions on an existing bucket.
 func (c Client) SetBucketPolicy(bucketName, policy string) error {
+	return c.SetBucketPolicyWithContext(context.Background(), bucketName, policy)
+}
+
+// SetBucketPolicy set the access permissions on an existing bucket.
+func (c Client) SetBucketPolicyWithContext(ctx context.Context, bucketName, policy string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -128,15 +156,15 @@ func (c Client) SetBucketPolicy(bucketName, policy string) error {
 
 	// If policy is empty then delete the bucket policy.
 	if policy == "" {
-		return c.removeBucketPolicy(bucketName)
+		return c.removeBucketPolicy(ctx, bucketName)
 	}
 
 	// Save the updated policies.
-	return c.putBucketPolicy(bucketName, policy)
+	return c.putBucketPolicy(ctx, bucketName, policy)
 }
 
 // Saves a new bucket policy.
-func (c Client) putBucketPolicy(bucketName, policy string) error {
+func (c Client) putBucketPolicy(ctx context.Context, bucketName, policy string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -162,7 +190,7 @@ func (c Client) putBucketPolicy(bucketName, policy string) error {
 	}
 
 	// Execute PUT to upload a new bucket policy.
-	resp, err := c.executeMethod(context.Background(), "PUT", reqMetadata)
+	resp, err := c.executeMethod(ctx, "PUT", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -176,7 +204,7 @@ func (c Client) putBucketPolicy(bucketName, policy string) error {
 }
 
 // Removes all policies on a bucket.
-func (c Client) removeBucketPolicy(bucketName string) error {
+func (c Client) removeBucketPolicy(ctx context.Context, bucketName string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -187,7 +215,7 @@ func (c Client) removeBucketPolicy(bucketName string) error {
 	urlValues.Set("policy", "")
 
 	// Execute DELETE on objectName.
-	resp, err := c.executeMethod(context.Background(), "DELETE", requestMetadata{
+	resp, err := c.executeMethod(ctx, "DELETE", requestMetadata{
 		bucketName:       bucketName,
 		queryValues:      urlValues,
 		contentSHA256Hex: emptySHA256Hex,
@@ -201,6 +229,11 @@ func (c Client) removeBucketPolicy(bucketName string) error {
 
 // SetBucketLifecycle set the lifecycle on an existing bucket.
 func (c Client) SetBucketLifecycle(bucketName, lifecycle string) error {
+	return c.SetBucketLifecycleWithContext(context.Background(), bucketName, lifecycle)
+}
+
+// SetBucketLifecycle set the lifecycle on an existing bucket with a context to control cancellations and timeouts.
+func (c Client) SetBucketLifecycleWithContext(ctx context.Context, bucketName, lifecycle string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -208,15 +241,15 @@ func (c Client) SetBucketLifecycle(bucketName, lifecycle string) error {
 
 	// If lifecycle is empty then delete it.
 	if lifecycle == "" {
-		return c.removeBucketLifecycle(bucketName)
+		return c.removeBucketLifecycle(ctx, bucketName)
 	}
 
 	// Save the updated lifecycle.
-	return c.putBucketLifecycle(bucketName, lifecycle)
+	return c.putBucketLifecycle(ctx, bucketName, lifecycle)
 }
 
 // Saves a new bucket lifecycle.
-func (c Client) putBucketLifecycle(bucketName, lifecycle string) error {
+func (c Client) putBucketLifecycle(ctx context.Context, bucketName, lifecycle string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -243,7 +276,7 @@ func (c Client) putBucketLifecycle(bucketName, lifecycle string) error {
 	}
 
 	// Execute PUT to upload a new bucket lifecycle.
-	resp, err := c.executeMethod(context.Background(), "PUT", reqMetadata)
+	resp, err := c.executeMethod(ctx, "PUT", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -257,7 +290,7 @@ func (c Client) putBucketLifecycle(bucketName, lifecycle string) error {
 }
 
 // Remove lifecycle from a bucket.
-func (c Client) removeBucketLifecycle(bucketName string) error {
+func (c Client) removeBucketLifecycle(ctx context.Context, bucketName string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -268,7 +301,7 @@ func (c Client) removeBucketLifecycle(bucketName string) error {
 	urlValues.Set("lifecycle", "")
 
 	// Execute DELETE on objectName.
-	resp, err := c.executeMethod(context.Background(), "DELETE", requestMetadata{
+	resp, err := c.executeMethod(ctx, "DELETE", requestMetadata{
 		bucketName:       bucketName,
 		queryValues:      urlValues,
 		contentSHA256Hex: emptySHA256Hex,
@@ -282,6 +315,12 @@ func (c Client) removeBucketLifecycle(bucketName string) error {
 
 // SetBucketNotification saves a new bucket notification.
 func (c Client) SetBucketNotification(bucketName string, bucketNotification BucketNotification) error {
+	return c.SetBucketNotificationWithContext(context.Background(), bucketName, bucketNotification)
+}
+
+// SetBucketNotificationWithContext saves a new bucket notification with a context to control cancellations
+// and timeouts.
+func (c Client) SetBucketNotificationWithContext(ctx context.Context, bucketName string, bucketNotification BucketNotification) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -308,7 +347,7 @@ func (c Client) SetBucketNotification(bucketName string, bucketNotification Buck
 	}
 
 	// Execute PUT to upload a new bucket notification.
-	resp, err := c.executeMethod(context.Background(), "PUT", reqMetadata)
+	resp, err := c.executeMethod(ctx, "PUT", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -338,7 +377,7 @@ var (
 	versionDisableConfigSHA256 = sum256Hex(versionDisableConfig)
 )
 
-func (c Client) setVersioning(bucketName string, config []byte, length int64, md5sum, sha256sum string) error {
+func (c Client) setVersioning(ctx context.Context, bucketName string, config []byte, length int64, md5sum, sha256sum string) error {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return err
@@ -359,7 +398,7 @@ func (c Client) setVersioning(bucketName string, config []byte, length int64, md
 	}
 
 	// Execute PUT to set a bucket versioning.
-	resp, err := c.executeMethod(context.Background(), "PUT", reqMetadata)
+	resp, err := c.executeMethod(ctx, "PUT", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
 		return err
@@ -374,10 +413,20 @@ func (c Client) setVersioning(bucketName string, config []byte, length int64, md
 
 // EnableVersioning - Enable object versioning in given bucket.
 func (c Client) EnableVersioning(bucketName string) error {
-	return c.setVersioning(bucketName, versionEnableConfig, versionEnableConfigLen, versionEnableConfigMD5Sum, versionEnableConfigSHA256)
+	return c.EnableVersioningWithContext(context.Background(), bucketName)
+}
+
+// EnableVersioning - Enable object versioning in given bucket with a context to control cancellations and timeouts.
+func (c Client) EnableVersioningWithContext(ctx context.Context, bucketName string) error {
+	return c.setVersioning(ctx, bucketName, versionEnableConfig, versionEnableConfigLen, versionEnableConfigMD5Sum, versionEnableConfigSHA256)
 }
 
 // DisableVersioning - Disable object versioning in given bucket.
 func (c Client) DisableVersioning(bucketName string) error {
-	return c.setVersioning(bucketName, versionDisableConfig, versionDisableConfigLen, versionDisableConfigMD5Sum, versionDisableConfigSHA256)
+	return c.DisableVersioningWithContext(context.Background(), bucketName)
+}
+
+// DisableVersioning - Disable object versioning in given bucket with a context to control cancellations and timeouts.
+func (c Client) DisableVersioningWithContext(ctx context.Context, bucketName string) error {
+	return c.setVersioning(ctx, bucketName, versionDisableConfig, versionDisableConfigLen, versionDisableConfigMD5Sum, versionDisableConfigSHA256)
 }

--- a/api-stat.go
+++ b/api-stat.go
@@ -100,7 +100,7 @@ func (c Client) StatObject(bucketName, objectName string, opts StatObjectOptions
 	return c.StatObjectWithContext(context.Background(), bucketName, objectName, opts)
 }
 
-// StatObject verifies if object exists and you have permission to access with a context to control
+// StatObjectWithContext verifies if object exists and you have permission to access with a context to control
 // cancellations and timeouts.
 func (c Client) StatObjectWithContext(ctx context.Context, bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
 	// Input validation.

--- a/api-stat.go
+++ b/api-stat.go
@@ -29,13 +29,19 @@ import (
 
 // BucketExists verify if bucket exists and you have permission to access it.
 func (c Client) BucketExists(bucketName string) (bool, error) {
+	return c.BucketExistsWithContext(context.Background(), bucketName)
+}
+
+// BucketExistsWithContext verify if bucket exists and you have permission to access it. Allows for a Context to
+// control cancellations and timeouts.
+func (c Client) BucketExistsWithContext(ctx context.Context, bucketName string) (bool, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return false, err
 	}
 
 	// Execute HEAD on bucketName.
-	resp, err := c.executeMethod(context.Background(), "HEAD", requestMetadata{
+	resp, err := c.executeMethod(ctx, "HEAD", requestMetadata{
 		bucketName:       bucketName,
 		contentSHA256Hex: emptySHA256Hex,
 	})
@@ -91,6 +97,12 @@ func extractObjMetadata(header http.Header) http.Header {
 
 // StatObject verifies if object exists and you have permission to access.
 func (c Client) StatObject(bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
+	return c.StatObjectWithContext(context.Background(), bucketName, objectName, opts)
+}
+
+// StatObject verifies if object exists and you have permission to access with a context to control
+// cancellations and timeouts.
+func (c Client) StatObjectWithContext(ctx context.Context, bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return ObjectInfo{}, err
@@ -98,7 +110,7 @@ func (c Client) StatObject(bucketName, objectName string, opts StatObjectOptions
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return ObjectInfo{}, err
 	}
-	return c.statObject(context.Background(), bucketName, objectName, opts)
+	return c.statObject(ctx, bucketName, objectName, opts)
 }
 
 // Lower level API for statObject supporting pre-conditions and range headers.

--- a/core.go
+++ b/core.go
@@ -174,8 +174,8 @@ func (c Core) PutBucketPolicy(bucket, bucketPolicy string) error {
 	return c.PutBucketPolicyWithContext(context.Background(), bucket, bucketPolicy)
 }
 
-// PutBucketPolicy - applies a new bucket access policy for a given bucket with a context to control cancellations
-// and timeouts.
+// PutBucketPolicyWithContext - applies a new bucket access policy for a given bucket with a context to control
+// cancellations and timeouts.
 func (c Core) PutBucketPolicyWithContext(ctx context.Context, bucket, bucketPolicy string) error {
 	return c.putBucketPolicy(ctx, bucket, bucketPolicy)
 }

--- a/core.go
+++ b/core.go
@@ -171,7 +171,13 @@ func (c Core) GetBucketPolicy(bucket string) (string, error) {
 
 // PutBucketPolicy - applies a new bucket access policy for a given bucket.
 func (c Core) PutBucketPolicy(bucket, bucketPolicy string) error {
-	return c.putBucketPolicy(bucket, bucketPolicy)
+	return c.PutBucketPolicyWithContext(context.Background(), bucket, bucketPolicy)
+}
+
+// PutBucketPolicy - applies a new bucket access policy for a given bucket with a context to control cancellations
+// and timeouts.
+func (c Core) PutBucketPolicyWithContext(ctx context.Context, bucket, bucketPolicy string) error {
+	return c.putBucketPolicy(ctx, bucket, bucketPolicy)
 }
 
 // GetObjectWithContext is a lower level API implemented to support reading

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4208,7 +4208,6 @@ func testFunctional() {
 	}
 
 	// Verify if bucket exits and you have access with context.
-	var exists bool
 	function = "BucketExistsWithContext(ctx, bucketName)"
 	functionAll += ", " + function
 	args = map[string]interface{}{
@@ -5320,7 +5319,7 @@ func testFPutObjectV2() {
 		return
 	}
 
-	rGTar, err := c.StatObjectWithContext(context.Background(), bucketName, objectName+"-GTar", minio.StatObjectOptions{})
+	rGTar, err = c.StatObjectWithContext(context.Background(), bucketName, objectName+"-GTar", minio.StatObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject failed", err)
 		return

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4325,7 +4325,7 @@ func testFunctional() {
 	function = "ListBucketsWithContext()"
 	functionAll += ", " + function
 	args = nil
-	buckets, err := c.ListBucketsWithContext(context.Background())
+	buckets, err = c.ListBucketsWithContext(context.Background())
 
 	if len(buckets) == 0 {
 		logError(testName, function, args, startTime, "", "Found bucket list to be empty", err)

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4321,6 +4321,21 @@ func testFunctional() {
 		return
 	}
 
+	// List all buckets with context.
+	function = "ListBucketsWithContext()"
+	functionAll += ", " + function
+	args = nil
+	buckets, err := c.ListBucketsWithContext(context.Background())
+
+	if len(buckets) == 0 {
+		logError(testName, function, args, startTime, "", "Found bucket list to be empty", err)
+		return
+	}
+	if err != nil {
+		logError(testName, function, args, startTime, "", "ListBucketsWithContext failed", err)
+		return
+	}
+
 	// Verify if previously created bucket is listed in list buckets.
 	bucketFound := false
 	for _, bucket := range buckets {


### PR DESCRIPTION
Needed to be able to timeout ListBuckets by passing a context, the implementation was already there, but it had a hard coded `context.Background` so I just wrapped the existing function and have it call by default with `context.Background` similar to what `PutObject` does with `PutObjectWithContext`