### PR TITLE
Put/Compose/Copy returns UploadInfo for uploaded/copied objects

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -413,9 +413,9 @@ func (c Client) uploadPartCopy(ctx context.Context, bucket, object, uploadID str
 // and concatenates them into a new object using only server-side copying
 // operations. Optionally takes progress reader hook for applications to
 // look at current progress.
-func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationInfo, srcs []SourceInfo, progress io.Reader) error {
+func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationInfo, srcs []SourceInfo, progress io.Reader) (UploadInfo, error) {
 	if len(srcs) < 1 || len(srcs) > maxPartsCount {
-		return ErrInvalidArgument("There must be as least one and up to 10000 source objects.")
+		return UploadInfo{}, ErrInvalidArgument("There must be as least one and up to 10000 source objects.")
 	}
 	srcSizes := make([]int64, len(srcs))
 	var totalSize, size, totalParts int64
@@ -425,13 +425,13 @@ func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationIn
 	for i, src := range srcs {
 		size, etags[i], srcUserMeta, err = src.getProps(c)
 		if err != nil {
-			return err
+			return UploadInfo{}, err
 		}
 
 		// Error out if client side encryption is used in this source object when
 		// more than one source objects are given.
 		if len(srcs) > 1 && src.Headers.Get("x-amz-meta-x-amz-key") != "" {
-			return ErrInvalidArgument(
+			return UploadInfo{}, ErrInvalidArgument(
 				fmt.Sprintf("Client side encryption is used in source object %s/%s", src.bucket, src.object))
 		}
 
@@ -442,7 +442,7 @@ func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationIn
 			//    0 <= src.start <= src.end
 			// so only invalid case to check is:
 			if src.end >= size {
-				return ErrInvalidArgument(
+				return UploadInfo{}, ErrInvalidArgument(
 					fmt.Sprintf("SourceInfo %d has invalid segment-to-copy [%d, %d] (size is %d)",
 						i, src.start, src.end, size))
 			}
@@ -451,14 +451,14 @@ func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationIn
 
 		// Only the last source may be less than `absMinPartSize`
 		if size < absMinPartSize && i < len(srcs)-1 {
-			return ErrInvalidArgument(
+			return UploadInfo{}, ErrInvalidArgument(
 				fmt.Sprintf("SourceInfo %d is too small (%d) and it is not the last part", i, size))
 		}
 
 		// Is data to copy too large?
 		totalSize += size
 		if totalSize > maxMultipartPutObjectSize {
-			return ErrInvalidArgument(fmt.Sprintf("Cannot compose an object of size %d (> 5TiB)", totalSize))
+			return UploadInfo{}, ErrInvalidArgument(fmt.Sprintf("Cannot compose an object of size %d (> 5TiB)", totalSize))
 		}
 
 		// record source size
@@ -468,7 +468,7 @@ func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationIn
 		totalParts += partsRequired(size)
 		// Do we need more parts than we are allowed?
 		if totalParts > maxPartsCount {
-			return ErrInvalidArgument(fmt.Sprintf(
+			return UploadInfo{}, ErrInvalidArgument(fmt.Sprintf(
 				"Your proposed compose object requires more than %d parts", maxPartsCount))
 		}
 	}
@@ -507,7 +507,7 @@ func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationIn
 
 	uploadID, err := c.newUploadID(ctx, dst.bucket, dst.object, PutObjectOptions{ServerSideEncryption: dst.opts.Encryption, UserMetadata: metaHeaders})
 	if err != nil {
-		return err
+		return UploadInfo{}, err
 	}
 
 	// 3. Perform copy part uploads
@@ -538,7 +538,7 @@ func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationIn
 			complPart, err := c.uploadPartCopy(ctx, dst.bucket,
 				dst.object, uploadID, partIndex, h)
 			if err != nil {
-				return err
+				return UploadInfo{}, err
 			}
 			if progress != nil {
 				io.CopyN(ioutil.Discard, progress, end-start+1)
@@ -549,19 +549,15 @@ func (c Client) ComposeObjectWithProgress(ctx context.Context, dst DestinationIn
 	}
 
 	// 4. Make final complete-multipart request.
-	_, err = c.completeMultipartUpload(ctx, dst.bucket, dst.object, uploadID,
+	return c.completeMultipartUpload(ctx, dst.bucket, dst.object, uploadID,
 		completeMultipartUpload{Parts: objParts})
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // ComposeObject - creates an object using server-side copying of
 // existing objects. It takes a list of source objects (with optional
 // offsets) and concatenates them into a new object using only
 // server-side copying operations.
-func (c Client) ComposeObject(ctx context.Context, dst DestinationInfo, srcs []SourceInfo) error {
+func (c Client) ComposeObject(ctx context.Context, dst DestinationInfo, srcs []SourceInfo) (UploadInfo, error) {
 	return c.ComposeObjectWithProgress(ctx, dst, srcs, nil)
 }
 

--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -62,6 +62,13 @@ func (m *StringMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
+// UploadInfo contains information about the
+// newly uploaded or copied object.
+type UploadInfo struct {
+	ETag      string
+	VersionID string
+}
+
 // ObjectInfo container for object metadata.
 type ObjectInfo struct {
 	// An ETag is optionally set to md5sum of an object.  In case of multipart objects,

--- a/api-put-object-copy.go
+++ b/api-put-object-copy.go
@@ -29,12 +29,12 @@ import (
 )
 
 // CopyObject - copy a source object into a new object
-func (c Client) CopyObject(ctx context.Context, dst DestinationInfo, src SourceInfo) error {
+func (c Client) CopyObject(ctx context.Context, dst DestinationInfo, src SourceInfo) (UploadInfo, error) {
 	return c.CopyObjectWithProgress(ctx, dst, src, nil)
 }
 
 // CopyObjectWithProgress is like CopyObject with additional progress bar.
-func (c Client) CopyObjectWithProgress(ctx context.Context, dst DestinationInfo, src SourceInfo, progress io.Reader) error {
+func (c Client) CopyObjectWithProgress(ctx context.Context, dst DestinationInfo, src SourceInfo, progress io.Reader) (UploadInfo, error) {
 	header := make(http.Header)
 	for k, v := range src.Headers {
 		header[k] = v
@@ -60,7 +60,7 @@ func (c Client) CopyObjectWithProgress(ctx context.Context, dst DestinationInfo,
 	if progress != nil {
 		size, _, _, err = src.getProps(c)
 		if err != nil {
-			return err
+			return UploadInfo{}, err
 		}
 	}
 
@@ -81,12 +81,12 @@ func (c Client) CopyObjectWithProgress(ctx context.Context, dst DestinationInfo,
 		customHeader: header,
 	})
 	if err != nil {
-		return err
+		return UploadInfo{}, err
 	}
 	defer closeResponse(resp)
 
 	if resp.StatusCode != http.StatusOK {
-		return httpRespToErrorResponse(resp, dst.bucket, dst.object)
+		return UploadInfo{}, httpRespToErrorResponse(resp, dst.bucket, dst.object)
 	}
 
 	// Update the progress properly after successful copy.
@@ -94,5 +94,8 @@ func (c Client) CopyObjectWithProgress(ctx context.Context, dst DestinationInfo,
 		io.CopyN(ioutil.Discard, progress, size)
 	}
 
-	return nil
+	return UploadInfo{
+		VersionID: resp.Header.Get("x-amz-version-id"),
+		ETag:      trimEtag(resp.Header.Get("ETag")),
+	}, nil
 }

--- a/api-put-object-file-context.go
+++ b/api-put-object-file-context.go
@@ -27,27 +27,27 @@ import (
 )
 
 // FPutObject - Create an object in a bucket, with contents from file at filePath. Allows request cancellation.
-func (c Client) FPutObject(ctx context.Context, bucketName, objectName, filePath string, opts PutObjectOptions) (n int64, err error) {
+func (c Client) FPutObject(ctx context.Context, bucketName, objectName, filePath string, opts PutObjectOptions) (info UploadInfo, err error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Open the referenced file.
 	fileReader, err := os.Open(filePath)
 	// If any error fail quickly here.
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	defer fileReader.Close()
 
 	// Save the file stat.
 	fileStat, err := fileReader.Stat()
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Save the file size.

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -37,8 +37,8 @@ import (
 )
 
 func (c Client) putObjectMultipart(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64,
-	opts PutObjectOptions) (n int64, err error) {
-	n, err = c.putObjectMultipartNoStream(ctx, bucketName, objectName, reader, opts)
+	opts PutObjectOptions) (info UploadInfo, err error) {
+	info, err = c.putObjectMultipartNoStream(ctx, bucketName, objectName, reader, opts)
 	if err != nil {
 		errResp := ToErrorResponse(err)
 		// Verify if multipart functionality is not available, if not
@@ -46,22 +46,22 @@ func (c Client) putObjectMultipart(ctx context.Context, bucketName, objectName s
 		if errResp.Code == "AccessDenied" && strings.Contains(errResp.Message, "Access Denied") {
 			// Verify if size of reader is greater than '5GiB'.
 			if size > maxSinglePutObjectSize {
-				return 0, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)
+				return UploadInfo{}, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)
 			}
 			// Fall back to uploading as single PutObject operation.
 			return c.putObject(ctx, bucketName, objectName, reader, size, opts)
 		}
 	}
-	return n, err
+	return info, err
 }
 
-func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, objectName string, reader io.Reader, opts PutObjectOptions) (n int64, err error) {
+func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, objectName string, reader io.Reader, opts PutObjectOptions) (info UploadInfo, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	if err = s3utils.CheckValidObjectName(objectName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Total data read and written to server. should be equal to
@@ -74,13 +74,13 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 	// Calculate the optimal parts info for a given size.
 	totalPartsCount, partSize, _, err := optimalPartInfo(-1, opts.PartSize)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	defer func() {
@@ -109,7 +109,7 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 			break
 		}
 		if rErr != nil && rErr != io.ErrUnexpectedEOF {
-			return 0, rErr
+			return UploadInfo{}, rErr
 		}
 
 		// Calculates hash sums while copying partSize bytes into cw.
@@ -139,7 +139,7 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID, rd, partNumber,
 			md5Base64, sha256Hex, int64(length), opts.ServerSideEncryption)
 		if uerr != nil {
-			return totalUploadedSize, uerr
+			return UploadInfo{}, uerr
 		}
 
 		// Save successfully uploaded part metadata.
@@ -163,7 +163,7 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 	for i := 1; i < partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
-			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
+			return UploadInfo{}, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
 			ETag:       part.ETag,
@@ -173,12 +173,8 @@ func (c Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obje
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
-	if _, err = c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload); err != nil {
-		return totalUploadedSize, err
-	}
 
-	// Return final size.
-	return totalUploadedSize, nil
+	return c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload)
 }
 
 // initiateMultipartUpload - Initiates a multipart upload and returns an upload ID.
@@ -298,13 +294,13 @@ func (c Client) uploadPart(ctx context.Context, bucketName, objectName, uploadID
 
 // completeMultipartUpload - Completes a multipart upload by assembling previously uploaded parts.
 func (c Client) completeMultipartUpload(ctx context.Context, bucketName, objectName, uploadID string,
-	complete completeMultipartUpload) (completeMultipartUploadResult, error) {
+	complete completeMultipartUpload) (UploadInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
-		return completeMultipartUploadResult{}, err
+		return UploadInfo{}, err
 	}
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
-		return completeMultipartUploadResult{}, err
+		return UploadInfo{}, err
 	}
 
 	// Initialize url queries.
@@ -313,7 +309,7 @@ func (c Client) completeMultipartUpload(ctx context.Context, bucketName, objectN
 	// Marshal complete multipart body.
 	completeMultipartUploadBytes, err := xml.Marshal(complete)
 	if err != nil {
-		return completeMultipartUploadResult{}, err
+		return UploadInfo{}, err
 	}
 
 	// Instantiate all the complete multipart buffer.
@@ -331,11 +327,11 @@ func (c Client) completeMultipartUpload(ctx context.Context, bucketName, objectN
 	resp, err := c.executeMethod(ctx, "POST", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
-		return completeMultipartUploadResult{}, err
+		return UploadInfo{}, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return completeMultipartUploadResult{}, httpRespToErrorResponse(resp, bucketName, objectName)
+			return UploadInfo{}, httpRespToErrorResponse(resp, bucketName, objectName)
 		}
 	}
 
@@ -343,14 +339,14 @@ func (c Client) completeMultipartUpload(ctx context.Context, bucketName, objectN
 	var b []byte
 	b, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return completeMultipartUploadResult{}, err
+		return UploadInfo{}, err
 	}
 	// Decode completed multipart upload response on success.
 	completeMultipartUploadResult := completeMultipartUploadResult{}
 	err = xmlDecoder(bytes.NewReader(b), &completeMultipartUploadResult)
 	if err != nil {
 		// xml parsing failure due to presence an ill-formed xml fragment
-		return completeMultipartUploadResult, err
+		return UploadInfo{}, err
 	} else if completeMultipartUploadResult.Bucket == "" {
 		// xml's Decode method ignores well-formed xml that don't apply to the type of value supplied.
 		// In this case, it would leave completeMultipartUploadResult with the corresponding zero-values
@@ -361,9 +357,14 @@ func (c Client) completeMultipartUpload(ctx context.Context, bucketName, objectN
 		err = xmlDecoder(bytes.NewReader(b), &completeMultipartUploadErr)
 		if err != nil {
 			// xml parsing failure due to presence an ill-formed xml fragment
-			return completeMultipartUploadResult, err
+			return UploadInfo{}, err
 		}
-		return completeMultipartUploadResult, completeMultipartUploadErr
+		return UploadInfo{}, completeMultipartUploadErr
 	}
-	return completeMultipartUploadResult, nil
+
+	return UploadInfo{
+		ETag:      trimEtag(completeMultipartUploadResult.ETag),
+		VersionID: resp.Header.Get("x-amz-version-id"),
+	}, nil
+
 }

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -40,13 +40,13 @@ import (
 //  - Any reader which has a method 'ReadAt()'
 //
 func (c Client) putObjectMultipartStream(ctx context.Context, bucketName, objectName string,
-	reader io.Reader, size int64, opts PutObjectOptions) (n int64, err error) {
+	reader io.Reader, size int64, opts PutObjectOptions) (info UploadInfo, err error) {
 
 	if !isObject(reader) && isReadAt(reader) && !opts.SendContentMd5 {
 		// Verify if the reader implements ReadAt and it is not a *minio.Object then we will use parallel uploader.
-		n, err = c.putObjectMultipartStreamFromReadAt(ctx, bucketName, objectName, reader.(io.ReaderAt), size, opts)
+		info, err = c.putObjectMultipartStreamFromReadAt(ctx, bucketName, objectName, reader.(io.ReaderAt), size, opts)
 	} else {
-		n, err = c.putObjectMultipartStreamOptionalChecksum(ctx, bucketName, objectName, reader, size, opts)
+		info, err = c.putObjectMultipartStreamOptionalChecksum(ctx, bucketName, objectName, reader, size, opts)
 	}
 	if err != nil {
 		errResp := ToErrorResponse(err)
@@ -55,13 +55,13 @@ func (c Client) putObjectMultipartStream(ctx context.Context, bucketName, object
 		if errResp.Code == "AccessDenied" && strings.Contains(errResp.Message, "Access Denied") {
 			// Verify if size of reader is greater than '5GiB'.
 			if size > maxSinglePutObjectSize {
-				return 0, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)
+				return UploadInfo{}, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)
 			}
 			// Fall back to uploading as single PutObject operation.
 			return c.putObject(ctx, bucketName, objectName, reader, size, opts)
 		}
 	}
-	return n, err
+	return info, err
 }
 
 // uploadedPartRes - the response received from a part upload.
@@ -89,25 +89,25 @@ type uploadPartReq struct {
 // cleaned automatically when the caller i.e http client closes the
 // stream after uploading all the contents successfully.
 func (c Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketName, objectName string,
-	reader io.ReaderAt, size int64, opts PutObjectOptions) (n int64, err error) {
+	reader io.ReaderAt, size int64, opts PutObjectOptions) (info UploadInfo, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	if err = s3utils.CheckValidObjectName(objectName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Calculate the optimal parts info for a given size.
 	totalPartsCount, partSize, lastPartSize, err := optimalPartInfo(size, opts.PartSize)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Aborts the multipart upload in progress, if the
@@ -195,7 +195,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketNa
 	for u := 1; u <= totalPartsCount; u++ {
 		uploadRes := <-uploadedPartsCh
 		if uploadRes.Error != nil {
-			return totalUploadedSize, uploadRes.Error
+			return UploadInfo{}, uploadRes.Error
 		}
 		// Update the totalUploadedSize.
 		totalUploadedSize += uploadRes.Size
@@ -208,39 +208,34 @@ func (c Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketNa
 
 	// Verify if we uploaded all the data.
 	if totalUploadedSize != size {
-		return totalUploadedSize, ErrUnexpectedEOF(totalUploadedSize, size, bucketName, objectName)
+		return UploadInfo{}, ErrUnexpectedEOF(totalUploadedSize, size, bucketName, objectName)
 	}
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
-	_, err = c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload)
-	if err != nil {
-		return totalUploadedSize, err
-	}
 
-	// Return final size.
-	return totalUploadedSize, nil
+	return c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload)
 }
 
 func (c Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, bucketName, objectName string,
-	reader io.Reader, size int64, opts PutObjectOptions) (n int64, err error) {
+	reader io.Reader, size int64, opts PutObjectOptions) (info UploadInfo, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	if err = s3utils.CheckValidObjectName(objectName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Calculate the optimal parts info for a given size.
 	totalPartsCount, partSize, lastPartSize, err := optimalPartInfo(size, opts.PartSize)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	// Initiates a new multipart request
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Aborts the multipart upload if the function returns
@@ -281,7 +276,7 @@ func (c Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, bu
 				break
 			}
 			if rerr != nil && rerr != io.ErrUnexpectedEOF && rerr != io.EOF {
-				return 0, rerr
+				return UploadInfo{}, rerr
 			}
 			// Calculate md5sum.
 			hash := c.md5Hasher()
@@ -302,7 +297,7 @@ func (c Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, bu
 			io.LimitReader(hookReader, partSize),
 			partNumber, md5Base64, "", partSize, opts.ServerSideEncryption)
 		if uerr != nil {
-			return totalUploadedSize, uerr
+			return UploadInfo{}, uerr
 		}
 
 		// Save successfully uploaded part metadata.
@@ -315,7 +310,7 @@ func (c Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, bu
 	// Verify if we uploaded all the data.
 	if size > 0 {
 		if totalUploadedSize != size {
-			return totalUploadedSize, ErrUnexpectedEOF(totalUploadedSize, size, bucketName, objectName)
+			return UploadInfo{}, ErrUnexpectedEOF(totalUploadedSize, size, bucketName, objectName)
 		}
 	}
 
@@ -327,7 +322,7 @@ func (c Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, bu
 	for i := 1; i < partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
-			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
+			return UploadInfo{}, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
 			ETag:       part.ETag,
@@ -337,34 +332,29 @@ func (c Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, bu
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
-	_, err = c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload)
-	if err != nil {
-		return totalUploadedSize, err
-	}
 
-	// Return final size.
-	return totalUploadedSize, nil
+	return c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload)
 }
 
 // putObject special function used Google Cloud Storage. This special function
 // is used for Google Cloud Storage since Google's multipart API is not S3 compatible.
-func (c Client) putObject(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64, opts PutObjectOptions) (n int64, err error) {
+func (c Client) putObject(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64, opts PutObjectOptions) (info UploadInfo, err error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Size -1 is only supported on Google Cloud Storage, we error
 	// out in all other situations.
 	if size < 0 && !s3utils.IsGoogleEndpoint(*c.endpointURL) {
-		return 0, ErrEntityTooSmall(size, bucketName, objectName)
+		return UploadInfo{}, ErrEntityTooSmall(size, bucketName, objectName)
 	}
 
 	if opts.SendContentMd5 && s3utils.IsGoogleEndpoint(*c.endpointURL) && size < 0 {
-		return 0, ErrInvalidArgument("MD5Sum cannot be calculated with size '-1'")
+		return UploadInfo{}, ErrInvalidArgument("MD5Sum cannot be calculated with size '-1'")
 	}
 
 	if size > 0 {
@@ -373,7 +363,7 @@ func (c Client) putObject(ctx context.Context, bucketName, objectName string, re
 			if ok {
 				offset, err := seeker.Seek(0, io.SeekCurrent)
 				if err != nil {
-					return 0, ErrInvalidArgument(err.Error())
+					return UploadInfo{}, ErrInvalidArgument(err.Error())
 				}
 				reader = io.NewSectionReader(reader.(io.ReaderAt), offset, size)
 			}
@@ -387,7 +377,7 @@ func (c Client) putObject(ctx context.Context, bucketName, objectName string, re
 
 		length, rErr := io.ReadFull(reader, buf)
 		if rErr != nil && rErr != io.ErrUnexpectedEOF {
-			return 0, rErr
+			return UploadInfo{}, rErr
 		}
 
 		// Calculate md5sum.
@@ -404,25 +394,18 @@ func (c Client) putObject(ctx context.Context, bucketName, objectName string, re
 
 	// This function does not calculate sha256 and md5sum for payload.
 	// Execute put object.
-	st, err := c.putObjectDo(ctx, bucketName, objectName, readSeeker, md5Base64, "", size, opts)
-	if err != nil {
-		return 0, err
-	}
-	if st.Size != size {
-		return 0, ErrUnexpectedEOF(st.Size, size, bucketName, objectName)
-	}
-	return size, nil
+	return c.putObjectDo(ctx, bucketName, objectName, readSeeker, md5Base64, "", size, opts)
 }
 
 // putObjectDo - executes the put object http operation.
 // NOTE: You must have WRITE permissions on a bucket to add an object to it.
-func (c Client) putObjectDo(ctx context.Context, bucketName, objectName string, reader io.Reader, md5Base64, sha256Hex string, size int64, opts PutObjectOptions) (ObjectInfo, error) {
+func (c Client) putObjectDo(ctx context.Context, bucketName, objectName string, reader io.Reader, md5Base64, sha256Hex string, size int64, opts PutObjectOptions) (UploadInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
-		return ObjectInfo{}, err
+		return UploadInfo{}, err
 	}
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
-		return ObjectInfo{}, err
+		return UploadInfo{}, err
 	}
 	// Set headers.
 	customHeader := opts.Header()
@@ -442,20 +425,16 @@ func (c Client) putObjectDo(ctx context.Context, bucketName, objectName string, 
 	resp, err := c.executeMethod(ctx, "PUT", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
-		return ObjectInfo{}, err
+		return UploadInfo{}, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return ObjectInfo{}, httpRespToErrorResponse(resp, bucketName, objectName)
+			return UploadInfo{}, httpRespToErrorResponse(resp, bucketName, objectName)
 		}
 	}
 
-	var objInfo ObjectInfo
-	// Trim off the odd double quotes from ETag in the beginning and end.
-	objInfo.ETag = trimEtag(resp.Header.Get("ETag"))
-	// A success here means data was written to server successfully.
-	objInfo.Size = size
-
-	// Return here.
-	return objInfo, nil
+	return UploadInfo{
+		ETag:      trimEtag(resp.Header.Get("ETag")),
+		VersionID: resp.Header.Get("x-amz-version-id"),
+	}, nil
 }

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -169,23 +169,23 @@ func (a completedParts) Less(i, j int) bool { return a[i].PartNumber < a[j].Part
 //    until input stream reaches EOF. Maximum object size that can
 //    be uploaded through this operation will be 5TiB.
 func (c Client) PutObject(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64,
-	opts PutObjectOptions) (n int64, err error) {
+	opts PutObjectOptions) (info UploadInfo, err error) {
 	if objectSize < 0 && opts.DisableMultipart {
-		return 0, errors.New("object size must be provided with disable multipart upload")
+		return UploadInfo{}, errors.New("object size must be provided with disable multipart upload")
 	}
 
 	err = opts.validate()
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	return c.putObjectCommon(ctx, bucketName, objectName, reader, objectSize, opts)
 }
 
-func (c Client) putObjectCommon(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64, opts PutObjectOptions) (n int64, err error) {
+func (c Client) putObjectCommon(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64, opts PutObjectOptions) (info UploadInfo, err error) {
 	// Check for largest object size allowed.
 	if size > int64(maxMultipartPutObjectSize) {
-		return 0, ErrEntityTooLarge(size, maxMultipartPutObjectSize, bucketName, objectName)
+		return UploadInfo{}, ErrEntityTooLarge(size, maxMultipartPutObjectSize, bucketName, objectName)
 	}
 
 	// NOTE: Streaming signature is not supported by GCS.
@@ -215,13 +215,13 @@ func (c Client) putObjectCommon(ctx context.Context, bucketName, objectName stri
 	return c.putObjectMultipartStream(ctx, bucketName, objectName, reader, size, opts)
 }
 
-func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName, objectName string, reader io.Reader, opts PutObjectOptions) (n int64, err error) {
+func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName, objectName string, reader io.Reader, opts PutObjectOptions) (info UploadInfo, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	if err = s3utils.CheckValidObjectName(objectName); err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	// Total data read and written to server. should be equal to
@@ -234,12 +234,12 @@ func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName
 	// Calculate the optimal parts info for a given size.
 	totalPartsCount, partSize, _, err := optimalPartInfo(-1, opts.PartSize)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {
-		return 0, err
+		return UploadInfo{}, err
 	}
 
 	defer func() {
@@ -263,7 +263,7 @@ func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName
 			break
 		}
 		if rerr != nil && rerr != io.ErrUnexpectedEOF && rerr != io.EOF {
-			return 0, rerr
+			return UploadInfo{}, rerr
 		}
 
 		var md5Base64 string
@@ -283,7 +283,7 @@ func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName
 		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID, rd, partNumber,
 			md5Base64, "", int64(length), opts.ServerSideEncryption)
 		if uerr != nil {
-			return totalUploadedSize, uerr
+			return UploadInfo{}, uerr
 		}
 
 		// Save successfully uploaded part metadata.
@@ -307,7 +307,7 @@ func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName
 	for i := 1; i < partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
-			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
+			return UploadInfo{}, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
 			ETag:       part.ETag,
@@ -317,10 +317,6 @@ func (c Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketName
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
-	if _, err = c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload); err != nil {
-		return totalUploadedSize, err
-	}
 
-	// Return final size.
-	return totalUploadedSize, nil
+	return c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload)
 }

--- a/core.go
+++ b/core.go
@@ -70,7 +70,7 @@ func (c Core) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBuck
 }
 
 // PutObject - Upload object. Uploads using single PUT call.
-func (c Core) PutObject(ctx context.Context, bucket, object string, data io.Reader, size int64, md5Base64, sha256Hex string, opts PutObjectOptions) (ObjectInfo, error) {
+func (c Core) PutObject(ctx context.Context, bucket, object string, data io.Reader, size int64, md5Base64, sha256Hex string, opts PutObjectOptions) (UploadInfo, error) {
 	return c.putObjectDo(ctx, bucket, object, data, md5Base64, sha256Hex, size, opts)
 }
 

--- a/core_test.go
+++ b/core_test.go
@@ -103,15 +103,19 @@ func TestGetObjectCore(t *testing.T) {
 
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
-	n, err := c.Client.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), PutObjectOptions{
+	_, err = c.Client.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), PutObjectOptions{
 		ContentType: "binary/octet-stream",
 	})
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
 
-	if n != int64(len(buf)) {
-		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), n)
+	st, err := c.Client.StatObject(context.Background(), bucketName, objectName, StatObjectOptions{})
+	if err != nil {
+		t.Fatal("Stat error:", err, bucketName, objectName)
+	}
+	if st.Size != int64(len(buf)) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), st.Size)
 	}
 
 	offset := int64(2048)
@@ -119,7 +123,7 @@ func TestGetObjectCore(t *testing.T) {
 	// read directly
 	buf1 := make([]byte, 512)
 	buf2 := make([]byte, 512)
-	buf3 := make([]byte, n)
+	buf3 := make([]byte, st.Size)
 	buf4 := make([]byte, 1)
 
 	opts := GetObjectOptions{}
@@ -296,15 +300,11 @@ func TestGetObjectContentEncoding(t *testing.T) {
 
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
-	n, err := c.Client.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), PutObjectOptions{
+	_, err = c.Client.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), PutObjectOptions{
 		ContentEncoding: "gzip",
 	})
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
-	}
-
-	if n != int64(len(buf)) {
-		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), n)
 	}
 
 	rwc, objInfo, _, err := c.GetObject(context.Background(), bucketName, objectName, GetObjectOptions{})
@@ -312,8 +312,8 @@ func TestGetObjectContentEncoding(t *testing.T) {
 		t.Fatalf("Error: %v", err)
 	}
 	rwc.Close()
-	if objInfo.Size <= 0 {
-		t.Fatalf("Unexpected size of the object %v, expected %v", objInfo.Size, n)
+	if objInfo.Size != int64(len(buf)) {
+		t.Fatalf("Unexpected size of the object %v, expected %v", objInfo.Size, len(buf))
 	}
 	value, ok := objInfo.Metadata["Content-Encoding"]
 	if !ok {
@@ -441,27 +441,32 @@ func TestCoreCopyObject(t *testing.T) {
 			"Content-Type": "binary/octet-stream",
 		},
 	}
-	objInfo, err := c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "", "", putopts)
+	uploadInfo, err := c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "", "", putopts)
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
 
-	if objInfo.Size != int64(len(buf)) {
-		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), objInfo.Size)
+	st, err := c.StatObject(context.Background(), bucketName, objectName, StatObjectOptions{})
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName)
+	}
+
+	if st.Size != int64(len(buf)) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), st.Size)
 	}
 
 	destBucketName := bucketName
 	destObjectName := objectName + "-dest"
 
-	cobjInfo, err := c.CopyObject(context.Background(), bucketName, objectName, destBucketName, destObjectName, map[string]string{
+	cuploadInfo, err := c.CopyObject(context.Background(), bucketName, objectName, destBucketName, destObjectName, map[string]string{
 		"X-Amz-Metadata-Directive": "REPLACE",
 		"Content-Type":             "application/javascript",
 	})
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName, destBucketName, destObjectName)
 	}
-	if cobjInfo.ETag != objInfo.ETag {
-		t.Fatalf("Error: expected etag to be same as source object %s, but found different etag %s", objInfo.ETag, cobjInfo.ETag)
+	if cuploadInfo.ETag != uploadInfo.ETag {
+		t.Fatalf("Error: expected etag to be same as source object %s, but found different etag %s", uploadInfo.ETag, cuploadInfo.ETag)
 	}
 
 	// Attempt to read from destBucketName and object name.
@@ -470,7 +475,7 @@ func TestCoreCopyObject(t *testing.T) {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
 
-	st, err := r.Stat()
+	st, err = r.Stat()
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
@@ -484,8 +489,8 @@ func TestCoreCopyObject(t *testing.T) {
 		t.Fatalf("Error: Content types don't match, expected: application/javascript, found: %+v\n", st.ContentType)
 	}
 
-	if st.ETag != objInfo.ETag {
-		t.Fatalf("Error: expected etag to be same as source object %s, but found different etag :%s", objInfo.ETag, st.ETag)
+	if st.ETag != uploadInfo.ETag {
+		t.Fatalf("Error: expected etag to be same as source object %s, but found different etag :%s", uploadInfo.ETag, st.ETag)
 	}
 
 	if err := r.Close(); err != nil {
@@ -559,13 +564,18 @@ func TestCoreCopyObjectPart(t *testing.T) {
 	}
 	// Save the data
 	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
-	objInfo, err := c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "", "", putopts)
+	_, err = c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "", "", putopts)
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
 	}
 
-	if objInfo.Size != int64(len(buf)) {
-		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), objInfo.Size)
+	st, err := c.StatObject(context.Background(), bucketName, objectName, StatObjectOptions{})
+	if err != nil {
+		t.Fatal("Error:", err, bucketName, objectName)
+	}
+
+	if st.Size != int64(len(buf)) {
+		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), st.Size)
 	}
 
 	destBucketName := bucketName
@@ -605,7 +615,7 @@ func TestCoreCopyObjectPart(t *testing.T) {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err = c.StatObject(context.Background(), destBucketName, destObjectName, StatObjectOptions{})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, StatObjectOptions{})
 	if err != nil {
 		t.Fatal("Error:", err, destBucketName, destObjectName)
 	}
@@ -709,18 +719,14 @@ func TestCorePutObject(t *testing.T) {
 	putopts := PutObjectOptions{
 		UserMetadata: metadata,
 	}
-	objInfo, err := c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "1B2M2Y8AsgTpgAmY7PhCfg==", "", putopts)
+	_, err = c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "1B2M2Y8AsgTpgAmY7PhCfg==", "", putopts)
 	if err == nil {
 		t.Fatal("Error expected: error, got: nil(success)")
 	}
 
-	objInfo, err = c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "", "", putopts)
+	_, err = c.PutObject(context.Background(), bucketName, objectName, bytes.NewReader(buf), int64(len(buf)), "", "", putopts)
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName)
-	}
-
-	if objInfo.Size != int64(len(buf)) {
-		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), objInfo.Size)
 	}
 
 	// Read the data back

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/minio/minio-go/v7
 go 1.12
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/json-iterator/go v1.1.9
 	github.com/minio/md5-simd v1.1.0
-	github.com/minio/minio-go/v6 v6.0.57 // indirect
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/sirupsen/logrus v1.6.0
+	github.com/smartystreets/goconvey v1.6.4 // indirect
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,10 +13,10 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/klauspost/cpuid v1.2.3 h1:CCtW0xUnWGVINKvE/WWOYKdsPV6mawAtvQuSl8guwQs=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/minio/md5-simd v1.1.0 h1:QPfiOqlZH+Cj9teu0t9b1nTBfPbyTl16Of5MeuShdK4=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
-github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJDswNVuni6km9o=
 github.com/minio/minio-go/v6 v6.0.57 h1:ixPkbKkyD7IhnluRgQpGSpHdpvNVaW6OD5R9IAO/9Tw=
 github.com/minio/minio-go/v6 v6.0.57/go.mod h1:5+R/nM9Pwrh0vqF+HbYYDQ84wdUFPyXHkrdT4AIkifM=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
@@ -36,6 +36,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2YqsZKovtsgrwcDH1RZhVbTKCjLp47XpqCDs=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=


### PR DESCRIPTION
PutObject()/ComposeObject/CopyObject are returning (UploadInfo, error) which
 contains the ETag/VersionID of the uploaded or the newly copied object.

**WARNING:** 
PutObject() does not return the uploaded size anymore. I do not believe it is useful.