### PR TITLE
list: Check EncodingType in list resp before decoding object names

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -317,14 +317,14 @@ func (c Client) listObjectsV2Query(bucketName, objectPrefix, continuationToken s
 	}
 
 	for i, obj := range listBucketResult.Contents {
-		listBucketResult.Contents[i].Key, err = url.QueryUnescape(obj.Key)
+		listBucketResult.Contents[i].Key, err = decodeS3Name(obj.Key, listBucketResult.EncodingType)
 		if err != nil {
 			return listBucketResult, err
 		}
 	}
 
 	for i, obj := range listBucketResult.CommonPrefixes {
-		listBucketResult.CommonPrefixes[i].Prefix, err = url.QueryUnescape(obj.Prefix)
+		listBucketResult.CommonPrefixes[i].Prefix, err = decodeS3Name(obj.Prefix, listBucketResult.EncodingType)
 		if err != nil {
 			return listBucketResult, err
 		}
@@ -500,21 +500,21 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 	}
 
 	for i, obj := range listBucketResult.Contents {
-		listBucketResult.Contents[i].Key, err = url.QueryUnescape(obj.Key)
+		listBucketResult.Contents[i].Key, err = decodeS3Name(obj.Key, listBucketResult.EncodingType)
 		if err != nil {
 			return listBucketResult, err
 		}
 	}
 
 	for i, obj := range listBucketResult.CommonPrefixes {
-		listBucketResult.CommonPrefixes[i].Prefix, err = url.QueryUnescape(obj.Prefix)
+		listBucketResult.CommonPrefixes[i].Prefix, err = decodeS3Name(obj.Prefix, listBucketResult.EncodingType)
 		if err != nil {
 			return listBucketResult, err
 		}
 	}
 
 	if listBucketResult.NextMarker != "" {
-		listBucketResult.NextMarker, err = url.QueryUnescape(listBucketResult.NextMarker)
+		listBucketResult.NextMarker, err = decodeS3Name(listBucketResult.NextMarker, listBucketResult.EncodingType)
 		if err != nil {
 			return listBucketResult, err
 		}
@@ -697,25 +697,25 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 		return listMultipartUploadsResult, err
 	}
 
-	listMultipartUploadsResult.NextKeyMarker, err = url.QueryUnescape(listMultipartUploadsResult.NextKeyMarker)
+	listMultipartUploadsResult.NextKeyMarker, err = decodeS3Name(listMultipartUploadsResult.NextKeyMarker, listMultipartUploadsResult.EncodingType)
 	if err != nil {
 		return listMultipartUploadsResult, err
 	}
 
-	listMultipartUploadsResult.NextUploadIDMarker, err = url.QueryUnescape(listMultipartUploadsResult.NextUploadIDMarker)
+	listMultipartUploadsResult.NextUploadIDMarker, err = decodeS3Name(listMultipartUploadsResult.NextUploadIDMarker, listMultipartUploadsResult.EncodingType)
 	if err != nil {
 		return listMultipartUploadsResult, err
 	}
 
 	for i, obj := range listMultipartUploadsResult.Uploads {
-		listMultipartUploadsResult.Uploads[i].Key, err = url.QueryUnescape(obj.Key)
+		listMultipartUploadsResult.Uploads[i].Key, err = decodeS3Name(obj.Key, listMultipartUploadsResult.EncodingType)
 		if err != nil {
 			return listMultipartUploadsResult, err
 		}
 	}
 
 	for i, obj := range listMultipartUploadsResult.CommonPrefixes {
-		listMultipartUploadsResult.CommonPrefixes[i].Prefix, err = url.QueryUnescape(obj.Prefix)
+		listMultipartUploadsResult.CommonPrefixes[i].Prefix, err = decodeS3Name(obj.Prefix, listMultipartUploadsResult.EncodingType)
 		if err != nil {
 			return listMultipartUploadsResult, err
 		}
@@ -836,4 +836,14 @@ func (c Client) listObjectPartsQuery(bucketName, objectName, uploadID string, pa
 		return listObjectPartsResult, err
 	}
 	return listObjectPartsResult, nil
+}
+
+// Decode an S3 object name according to the encoding type
+func decodeS3Name(name, encodingType string) (string, error) {
+	switch encodingType {
+	case "url":
+		return url.QueryUnescape(name)
+	default:
+		return name, nil
+	}
 }

--- a/bucket-notification.go
+++ b/bucket-notification.go
@@ -81,7 +81,7 @@ func NewArn(partition, service, region, accountID, resource string) Arn {
 		Resource:  resource}
 }
 
-// Return the string format of the ARN
+// String returns the string format of the ARN
 func (arn Arn) String() string {
 	return "arn:" + arn.Partition + ":" + arn.Service + ":" + arn.Region + ":" + arn.AccountID + ":" + arn.Resource
 }

--- a/post-policy.go
+++ b/post-policy.go
@@ -258,7 +258,7 @@ func (p *PostPolicy) addNewPolicy(policyCond policyCondition) error {
 	return nil
 }
 
-// Stringer interface for printing policy in json formatted string.
+// String function for printing policy in json formatted string.
 func (p PostPolicy) String() string {
 	return string(p.marshalJSON())
 }


### PR DESCRIPTION
minio-go was always decoding object names in the xml listing response
since encoding-type=url is always sent. However some S3 servers are
not able to satisfy the encoding type requirement, therefore confusing
minio-go.

This change will check EncondingType field in the xml list response
and decode object names depending on that. No decoding will be done
if EncodingType is missing or empty.