### PR TITLE
remove usages of debug.FreeOSMemory()

### DIFF
--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -28,7 +28,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -98,7 +97,6 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 
 	// Create a buffer.
 	buf := make([]byte, partSize)
-	defer debug.FreeOSMemory()
 
 	for partNumber <= totalPartsCount {
 		// Choose hash algorithms to be calculated by hashCopyN,

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -262,7 +261,6 @@ func (c Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, bu
 
 	// Create a buffer.
 	buf := make([]byte, partSize)
-	defer debug.FreeOSMemory()
 
 	// Avoid declaring variables in the for loop
 	var md5Base64 string
@@ -386,7 +384,6 @@ func (c Client) putObject(ctx context.Context, bucketName, objectName string, re
 	if opts.SendContentMd5 {
 		// Create a buffer.
 		buf := make([]byte, size)
-		defer debug.FreeOSMemory()
 
 		length, rErr := io.ReadFull(reader, buf)
 		if rErr != nil && rErr != io.ErrUnexpectedEOF {

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"runtime/debug"
 	"sort"
 	"time"
 
@@ -252,7 +251,6 @@ func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName
 
 	// Create a buffer.
 	buf := make([]byte, partSize)
-	defer debug.FreeOSMemory()
 
 	for partNumber <= totalPartsCount {
 		length, rerr := io.ReadFull(reader, buf)


### PR DESCRIPTION
This can be detrimental to an application due to:
* Forces a GC on every execution and blocks until the GC is complete.
* Returns OS memory immediately instead of allowing the runtime to reuse it.

The above two issues aren't limited only to the Minio code but the entire application.

This was introduced in #781. It's unclear whether the changes were tested without `debug.FreeOSMemory()`. Removing `debug.FreeOSMemory()` may be fine even in the memory constrained use case. If not, the user can tune `GOGC` to run GC more aggressively. Additionally, a `sync.Pool` could be reintroduced as the `sync.Pool` implementation has improved in the intervening years.