### PR TITLE
Treat x-amz-metadata-directive as a standard header

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -325,6 +325,7 @@ var supportedHeaders = []string{
 	"content-language",
 	"x-amz-website-redirect-location",
 	"x-amz-object-lock-mode",
+	"x-amz-metadata-directive",
 	"x-amz-object-lock-retain-until-date",
 	"expires",
 	// Add more supported headers here.


### PR DESCRIPTION
Fixes #1295

Do not append `x-amz-meta` to `x-amz-metadata-directive` header, if passed as metadata as part of `DestinationInfo` in `CopyObject`