### PR TITLE
Fix AWS STS url to https when using web identity token

### DIFF
--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -82,7 +82,7 @@ func (m *IAM) Retrieve() (Value, error) {
 	case len(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")) > 0:
 		if len(endpoint) == 0 {
 			if len(os.Getenv("AWS_REGION")) > 0 {
-				endpoint = "sts." + os.Getenv("AWS_REGION") + ".amazonaws.com"
+				endpoint = "https://sts." + os.Getenv("AWS_REGION") + ".amazonaws.com"
 			} else {
 				endpoint = defaultSTSRoleEndpoint
 			}


### PR DESCRIPTION
This PR fixes AWS STS url to https when using web identity token.

I'm using EKS ServiceAccount IAM auth for thanos deployment and thanos uses minio-go to access S3 bucket. There were thanos logs like below, which means minio-go failed to get temporary credentials when using web identity token file.

```
level=warn ts=2020-04-08T03:57:12.445984084Z caller=sidecar.go:340 err="iter local block metas: check exists: stat s3 object: Access Denied." uploaded=0
```

After digging into minio-go codes, I found error was returned in [sts_web_identity.go#L143](https://github.com/minio/minio-go/blob/master/pkg/credentials/sts_web_identity.go#L143)

```
Post sts.ap-northeast-1.amazonaws.com?Action=AssumeRoleWithWebIdentity&...: unsupported protocol scheme ""
```

And it was because of missing 'https://' in minio-go sts url, so I'm using my own custom build docker image by fixing it. It would be better to merge in upstream repository if there are not any exceptions :D