### PR TITLE
Bucket Exists With Context

### DIFF
--- a/api-stat.go
+++ b/api-stat.go
@@ -29,6 +29,12 @@ import (
 
 // BucketExists verify if bucket exists and you have permission to access it.
 func (c Client) BucketExists(bucketName string) (bool, error) {
+	return c.BucketExistsWithContext(context.Background(), bucketName)
+}
+
+// BucketExistsWithContext verify if bucket exists and you have permission to access it. Allows for a Context to
+// control cancellations and timeouts.
+func (c Client) BucketExistsWithContext(ctx context.Context, bucketName string) (bool, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return false, err

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4207,6 +4207,24 @@ func testFunctional() {
 		return
 	}
 
+	// Verify if bucket exits and you have access.
+	var exists bool
+	function = "BucketExistsWithContext(ctx, bucketName)"
+	functionAll += ", " + function
+	args = map[string]interface{}{
+		"bucketName": bucketName,
+	}
+	exists, err = c.BucketExistsWithContext(context.Background(), bucketName)
+
+	if err != nil {
+		logError(testName, function, args, startTime, "", "BucketExistsWithContext failed", err)
+		return
+	}
+	if !exists {
+		logError(testName, function, args, startTime, "", "Could not find the bucket", err)
+		return
+	}
+
 	// Asserting the default bucket policy.
 	function = "GetBucketPolicy(bucketName)"
 	functionAll += ", " + function


### PR DESCRIPTION
Needed to be able to timeout `BucketExists` by passing a context, the implementation was already there, but it had a hard coded context.Background so I just wrapped the existing function and have it call by default with context.Background similar to what `PutObject` does with `PutObjectWithContext`