### PR TITLE
Add Support for Legal-Hold

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -60,6 +60,9 @@ type DestInfoOptions struct {
 	// Otherwise this field is ignored
 	UserTags    map[string]string
 	ReplaceTags bool
+
+	// Specifies whether you want to apply a Legal Hold to the copied object.
+	LegalHold LegalHoldStatus
 }
 
 // Process custom-metadata to remove a `x-amz-meta-` prefix if
@@ -107,6 +110,7 @@ func NewDestinationInfo(bucket, object string, sse encrypt.ServerSide, userMeta 
 		UserMeta:    m,
 		UserTags:    nil,
 		ReplaceTags: false,
+		LegalHold:   LegalHoldStatus(""),
 	}
 	return DestinationInfo{
 		bucket: bucket,

--- a/api-object-lock.go
+++ b/api-object-lock.go
@@ -184,10 +184,10 @@ func (c Client) SetBucketObjectLockConfig(bucketName string, mode *RetentionMode
 }
 
 // GetBucketObjectLockConfig gets object lock configuration of given bucket.
-func (c Client) GetBucketObjectLockConfig(bucketName string) (mode *RetentionMode, validity *uint, unit *ValidityUnit, err error) {
+func (c Client) GetBucketObjectLockConfig(bucketName string) (objectLock string, mode *RetentionMode, validity *uint, unit *ValidityUnit, err error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
-		return nil, nil, nil, err
+		return "", nil, nil, nil, err
 	}
 
 	urlValues := make(url.Values)
@@ -201,16 +201,16 @@ func (c Client) GetBucketObjectLockConfig(bucketName string) (mode *RetentionMod
 	})
 	defer closeResponse(resp)
 	if err != nil {
-		return nil, nil, nil, err
+		return "", nil, nil, nil, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return nil, nil, nil, httpRespToErrorResponse(resp, bucketName, "")
+			return "", nil, nil, nil, httpRespToErrorResponse(resp, bucketName, "")
 		}
 	}
 	config := &objectLockConfig{}
 	if err = xml.NewDecoder(resp.Body).Decode(config); err != nil {
-		return nil, nil, nil, err
+		return "", nil, nil, nil, err
 	}
 
 	if config.Rule != nil {
@@ -225,8 +225,8 @@ func (c Client) GetBucketObjectLockConfig(bucketName string) (mode *RetentionMod
 			unit = &years
 		}
 
-		return mode, validity, unit, nil
+		return config.ObjectLockEnabled, mode, validity, unit, nil
 	}
 
-	return nil, nil, nil, nil
+	return "", nil, nil, nil, nil
 }

--- a/api-put-object-copy.go
+++ b/api-put-object-copy.go
@@ -45,6 +45,10 @@ func (c Client) CopyObjectWithProgress(dst DestinationInfo, src SourceInfo, prog
 		header.Set(amzTaggingHeader, s3utils.TagEncode(dst.opts.UserTags))
 	}
 
+	if dst.opts.LegalHold != LegalHoldStatus("") {
+		header.Set(amzLegalHoldHeader, dst.opts.LegalHold.String())
+	}
+
 	var err error
 	var size int64
 	// If progress bar is specified, size should be requested as well initiate a StatObject request.

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -50,7 +50,7 @@ func (c Client) putObjectMultipart(ctx context.Context, bucketName, objectName s
 				return 0, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)
 			}
 			// Fall back to uploading as single PutObject operation.
-			return c.putObjectNoChecksum(ctx, bucketName, objectName, reader, size, opts)
+			return c.putObject(ctx, bucketName, objectName, reader, size, opts)
 		}
 	}
 	return n, err
@@ -104,7 +104,7 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 		// Choose hash algorithms to be calculated by hashCopyN,
 		// avoid sha256 with non-v4 signature request or
 		// HTTPS connection.
-		hashAlgos, hashSums := c.hashMaterials()
+		hashAlgos, hashSums := c.hashMaterials(opts.SendContentMd5)
 
 		length, rErr := io.ReadFull(reader, buf)
 		if rErr == io.EOF {

--- a/api.go
+++ b/api.go
@@ -413,7 +413,7 @@ func (c *Client) SetS3TransferAccelerate(accelerateEndpoint string) {
 //  - For signature v4 request if the connection is insecure compute only sha256.
 //  - For signature v4 request if the connection is secure compute only md5.
 //  - For anonymous request compute md5.
-func (c *Client) hashMaterials() (hashAlgos map[string]hash.Hash, hashSums map[string][]byte) {
+func (c *Client) hashMaterials(isMd5Requested bool) (hashAlgos map[string]hash.Hash, hashSums map[string][]byte) {
 	hashSums = make(map[string][]byte)
 	hashAlgos = make(map[string]hash.Hash)
 	if c.overrideSignerType.IsV4() {
@@ -426,6 +426,9 @@ func (c *Client) hashMaterials() (hashAlgos map[string]hash.Hash, hashSums map[s
 		if c.overrideSignerType.IsAnonymous() {
 			hashAlgos["md5"] = md5.New()
 		}
+	}
+	if isMd5Requested {
+		hashAlgos["md5"] = md5.New()
 	}
 	return hashAlgos, hashSums
 }

--- a/bucket-notification.go
+++ b/bucket-notification.go
@@ -81,7 +81,7 @@ func NewArn(partition, service, region, accountID, resource string) Arn {
 		Resource:  resource}
 }
 
-// Return the string format of the ARN
+// String returns the string format of the ARN
 func (arn Arn) String() string {
 	return "arn:" + arn.Partition + ":" + arn.Service + ":" + arn.Region + ":" + arn.AccountID + ":" + arn.Resource
 }

--- a/constants.go
+++ b/constants.go
@@ -65,3 +65,6 @@ const amzWebsiteRedirectLocation = "X-Amz-Website-Redirect-Location"
 const amzTaggingHeader = "X-Amz-Tagging"
 const amzTaggingHeaderDirective = "X-Amz-Tagging-Directive"
 const amzTaggingHeaderCount = "X-Amz-Tagging-Count"
+
+// LegalHold Header constants
+const amzLegalHoldHeader = "X-Amz-Object-Lock-Legal-Hold"

--- a/docs/API.md
+++ b/docs/API.md
@@ -617,6 +617,7 @@ __minio.PutObjectOptions__
 | `opts.ServerSideEncryption` | _encrypt.ServerSide_ | Interface provided by `encrypt` package to specify server-side-encryption. (For more information see https://godoc.org/github.com/minio/minio-go/v6) |
 | `opts.StorageClass` | _string_ | Specify storage class for the object. Supported values for MinIO server are `REDUCED_REDUNDANCY` and `STANDARD` |
 | `opts.WebsiteRedirectLocation` | _string_ | Specify a redirect for the object, to another object in the same bucket or to a external URL. |
+| `opts.SendContentMd5` | _bool_ | Specify if you'd like to send `content-md5` header with PutObject operation. Note that setting this flag will cause higher memory usage because of in-memory `md5sum` calculation. |
 
 __Example__
 
@@ -938,6 +939,16 @@ __Parameters__
 | `bucket`      | _string_            | Name of the destination bucket                                                                                 |
 | `object`      | _string_            | Name of the destination object                                                                                 |
 | `destOpts`    | _minio.DestInfoOptions_   | Pointer to struct that allows user to set optional custom metadata, user tags, and server side encryption parameters. |
+
+__minio.DestInfoOptions__
+
+|Field | Type | Description |
+|:--- |:--- | :--- |
+| `destOpts.Encryption` | _encrypt.ServerSide_ | Interface provided by encrypt package to specify server-side-encryption. (For more information see https://godoc.org/github.com/minio/minio-go/v6). |
+| `destOpts.UserMetadata` | _map[string]string_ | Map of user meta data to be set on destination object. |
+| `destOpts.UserTags` | _map[string]string_ | Map of user object tags to be set on destination object. |
+| `destOpts.ReplaceTags` | _bool_ | Replace object tags of the destination object. |
+| `destOpts.LegalHold` | _*minio.LegalHoldStatus_ | LegalHold(En|Dis)abled. |
 
 __Example__
 

--- a/examples/s3/setbucketencryption.go
+++ b/examples/s3/setbucketencryption.go
@@ -43,7 +43,7 @@ func main() {
 
 	// Set default encryption configuration on a bucket
 	config := minio.ServerSideEncryptionConfiguration{Rules: []minio.Rule{
-		minio.Rule{
+		{
 			Apply: minio.ApplyServerSideEncryptionByDefault{
 				SSEAlgorithm: "AES256",
 				// KmsMasterKeyID: "my-masterkey",

--- a/post-policy.go
+++ b/post-policy.go
@@ -258,7 +258,7 @@ func (p *PostPolicy) addNewPolicy(policyCond policyCondition) error {
 	return nil
 }
 
-// Stringer interface for printing policy in json formatted string.
+// String implement the Stringer interface for printing policy in json formatted string.
 func (p PostPolicy) String() string {
 	return string(p.marshalJSON())
 }


### PR DESCRIPTION
This PR adds support for legal-hold in PutObject, GetObject,
StatObject & CopyObject APIs.

This PR also adds support for "SendContentMd5" field in PutObjectOptions
so users can ask the SDK to send the content-md5. Users are expected
to set this flag for PutObject operations in case locking is enabled
on given bucket.

Note regarding PutObject behaviour:

If SendContentMd5 flag is set minio-go may consume higher memory
due to in-memory md5sum calculation.
