### PR TITLE
retry: Quit when the context is cancelled

### DIFF
--- a/api.go
+++ b/api.go
@@ -630,6 +630,9 @@ func (c Client) executeMethod(ctx context.Context, method string, metadata reque
 		// Initiate the request.
 		res, err = c.do(req)
 		if err != nil {
+			if err == context.Canceled || err == context.DeadlineExceeded {
+				return nil, err
+			}
 			continue
 		}
 
@@ -709,6 +712,12 @@ func (c Client) executeMethod(ctx context.Context, method string, metadata reque
 		// For all other cases break out of the retry loop.
 		break
 	}
+
+	// Return an error when retry is canceled or deadlined
+	if e := retryCtx.Err(); e != nil {
+		return nil, e
+	}
+
 	return res, err
 }
 

--- a/retry.go
+++ b/retry.go
@@ -70,7 +70,11 @@ func (c Client) newRetryTimer(ctx context.Context, maxRetry int, unit time.Durat
 	go func() {
 		defer close(attemptCh)
 		for i := 0; i < maxRetry; i++ {
-			attemptCh <- i + 1
+			select {
+			case attemptCh <- i + 1:
+			case <-ctx.Done():
+				return
+			}
 
 			select {
 			case <-time.After(exponentialBackoffWait(i)):


### PR DESCRIPTION
The retry goroutine can be stuck when sending a new
retry number, this commit will listen for a context
cancelltion to properly quit when the retry is canceled
from the caller.