### PR TITLE
Add ObjectTagging Support

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -36,18 +36,53 @@ import (
 // created via server-side copy requests, using the Compose API.
 type DestinationInfo struct {
 	bucket, object string
-	encryption     encrypt.ServerSide
+	opts           DestInfoOptions
+}
 
+// DestInfoOptions represents options specified by user for NewDestinationInfo call
+type DestInfoOptions struct {
+	// `Encryption` is the key info for server-side-encryption with customer
+	// provided key. If it is nil, no encryption is performed.
+	Encryption encrypt.ServerSide
+
+	// `userMeta` is the user-metadata key-value pairs to be set on the
+	// destination. The keys are automatically prefixed with `x-amz-meta-`
+	// if needed. If nil is passed, and if only a single source (of any
+	// size) is provided in the ComposeObject call, then metadata from the
+	// source is copied to the destination.
 	// if no user-metadata is provided, it is copied from source
 	// (when there is only once source object in the compose
 	// request)
-	userMetadata map[string]string
+	UserMeta map[string]string
+
+	// `userTags` is the user defined object tags to be set on destination.
+	// This will be set only if the `replaceTags` field is set to true.
+	// Otherwise this field is ignored
+	UserTags    map[string]string
+	ReplaceTags bool
+}
+
+// Process custom-metadata to remove a `x-amz-meta-` prefix if
+// present and validate that keys are distinct (after this
+// prefix removal).
+func filterCustomMeta(userMeta map[string]string) (map[string]string, error) {
+	m := make(map[string]string)
+	for k, v := range userMeta {
+		if strings.HasPrefix(strings.ToLower(k), "x-amz-meta-") {
+			k = k[len("x-amz-meta-"):]
+		}
+		if _, ok := m[k]; ok {
+			return nil, ErrInvalidArgument(fmt.Sprintf("Cannot add both %s and x-amz-meta-%s keys as custom metadata", k, k))
+		}
+		m[k] = v
+	}
+	return m, nil
 }
 
 // NewDestinationInfo - creates a compose-object/copy-source
 // destination info object.
 //
-// `encSSEC` is the key info for server-side-encryption with customer
+// `sse` is the key info for server-side-encryption with customer
 // provided key. If it is nil, no encryption is performed.
 //
 // `userMeta` is the user-metadata key-value pairs to be set on the
@@ -63,26 +98,41 @@ func NewDestinationInfo(bucket, object string, sse encrypt.ServerSide, userMeta 
 	if err = s3utils.CheckValidObjectName(object); err != nil {
 		return d, err
 	}
-
-	// Process custom-metadata to remove a `x-amz-meta-` prefix if
-	// present and validate that keys are distinct (after this
-	// prefix removal).
-	m := make(map[string]string)
-	for k, v := range userMeta {
-		if strings.HasPrefix(strings.ToLower(k), "x-amz-meta-") {
-			k = k[len("x-amz-meta-"):]
-		}
-		if _, ok := m[k]; ok {
-			return d, ErrInvalidArgument(fmt.Sprintf("Cannot add both %s and x-amz-meta-%s keys as custom metadata", k, k))
-		}
-		m[k] = v
+	m, err := filterCustomMeta(userMeta)
+	if err != nil {
+		return d, err
 	}
-
+	opts := DestInfoOptions{
+		Encryption:  sse,
+		UserMeta:    m,
+		UserTags:    nil,
+		ReplaceTags: false,
+	}
 	return DestinationInfo{
-		bucket:       bucket,
-		object:       object,
-		encryption:   sse,
-		userMetadata: m,
+		bucket: bucket,
+		object: object,
+		opts:   opts,
+	}, nil
+}
+
+// NewDestinationInfoWithOptions - creates a compose-object/copy-source
+// destination info object.
+func NewDestinationInfoWithOptions(bucket, object string, destOpts DestInfoOptions) (d DestinationInfo, err error) {
+	// Input validation.
+	if err = s3utils.CheckValidBucketName(bucket); err != nil {
+		return d, err
+	}
+	if err = s3utils.CheckValidObjectName(object); err != nil {
+		return d, err
+	}
+	destOpts.UserMeta, err = filterCustomMeta(destOpts.UserMeta)
+	if err != nil {
+		return d, err
+	}
+	return DestinationInfo{
+		bucket: bucket,
+		object: object,
+		opts:   destOpts,
 	}, nil
 }
 
@@ -93,14 +143,14 @@ func NewDestinationInfo(bucket, object string, sse encrypt.ServerSide, userMeta 
 // `REPLACE`, so that metadata headers from the source are not copied
 // over.
 func (d *DestinationInfo) getUserMetaHeadersMap(withCopyDirectiveHeader bool) map[string]string {
-	if len(d.userMetadata) == 0 {
+	if len(d.opts.UserMeta) == 0 {
 		return nil
 	}
 	r := make(map[string]string)
 	if withCopyDirectiveHeader {
 		r["x-amz-metadata-directive"] = "REPLACE"
 	}
-	for k, v := range d.userMetadata {
+	for k, v := range d.opts.UserMeta {
 		if isAmzHeader(k) || isStandardHeader(k) || isStorageClassHeader(k) {
 			r[k] = v
 		} else {
@@ -447,7 +497,7 @@ func (c Client) ComposeObjectWithProgress(dst DestinationInfo, srcs []SourceInfo
 		metaHeaders[k] = v
 	}
 
-	uploadID, err := c.newUploadID(ctx, dst.bucket, dst.object, PutObjectOptions{ServerSideEncryption: dst.encryption, UserMetadata: metaHeaders})
+	uploadID, err := c.newUploadID(ctx, dst.bucket, dst.object, PutObjectOptions{ServerSideEncryption: dst.opts.Encryption, UserMetadata: metaHeaders})
 	if err != nil {
 		return err
 	}
@@ -461,8 +511,8 @@ func (c Client) ComposeObjectWithProgress(dst DestinationInfo, srcs []SourceInfo
 			encrypt.SSECopy(src.encryption).Marshal(h)
 		}
 		// Add destination encryption headers
-		if dst.encryption != nil {
-			dst.encryption.Marshal(h)
+		if dst.opts.Encryption != nil {
+			dst.opts.Encryption.Marshal(h)
 		}
 
 		// calculate start/end indices of parts after

--- a/api-compose-object_test.go
+++ b/api-compose-object_test.go
@@ -130,7 +130,7 @@ func TestGetUserMetaHeadersMap(t *testing.T) {
 		"x-amz-grant-write":   "test@exo.ch",
 	}
 
-	destInfo := &DestinationInfo{"bucket", "object", nil, userMetadata}
+	destInfo, _ := NewDestinationInfo("bucket", "object", nil, userMetadata)
 
 	r := destInfo.getUserMetaHeadersMap(true)
 

--- a/api-object-tagging.go
+++ b/api-object-tagging.go
@@ -1,0 +1,163 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/minio/minio-go/v6/pkg/s3utils"
+)
+
+// PutObjectTagging replaces or creates object tag(s)
+func (c Client) PutObjectTagging(bucketName, objectName string, objectTags map[string]string) error {
+	return c.PutObjectTaggingWithContext(context.Background(), bucketName, objectName, objectTags)
+}
+
+// PutObjectTaggingWithContext replaces or creates object tag(s) with a context to control cancellations
+// and timeouts.
+func (c Client) PutObjectTaggingWithContext(ctx context.Context, bucketName, objectName string, objectTags map[string]string) error {
+	// Input validation.
+	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
+		return err
+	}
+
+	// Get resources properly escaped and lined up before
+	// using them in http request.
+	urlValues := make(url.Values)
+	urlValues.Set("tagging", "")
+
+	tags := make([]tag, 0)
+	for k, v := range objectTags {
+		t := tag{
+			Key:   k,
+			Value: v,
+		}
+		tags = append(tags, t)
+	}
+
+	// Prepare Tagging struct
+	reqBody := tagging{
+		TagSet: tagSet{
+			Tags: tags,
+		},
+	}
+
+	reqBytes, err := xml.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	reqMetadata := requestMetadata{
+		bucketName:       bucketName,
+		objectName:       objectName,
+		queryValues:      urlValues,
+		contentBody:      bytes.NewReader(reqBytes),
+		contentLength:    int64(len(reqBytes)),
+		contentMD5Base64: sumMD5Base64(reqBytes),
+	}
+
+	// Execute PUT to set a object tagging.
+	resp, err := c.executeMethod(ctx, "PUT", reqMetadata)
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+	if resp != nil {
+		if resp.StatusCode != http.StatusOK {
+			return httpRespToErrorResponse(resp, bucketName, objectName)
+		}
+	}
+	return nil
+}
+
+// GetObjectTagging fetches object tag(s)
+func (c Client) GetObjectTagging(bucketName, objectName string) (string, error) {
+	return c.GetObjectTaggingWithContext(context.Background(), bucketName, objectName)
+}
+
+// GetObjectTaggingWithContext fetches object tag(s) with a context to control cancellations
+// and timeouts.
+func (c Client) GetObjectTaggingWithContext(ctx context.Context, bucketName, objectName string) (string, error) {
+	// Get resources properly escaped and lined up before
+	// using them in http request.
+	urlValues := make(url.Values)
+	urlValues.Set("tagging", "")
+
+	// Execute GET on object to get object tag(s)
+	resp, err := c.executeMethod(ctx, "GET", requestMetadata{
+		bucketName:  bucketName,
+		objectName:  objectName,
+		queryValues: urlValues,
+	})
+
+	defer closeResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	if resp != nil {
+		if resp.StatusCode != http.StatusOK {
+			return "", httpRespToErrorResponse(resp, bucketName, objectName)
+		}
+	}
+
+	tagBuf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(tagBuf), err
+}
+
+// RemoveObjectTagging deletes object tag(s)
+func (c Client) RemoveObjectTagging(bucketName, objectName string) error {
+	return c.RemoveObjectTaggingWithContext(context.Background(), bucketName, objectName)
+}
+
+// RemoveObjectTaggingWithContext removes object tag(s) with a context to control cancellations
+// and timeouts.
+func (c Client) RemoveObjectTaggingWithContext(ctx context.Context, bucketName, objectName string) error {
+	// Get resources properly escaped and lined up before
+	// using them in http request.
+	urlValues := make(url.Values)
+	urlValues.Set("tagging", "")
+
+	// Execute DELETE on object to remove object tag(s)
+	resp, err := c.executeMethod(ctx, "DELETE", requestMetadata{
+		bucketName:  bucketName,
+		objectName:  objectName,
+		queryValues: urlValues,
+	})
+
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp != nil {
+		if resp.StatusCode != http.StatusOK {
+			return httpRespToErrorResponse(resp, bucketName, objectName)
+		}
+	}
+	return err
+}

--- a/api-put-object-copy.go
+++ b/api-put-object-copy.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	"github.com/minio/minio-go/v6/pkg/encrypt"
+	"github.com/minio/minio-go/v6/pkg/s3utils"
 )
 
 // CopyObject - copy a source object into a new object
@@ -37,6 +38,11 @@ func (c Client) CopyObjectWithProgress(dst DestinationInfo, src SourceInfo, prog
 	header := make(http.Header)
 	for k, v := range src.Headers {
 		header[k] = v
+	}
+
+	if dst.opts.ReplaceTags && len(dst.opts.UserTags) != 0 {
+		header.Set(amzTaggingHeaderDirective, "REPLACE")
+		header.Set(amzTaggingHeader, s3utils.TagEncode(dst.opts.UserTags))
 	}
 
 	var err error
@@ -53,8 +59,8 @@ func (c Client) CopyObjectWithProgress(dst DestinationInfo, src SourceInfo, prog
 		encrypt.SSECopy(src.encryption).Marshal(header)
 	}
 
-	if dst.encryption != nil {
-		dst.encryption.Marshal(header)
+	if dst.opts.Encryption != nil {
+		dst.opts.Encryption.Marshal(header)
 	}
 	for k, v := range dst.getUserMetaHeadersMap(true) {
 		header.Set(k, v)

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -35,6 +35,7 @@ import (
 // PutObjectOptions represents options specified by user for PutObject call
 type PutObjectOptions struct {
 	UserMetadata            map[string]string
+	UserTags                map[string]string
 	Progress                io.Reader
 	ContentType             string
 	ContentEncoding         string
@@ -99,6 +100,9 @@ func (opts PutObjectOptions) Header() (header http.Header) {
 	}
 	if opts.WebsiteRedirectLocation != "" {
 		header[amzWebsiteRedirectLocation] = []string{opts.WebsiteRedirectLocation}
+	}
+	if len(opts.UserTags) != 0 {
+		header[amzTaggingHeader] = []string{s3utils.TagEncode(opts.UserTags)}
 	}
 	for k, v := range opts.UserMetadata {
 		if !isAmzHeader(k) && !isStandardHeader(k) && !isStorageClassHeader(k) {

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -243,3 +243,19 @@ type deleteMultiObjectsResult struct {
 	DeletedObjects   []deletedObject    `xml:"Deleted"`
 	UnDeletedObjects []nonDeletedObject `xml:"Error"`
 }
+
+type tagging struct {
+	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Tagging"`
+	TagSet  tagSet
+}
+
+type tagSet struct {
+	XMLName xml.Name `xml:"TagSet"`
+	Tags    []tag
+}
+
+type tag struct {
+	XMLName xml.Name `xml:"Tag"`
+	Key     string   `xml:"Key"`
+	Value   string   `xml:"Value"`
+}

--- a/api-stat.go
+++ b/api-stat.go
@@ -78,7 +78,7 @@ var defaultFilterKeys = []string{
 	"x-amz-id-2",
 	"Content-Security-Policy",
 	"X-Xss-Protection",
-
+	amzTaggingHeaderCount,
 	// Add new headers to be ignored.
 }
 

--- a/api.go
+++ b/api.go
@@ -824,7 +824,7 @@ func (c Client) newRequest(method string, metadata requestMetadata) (req *http.R
 	case signerType.IsV2():
 		// Add signature version '2' authorization header.
 		req = s3signer.SignV2(*req, accessKeyID, secretAccessKey, isVirtualHost)
-	case metadata.objectName != "" && method == "PUT" && metadata.customHeader.Get("X-Amz-Copy-Source") == "" && !c.secure:
+	case metadata.objectName != "" && metadata.queryValues == nil && method == "PUT" && metadata.customHeader.Get("X-Amz-Copy-Source") == "" && !c.secure:
 		// Streaming signature is used by default for a PUT object request. Additionally we also
 		// look if the initialized client is secure, if yes then we don't need to perform
 		// streaming signature.

--- a/constants.go
+++ b/constants.go
@@ -60,3 +60,8 @@ const amzStorageClass = "X-Amz-Storage-Class"
 
 // Website redirect location header constant
 const amzWebsiteRedirectLocation = "X-Amz-Website-Redirect-Location"
+
+// Tagging header constants
+const amzTaggingHeader = "X-Amz-Tagging"
+const amzTaggingHeaderDirective = "X-Amz-Tagging-Directive"
+const amzTaggingHeaderCount = "X-Amz-Tagging-Count"

--- a/examples/s3/copyobject-with-new-tags.go
+++ b/examples/s3/copyobject-with-new-tags.go
@@ -2,7 +2,7 @@
 
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2015-2017 MinIO, Inc.
+ * Copyright 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/s3/copyobject-with-new-tags.go
+++ b/examples/s3/copyobject-with-new-tags.go
@@ -1,0 +1,81 @@
+// +build ignore
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/minio/minio-go/v6"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-testfile, my-bucketname and
+	// my-objectname are dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Enable trace.
+	// s3Client.TraceOn(os.Stderr)
+
+	// Source object
+	src := minio.NewSourceInfo("my-sourcebucketname", "my-sourceobjectname", nil)
+
+	// All following conditions are allowed and can be combined together.
+
+	// Set modified condition, copy object modified since 2014 April.
+	src.SetModifiedSinceCond(time.Date(2014, time.April, 0, 0, 0, 0, 0, time.UTC))
+
+	// Set unmodified condition, copy object unmodified since 2014 April.
+	// src.SetUnmodifiedSinceCond(time.Date(2014, time.April, 0, 0, 0, 0, 0, time.UTC))
+
+	// Set matching ETag condition, copy object which matches the following ETag.
+	// src.SetMatchETagCond("31624deb84149d2f8ef9c385918b653a")
+
+	// Set matching ETag except condition, copy object which does not match the following ETag.
+	// src.SetMatchETagExceptCond("31624deb84149d2f8ef9c385918b653a")
+
+	tags := map[string]string{
+		"Tag1": "Value1",
+		"Tag2": "Value2",
+	}
+
+	// Destination object
+	dst, err := minio.NewDestinationInfoWithOptions("my-bucketname", "my-objectname", minio.DestInfoOptions{
+		UserTags: tags, ReplaceTags: true,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	// Initiate copy object.
+	err = s3Client.CopyObject(dst, src)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println("Copied source object /my-sourcebucketname/my-sourceobjectname to destination /my-bucketname/my-objectname Successfully.")
+}

--- a/examples/s3/getobjecttagging.go
+++ b/examples/s3/getobjecttagging.go
@@ -1,0 +1,47 @@
+// +build ignore
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/minio/minio-go/v6"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-testfile, my-bucketname and
+	// my-objectname are dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	tags, err := s3Client.GetObjectTagging("my-bucketname", "my-objectname")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	fmt.Printf("Fetched Object Tags: %s", tags)
+}

--- a/examples/s3/getobjecttagging.go
+++ b/examples/s3/getobjecttagging.go
@@ -2,7 +2,7 @@
 
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2015-2017 MinIO, Inc.
+ * Copyright 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/s3/putobject-with-tags.go
+++ b/examples/s3/putobject-with-tags.go
@@ -1,0 +1,61 @@
+// +build ignore
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/minio/minio-go/v6"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-testfile, my-bucketname and
+	// my-objectname are dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	object, err := os.Open("my-testfile")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer object.Close()
+	objectStat, err := object.Stat()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	tags := map[string]string{
+		"Tag1": "Value1",
+		"Tag2": "Value2",
+	}
+	n, err := s3Client.PutObject("my-bucketname", "my-objectname", object, objectStat.Size(), minio.PutObjectOptions{ContentType: "application/octet-stream", UserTags: tags})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println("Uploaded", "my-objectname", " of size: ", n, "Successfully.")
+}

--- a/examples/s3/putobjecttagging.go
+++ b/examples/s3/putobjecttagging.go
@@ -1,0 +1,49 @@
+// +build ignore
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio-go/v6"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-testfile, my-bucketname and
+	// my-objectname are dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	tags := map[string]string{
+		"Tag1": "Value1",
+		"Tag2": "Value2",
+	}
+	err = s3Client.PutObjectTagging("my-bucketname", "my-objectname", tags)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/examples/s3/removeobjecttagging.go
+++ b/examples/s3/removeobjecttagging.go
@@ -1,0 +1,45 @@
+// +build ignore
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio-go/v6"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-testfile, my-bucketname and
+	// my-objectname are dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	err = s3Client.RemoveObjectTagging("my-bucketname", "my-objectname")
+	if err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -219,6 +219,31 @@ func QueryEncode(v url.Values) string {
 	return buf.String()
 }
 
+// TagEncode - encodes tag values in their URL encoded form. In
+// addition to the percent encoding performed by urlEncodePath() used
+// here, it also percent encodes '/' (forward slash)
+func TagEncode(tags map[string]string) string {
+	if tags == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := tags[k]
+		prefix := percentEncodeSlash(EncodePath(k)) + "="
+		if buf.Len() > 0 {
+			buf.WriteByte('&')
+		}
+		buf.WriteString(prefix)
+		buf.WriteString(percentEncodeSlash(EncodePath(v)))
+	}
+	return buf.String()
+}
+
 // if object matches reserved string, no need to encode them
 var reservedObjectNames = regexp.MustCompile("^[a-zA-Z0-9-_.~/]+$")
 


### PR DESCRIPTION
Add new ObjectTagging APIs. Also, add ObjectTagging support
in PutObject, CopyObject and other existing APIs.
Changes are as per the documentation here
https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html

This is a precursor to ObjectTagging support on MinIO server.

Refer minio/minio#8446