### PR TITLE
Add tagging count to known header

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -175,6 +175,7 @@ func extractObjMetadata(header http.Header) http.Header {
 		"X-Amz-Object-Lock-Legal-Hold",
 		"X-Amz-Website-Redirect-Location",
 		"X-Amz-Server-Side-Encryption",
+		"X-Amz-Tagging-Count",
 		"X-Amz-Meta-",
 		// Add new headers to be preserved.
 		// if you add new headers here, please extend


### PR DESCRIPTION
Currently, X-Amz-Tagging-Count gets filtered. This prevents from that header being displayed as part of stat-object call. This is also required for the head-object call to work in Gateway