### PR TITLE
Remove empty X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id from request headers

### DIFF
--- a/pkg/encrypt/server-side.go
+++ b/pkg/encrypt/server-side.go
@@ -188,7 +188,9 @@ func (s kms) Type() Type { return KMS }
 
 func (s kms) Marshal(h http.Header) {
 	h.Set(sseGenericHeader, "aws:kms")
-	h.Set(sseKmsKeyID, s.key)
+	if s.key != "" {
+		h.Set(sseKmsKeyID, s.key)
+	}
 	if s.hasContext {
 		h.Set(sseEncryptionContext, base64.StdEncoding.EncodeToString(s.context))
 	}


### PR DESCRIPTION
Looks like it is correct fix to https://github.com/minio/minio/issues/8832

S3 API complains if empty `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id ` header is provided. If a client doesn't intend to pass kms key, this header must be fully omitted 

now next commands work in the same way
```
aws s3 cp 1.txt s3://my_specific_bucket --sse:aws:kms --sse-kms-key-id ""
aws s3 cp 1.txt s3://my_specific_bucket --sse:aws:kms
aws s3 cp 1.txt s3://my_specific_bucket --sse:aws:kms --sse-kms-key-id "" --endpoint-url=http://localhost:9000 --profile=minio
aws s3 cp 1.txt s3://my_specific_bucket --sse:aws:kms --endpoint-url=http://localhost:9000 --profile=minio
```

As there were no corresponding unit tests, I did't add any new tests
