### PR TITLE
Export identifiers for shared credentials providers

### DIFF
--- a/pkg/credentials/file_aws_credentials.go
+++ b/pkg/credentials/file_aws_credentials.go
@@ -36,12 +36,12 @@ type FileAWSCredentials struct {
 	// env value is empty will default to current user's home directory.
 	// Linux/OSX: "$HOME/.aws/credentials"
 	// Windows:   "%USERPROFILE%\.aws\credentials"
-	filename string
+	Filename string
 
 	// AWS Profile to extract credentials from the shared credentials file. If empty
 	// will default to environment variable "AWS_PROFILE" or "default" if
 	// environment variable is also not set.
-	profile string
+	Profile string
 
 	// retrieved states if the credentials have been successfully retrieved.
 	retrieved bool
@@ -51,34 +51,34 @@ type FileAWSCredentials struct {
 // wrapping the Profile file provider.
 func NewFileAWSCredentials(filename string, profile string) *Credentials {
 	return New(&FileAWSCredentials{
-		filename: filename,
-		profile:  profile,
+		Filename: filename,
+		Profile:  profile,
 	})
 }
 
 // Retrieve reads and extracts the shared credentials from the current
 // users home directory.
 func (p *FileAWSCredentials) Retrieve() (Value, error) {
-	if p.filename == "" {
-		p.filename = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
-		if p.filename == "" {
+	if p.Filename == "" {
+		p.Filename = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+		if p.Filename == "" {
 			homeDir, err := homedir.Dir()
 			if err != nil {
 				return Value{}, err
 			}
-			p.filename = filepath.Join(homeDir, ".aws", "credentials")
+			p.Filename = filepath.Join(homeDir, ".aws", "credentials")
 		}
 	}
-	if p.profile == "" {
-		p.profile = os.Getenv("AWS_PROFILE")
-		if p.profile == "" {
-			p.profile = "default"
+	if p.Profile == "" {
+		p.Profile = os.Getenv("AWS_PROFILE")
+		if p.Profile == "" {
+			p.Profile = "default"
 		}
 	}
 
 	p.retrieved = false
 
-	iniProfile, err := loadProfile(p.filename, p.profile)
+	iniProfile, err := loadProfile(p.Filename, p.Profile)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/file_minio_client.go
+++ b/pkg/credentials/file_minio_client.go
@@ -38,12 +38,12 @@ type FileMinioClient struct {
 	// env value is empty will default to current user's home directory.
 	// Linux/OSX: "$HOME/.mc/config.json"
 	// Windows:   "%USERALIAS%\mc\config.json"
-	filename string
+	Filename string
 
 	// MinIO Alias to extract credentials from the shared credentials file. If empty
 	// will default to environment variable "MINIO_ALIAS" or "default" if
 	// environment variable is also not set.
-	alias string
+	Alias string
 
 	// retrieved states if the credentials have been successfully retrieved.
 	retrieved bool
@@ -53,39 +53,39 @@ type FileMinioClient struct {
 // wrapping the Alias file provider.
 func NewFileMinioClient(filename string, alias string) *Credentials {
 	return New(&FileMinioClient{
-		filename: filename,
-		alias:    alias,
+		Filename: filename,
+		Alias:    alias,
 	})
 }
 
 // Retrieve reads and extracts the shared credentials from the current
 // users home directory.
 func (p *FileMinioClient) Retrieve() (Value, error) {
-	if p.filename == "" {
+	if p.Filename == "" {
 		if value, ok := os.LookupEnv("MINIO_SHARED_CREDENTIALS_FILE"); ok {
-			p.filename = value
+			p.Filename = value
 		} else {
 			homeDir, err := homedir.Dir()
 			if err != nil {
 				return Value{}, err
 			}
-			p.filename = filepath.Join(homeDir, ".mc", "config.json")
+			p.Filename = filepath.Join(homeDir, ".mc", "config.json")
 			if runtime.GOOS == "windows" {
-				p.filename = filepath.Join(homeDir, "mc", "config.json")
+				p.Filename = filepath.Join(homeDir, "mc", "config.json")
 			}
 		}
 	}
 
-	if p.alias == "" {
-		p.alias = os.Getenv("MINIO_ALIAS")
-		if p.alias == "" {
-			p.alias = "s3"
+	if p.Alias == "" {
+		p.Alias = os.Getenv("MINIO_ALIAS")
+		if p.Alias == "" {
+			p.Alias = "s3"
 		}
 	}
 
 	p.retrieved = false
 
-	hostCfg, err := loadAlias(p.filename, p.alias)
+	hostCfg, err := loadAlias(p.Filename, p.Alias)
 	if err != nil {
 		return Value{}, err
 	}


### PR DESCRIPTION
This makes it possible to build a chain provider with this kind of
providers, e.g.:

    creds := credentials.NewChainCredentials(
      []credentials.Provider{
        &credentials.FileAWSCredentials{
          Filename: filename,
          Profile: profile
        },
      })

Signed-off-by: Vincent Besanceney <vincent@b9company.fr>