### PR TITLE
list: Use PathUnescape when decoding object names

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -317,14 +317,14 @@ func (c Client) listObjectsV2Query(bucketName, objectPrefix, continuationToken s
 	}
 
 	for i, obj := range listBucketResult.Contents {
-		listBucketResult.Contents[i].Key, err = url.QueryUnescape(obj.Key)
+		listBucketResult.Contents[i].Key, err = url.PathUnescape(obj.Key)
 		if err != nil {
 			return listBucketResult, err
 		}
 	}
 
 	for i, obj := range listBucketResult.CommonPrefixes {
-		listBucketResult.CommonPrefixes[i].Prefix, err = url.QueryUnescape(obj.Prefix)
+		listBucketResult.CommonPrefixes[i].Prefix, err = url.PathUnescape(obj.Prefix)
 		if err != nil {
 			return listBucketResult, err
 		}
@@ -500,21 +500,21 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 	}
 
 	for i, obj := range listBucketResult.Contents {
-		listBucketResult.Contents[i].Key, err = url.QueryUnescape(obj.Key)
+		listBucketResult.Contents[i].Key, err = url.PathUnescape(obj.Key)
 		if err != nil {
 			return listBucketResult, err
 		}
 	}
 
 	for i, obj := range listBucketResult.CommonPrefixes {
-		listBucketResult.CommonPrefixes[i].Prefix, err = url.QueryUnescape(obj.Prefix)
+		listBucketResult.CommonPrefixes[i].Prefix, err = url.PathUnescape(obj.Prefix)
 		if err != nil {
 			return listBucketResult, err
 		}
 	}
 
 	if listBucketResult.NextMarker != "" {
-		listBucketResult.NextMarker, err = url.QueryUnescape(listBucketResult.NextMarker)
+		listBucketResult.NextMarker, err = url.PathUnescape(listBucketResult.NextMarker)
 		if err != nil {
 			return listBucketResult, err
 		}
@@ -697,25 +697,25 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 		return listMultipartUploadsResult, err
 	}
 
-	listMultipartUploadsResult.NextKeyMarker, err = url.QueryUnescape(listMultipartUploadsResult.NextKeyMarker)
+	listMultipartUploadsResult.NextKeyMarker, err = url.PathUnescape(listMultipartUploadsResult.NextKeyMarker)
 	if err != nil {
 		return listMultipartUploadsResult, err
 	}
 
-	listMultipartUploadsResult.NextUploadIDMarker, err = url.QueryUnescape(listMultipartUploadsResult.NextUploadIDMarker)
+	listMultipartUploadsResult.NextUploadIDMarker, err = url.PathUnescape(listMultipartUploadsResult.NextUploadIDMarker)
 	if err != nil {
 		return listMultipartUploadsResult, err
 	}
 
 	for i, obj := range listMultipartUploadsResult.Uploads {
-		listMultipartUploadsResult.Uploads[i].Key, err = url.QueryUnescape(obj.Key)
+		listMultipartUploadsResult.Uploads[i].Key, err = url.PathUnescape(obj.Key)
 		if err != nil {
 			return listMultipartUploadsResult, err
 		}
 	}
 
 	for i, obj := range listMultipartUploadsResult.CommonPrefixes {
-		listMultipartUploadsResult.CommonPrefixes[i].Prefix, err = url.QueryUnescape(obj.Prefix)
+		listMultipartUploadsResult.CommonPrefixes[i].Prefix, err = url.PathUnescape(obj.Prefix)
 		if err != nil {
 			return listMultipartUploadsResult, err
 		}


### PR DESCRIPTION
When url-encoding is set to 'url', minio-go should avoid decoding plain '+'
to a space in object names.

Although, '+' is generally encoded to %2B in the listing response (see AWS
response), we still can tolerate plain '+' as well.