### PR TITLE
Custom metadata copy issue

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -79,7 +79,7 @@ func filterCustomMeta(userMeta map[string]string) (map[string]string, error) {
 			k = k[len("x-amz-meta-"):]
 		}
 		if _, ok := m[k]; ok {
-			return nil, errInvalidArgument(fmt.Sprintf("Cannot add both %s and x-amz-meta-%s keys as custom metadata", k, k))
+			continue
 		}
 		m[k] = v
 	}


### PR DESCRIPTION
Copying an object with user defined metadata between s3 servers fails with:

```
mc: <ERROR> Failed to copy `https://play.minio.io:9000/test/test`. Cannot add both Sss and x-amz-meta-Sss keys as custom metadata
That is because we try to copy the same metadata information twice, as user defined metadata raw name, Sss, and as already converted and added into metadata with the standard name, x-amz-meta-Sss.
```

So, the fix is to ignore if the user defined metadata appears more than once in `UserMetadata` list.