### PR TITLE
Add function to set policy parameter

### DIFF
--- a/post-policy.go
+++ b/post-policy.go
@@ -131,6 +131,27 @@ func (p *PostPolicy) SetBucket(bucketName string) error {
 	return nil
 }
 
+// SetCondition - Sets condition for credentials, date and algorithm
+func (p *PostPolicy) SetCondition(matchType, condition, value string) error {
+	if strings.TrimSpace(value) == "" || value == "" {
+		return ErrInvalidArgument("No value specified for condition")
+	}
+
+	policyCond := policyCondition{
+		matchType: matchType,
+		condition: "$" + condition,
+		value:     value,
+	}
+	if condition == "X-Amz-Credential" || condition == "X-Amz-Date" || condition == "X-Amz-Algorithm" {
+		if err := p.addNewPolicy(policyCond); err != nil {
+			return err
+		}
+		p.formData[condition] = value
+		return nil
+	}
+	return ErrInvalidArgument("Invalid condition in policy")
+}
+
 // SetContentType - Sets content-type of the object for this policy
 // based upload.
 func (p *PostPolicy) SetContentType(contentType string) error {


### PR DESCRIPTION
PR adds   `SetCondition`  function which is used  in the test cases of `TestPostPolicyForm` in `minio/minio/cmd/postpolicyform_test.go`


As per S3 docs 
```
Each form field that you specify in a form (except x-amz-signature, file, policy, and field names that have an x-ignore- prefix) must appear in the list of conditions.
```
[PR](https://github.com/minio/minio/pull/8623) adds the condition to check if any extra field is passed.

Now, `PresignedPostPolicy`  method of  `api-presigned.go`  was internally adding `"$x-amz-credential"` , `"$x-amz-algorithm"` , `"$x-amz-date"` to the policy which was not happening in cases of `TestPostPolicyForm` of `minio/minio/cmd/postpolicyform_test.go` , thus `SetCondition`  function was introduced. `SetCondition`  should not be used by users, it is only used in test case. 




Closes https://github.com/minio/minio/issues/8498. 
This PR is needed for minio PR https://github.com/minio/minio/pull/8623



