### PR TITLE
Filter out X-Cache and X-Cache-Lookup from metadata

### DIFF
--- a/api-stat.go
+++ b/api-stat.go
@@ -91,6 +91,8 @@ func extractObjMetadata(header http.Header) http.Header {
 		"Last-Modified",
 		"Content-Type",
 		"Expires",
+		"X-Cache",
+		"X-Cache-Lookup",
 	}, defaultFilterKeys...)
 	return filterHeader(header, filterKeys)
 }


### PR DESCRIPTION
PR add above response headers in  https://github.com/minio/minio/pull/8794. These need to be filtered out from metadata.