### PR TITLE
simplify extracting metadata in Head/Get object

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -71,51 +71,58 @@ func (opts PutObjectOptions) getNumThreads() (numThreads int) {
 func (opts PutObjectOptions) Header() (header http.Header) {
 	header = make(http.Header)
 
-	if opts.ContentType != "" {
-		header["Content-Type"] = []string{opts.ContentType}
-	} else {
-		header["Content-Type"] = []string{"application/octet-stream"}
+	contentType := opts.ContentType
+	if contentType == "" {
+		contentType = "application/octet-stream"
 	}
+	header.Set("Content-Type", contentType)
+
 	if opts.ContentEncoding != "" {
-		header["Content-Encoding"] = []string{opts.ContentEncoding}
+		header.Set("Content-Encoding", opts.ContentEncoding)
 	}
 	if opts.ContentDisposition != "" {
-		header["Content-Disposition"] = []string{opts.ContentDisposition}
+		header.Set("Content-Disposition", opts.ContentDisposition)
 	}
 	if opts.ContentLanguage != "" {
-		header["Content-Language"] = []string{opts.ContentLanguage}
+		header.Set("Content-Language", opts.ContentLanguage)
 	}
 	if opts.CacheControl != "" {
-		header["Cache-Control"] = []string{opts.CacheControl}
+		header.Set("Cache-Control", opts.CacheControl)
 	}
 
 	if opts.Mode != nil {
-		header["x-amz-object-lock-mode"] = []string{opts.Mode.String()}
+		header.Set("X-Amz-Object-Lock-Mode", opts.Mode.String())
 	}
+
 	if opts.RetainUntilDate != nil {
-		header["x-amz-object-lock-retain-until-date"] = []string{opts.RetainUntilDate.Format(time.RFC3339)}
+		header.Set("X-Amz-Object-Lock-Retain-Until-Date", opts.RetainUntilDate.Format(time.RFC3339))
 	}
 
 	if opts.LegalHold != "" {
-		header[amzLegalHoldHeader] = []string{opts.LegalHold.String()}
+		header.Set(amzLegalHoldHeader, opts.LegalHold.String())
 	}
+
 	if opts.ServerSideEncryption != nil {
 		opts.ServerSideEncryption.Marshal(header)
 	}
+
 	if opts.StorageClass != "" {
-		header[amzStorageClass] = []string{opts.StorageClass}
+		header.Set(amzStorageClass, opts.StorageClass)
 	}
+
 	if opts.WebsiteRedirectLocation != "" {
-		header[amzWebsiteRedirectLocation] = []string{opts.WebsiteRedirectLocation}
+		header.Set(amzWebsiteRedirectLocation, opts.WebsiteRedirectLocation)
 	}
+
 	if len(opts.UserTags) != 0 {
-		header[amzTaggingHeader] = []string{s3utils.TagEncode(opts.UserTags)}
+		header.Set(amzTaggingHeader, s3utils.TagEncode(opts.UserTags))
 	}
+
 	for k, v := range opts.UserMetadata {
 		if !isAmzHeader(k) && !isStandardHeader(k) && !isStorageClassHeader(k) {
-			header["X-Amz-Meta-"+k] = []string{v}
+			header.Set("X-Amz-Meta-"+k, v)
 		} else {
-			header[k] = []string{v}
+			header.Set(k, v)
 		}
 	}
 	return

--- a/api-stat.go
+++ b/api-stat.go
@@ -20,9 +20,6 @@ package minio
 import (
 	"context"
 	"net/http"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/minio/minio-go/v6/pkg/s3utils"
 )
@@ -62,39 +59,6 @@ func (c Client) BucketExistsWithContext(ctx context.Context, bucketName string) 
 		}
 	}
 	return true, nil
-}
-
-// List of header keys to be filtered, usually
-// from all S3 API http responses.
-var defaultFilterKeys = []string{
-	"Connection",
-	"Transfer-Encoding",
-	"Accept-Ranges",
-	"Date",
-	"Server",
-	"Vary",
-	"x-amz-bucket-region",
-	"x-amz-request-id",
-	"x-amz-id-2",
-	"Content-Security-Policy",
-	"X-Xss-Protection",
-	amzTaggingHeaderCount,
-	// Add new headers to be ignored.
-}
-
-// Extract only necessary metadata header key/values by
-// filtering them out with a list of custom header keys.
-func extractObjMetadata(header http.Header) http.Header {
-	filterKeys := append([]string{
-		"ETag",
-		"Content-Length",
-		"Last-Modified",
-		"Content-Type",
-		"Expires",
-		"X-Cache",
-		"X-Cache-Lookup",
-	}, defaultFilterKeys...)
-	return filterHeader(header, filterKeys)
 }
 
 // StatObject verifies if object exists and you have permission to access.
@@ -142,76 +106,5 @@ func (c Client) statObject(ctx context.Context, bucketName, objectName string, o
 		}
 	}
 
-	// Trim off the odd double quotes from ETag in the beginning and end.
-	md5sum := trimEtag(resp.Header.Get("ETag"))
-
-	// Parse content length is exists
-	var size int64 = -1
-	contentLengthStr := resp.Header.Get("Content-Length")
-	if contentLengthStr != "" {
-		size, err = strconv.ParseInt(contentLengthStr, 10, 64)
-		if err != nil {
-			// Content-Length is not valid
-			return ObjectInfo{}, ErrorResponse{
-				Code:       "InternalError",
-				Message:    "Content-Length is invalid. " + reportIssue,
-				BucketName: bucketName,
-				Key:        objectName,
-				RequestID:  resp.Header.Get("x-amz-request-id"),
-				HostID:     resp.Header.Get("x-amz-id-2"),
-				Region:     resp.Header.Get("x-amz-bucket-region"),
-			}
-		}
-	}
-
-	// Parse Last-Modified has http time format.
-	date, err := time.Parse(http.TimeFormat, resp.Header.Get("Last-Modified"))
-	if err != nil {
-		return ObjectInfo{}, ErrorResponse{
-			Code:       "InternalError",
-			Message:    "Last-Modified time format is invalid. " + reportIssue,
-			BucketName: bucketName,
-			Key:        objectName,
-			RequestID:  resp.Header.Get("x-amz-request-id"),
-			HostID:     resp.Header.Get("x-amz-id-2"),
-			Region:     resp.Header.Get("x-amz-bucket-region"),
-		}
-	}
-
-	// Fetch content type if any present.
-	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
-
-	expiryStr := resp.Header.Get("Expires")
-	var expTime time.Time
-	if t, err := time.Parse(http.TimeFormat, expiryStr); err == nil {
-		expTime = t.UTC()
-	}
-
-	metadata := extractObjMetadata(resp.Header)
-	userMetadata := map[string]string{}
-	const xamzmeta = "x-amz-meta-"
-	const xamzmetaLen = len(xamzmeta)
-	for k, v := range metadata {
-		if strings.HasPrefix(strings.ToLower(k), xamzmeta) {
-			userMetadata[k[xamzmetaLen:]] = v[0]
-		}
-	}
-
-	// Save object metadata info.
-	return ObjectInfo{
-		ETag:         md5sum,
-		Key:          objectName,
-		Size:         size,
-		LastModified: date,
-		ContentType:  contentType,
-		Expires:      expTime,
-		// Extract only the relevant header keys describing the object.
-		// following function filters out a list of standard set of keys
-		// which are not part of object metadata.
-		Metadata:     metadata,
-		UserMetadata: userMetadata,
-	}, nil
+	return ToObjectInfo(bucketName, objectName, resp.Header)
 }

--- a/constants.go
+++ b/constants.go
@@ -55,16 +55,17 @@ const (
 	iso8601DateFormat = "20060102T150405Z"
 )
 
-// Storage class header constant.
-const amzStorageClass = "X-Amz-Storage-Class"
+const (
+	// Storage class header.
+	amzStorageClass = "X-Amz-Storage-Class"
 
-// Website redirect location header constant
-const amzWebsiteRedirectLocation = "X-Amz-Website-Redirect-Location"
+	// Website redirect location header
+	amzWebsiteRedirectLocation = "X-Amz-Website-Redirect-Location"
 
-// Tagging header constants
-const amzTaggingHeader = "X-Amz-Tagging"
-const amzTaggingHeaderDirective = "X-Amz-Tagging-Directive"
-const amzTaggingHeaderCount = "X-Amz-Tagging-Count"
+	// Object Tagging headers
+	amzTaggingHeader          = "X-Amz-Tagging"
+	amzTaggingHeaderDirective = "X-Amz-Tagging-Directive"
 
-// LegalHold Header constants
-const amzLegalHoldHeader = "X-Amz-Object-Lock-Legal-Hold"
+	// Object legal hold header
+	amzLegalHoldHeader = "X-Amz-Object-Lock-Legal-Hold"
+)

--- a/utils.go
+++ b/utils.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -159,27 +160,117 @@ func isValidExpiry(expires time.Duration) error {
 	return nil
 }
 
-// make a copy of http.Header
-func cloneHeader(h http.Header) http.Header {
-	h2 := make(http.Header, len(h))
-	for k, vv := range h {
-		vv2 := make([]string, len(vv))
-		copy(vv2, vv)
-		h2[k] = vv2
+// Extract only necessary metadata header key/values by
+// filtering them out with a list of custom header keys.
+func extractObjMetadata(header http.Header) http.Header {
+	preserveKeys := []string{
+		"Content-Type",
+		"Cache-Control",
+		"Content-Encoding",
+		"Content-Language",
+		"Content-Disposition",
+		"X-Amz-Storage-Class",
+		"X-Amz-Object-Lock-Mode",
+		"X-Amz-Object-Lock-Retain-Until-Date",
+		"X-Amz-Object-Lock-Legal-Hold",
+		"X-Amz-Website-Redirect-Location",
+		"X-Amz-Meta-",
+		// Add new headers to be preserved.
+		// if you add new headers here, please extend
+		// PutObjectOptions{} to preserve them
+		// upon upload as well.
 	}
-	return h2
-}
-
-// Filter relevant response headers from
-// the HEAD, GET http response. The function takes
-// a list of headers which are filtered out and
-// returned as a new http header.
-func filterHeader(header http.Header, filterKeys []string) (filteredHeader http.Header) {
-	filteredHeader = cloneHeader(header)
-	for _, key := range filterKeys {
-		filteredHeader.Del(key)
+	filteredHeader := make(http.Header)
+	for k, v := range header {
+		var found bool
+		for _, prefix := range preserveKeys {
+			if !strings.HasPrefix(k, prefix) {
+				continue
+			}
+			found = true
+			break
+		}
+		if found {
+			filteredHeader[k] = v
+		}
 	}
 	return filteredHeader
+}
+
+// ToObjectInfo converts http header values into ObjectInfo type,
+// extracts metadata and fills in all the necessary fields in ObjectInfo.
+func ToObjectInfo(bucketName string, objectName string, h http.Header) (ObjectInfo, error) {
+	var err error
+	// Trim off the odd double quotes from ETag in the beginning and end.
+	etag := trimEtag(h.Get("ETag"))
+
+	// Parse content length is exists
+	var size int64 = -1
+	contentLengthStr := h.Get("Content-Length")
+	if contentLengthStr != "" {
+		size, err = strconv.ParseInt(contentLengthStr, 10, 64)
+		if err != nil {
+			// Content-Length is not valid
+			return ObjectInfo{}, ErrorResponse{
+				Code:       "InternalError",
+				Message:    "Content-Length is invalid. " + reportIssue,
+				BucketName: bucketName,
+				Key:        objectName,
+				RequestID:  h.Get("x-amz-request-id"),
+				HostID:     h.Get("x-amz-id-2"),
+				Region:     h.Get("x-amz-bucket-region"),
+			}
+		}
+	}
+
+	// Parse Last-Modified has http time format.
+	date, err := time.Parse(http.TimeFormat, h.Get("Last-Modified"))
+	if err != nil {
+		return ObjectInfo{}, ErrorResponse{
+			Code:       "InternalError",
+			Message:    "Last-Modified time format is invalid. " + reportIssue,
+			BucketName: bucketName,
+			Key:        objectName,
+			RequestID:  h.Get("x-amz-request-id"),
+			HostID:     h.Get("x-amz-id-2"),
+			Region:     h.Get("x-amz-bucket-region"),
+		}
+	}
+
+	// Fetch content type if any present.
+	contentType := strings.TrimSpace(h.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	expiryStr := h.Get("Expires")
+	var expTime time.Time
+	if t, err := time.Parse(http.TimeFormat, expiryStr); err == nil {
+		expTime = t.UTC()
+	}
+
+	metadata := extractObjMetadata(h)
+	userMetadata := make(map[string]string)
+	for k, v := range metadata {
+		if strings.HasPrefix(k, "X-Amz-Meta-") {
+			userMetadata[strings.TrimPrefix(k, "X-Amz-Meta-")] = v[0]
+		}
+	}
+
+	// Save object metadata info.
+	return ObjectInfo{
+		ETag:         etag,
+		Key:          objectName,
+		Size:         size,
+		LastModified: date,
+		ContentType:  contentType,
+		Expires:      expTime,
+		// Extract only the relevant header keys describing the object.
+		// following function filters out a list of standard set of keys
+		// which are not part of object metadata.
+		Metadata:     metadata,
+		UserMetadata: userMetadata,
+	}, nil
 }
 
 // regCred matches credential string in HTTP header

--- a/utils_test.go
+++ b/utils_test.go
@@ -19,7 +19,6 @@ package minio
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"testing"
 	"time"
@@ -49,21 +48,6 @@ func TestRedactSignature(t *testing.T) {
 		if redactedAuthValue != testCase.expectedRedactedAuthValue {
 			t.Errorf("Test %d: Expected %s, got %s", i+1, testCase.expectedRedactedAuthValue, redactedAuthValue)
 		}
-	}
-}
-
-// Tests filter header function by filtering out
-// some custom header keys.
-func TestFilterHeader(t *testing.T) {
-	header := http.Header{}
-	header.Set("Content-Type", "binary/octet-stream")
-	header.Set("Content-Encoding", "gzip")
-	newHeader := filterHeader(header, []string{"Content-Type"})
-	if len(newHeader) > 1 {
-		t.Fatalf("Unexpected size of the returned header, should be 1, got %d", len(newHeader))
-	}
-	if newHeader.Get("Content-Encoding") != "gzip" {
-		t.Fatalf("Unexpected content-encoding value, expected 'gzip', got %s", newHeader.Get("Content-Encoding"))
 	}
 }
 


### PR DESCRIPTION
ensure that we only look for correct headers
needed, rather than filtering out headers
which may be many, this will ensure that we
shall never copy unexpected headers.