### PR TITLE
Cache STS Web Identity Credentials

### DIFF
--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -106,7 +106,7 @@ func (m *IAM) Retrieve() (Value, error) {
 
 		stsWebIdentityCreds, err := creds.Retrieve()
 		if err == nil {
-			m.SetExpiration(creds.Expiration(), 0)
+			m.SetExpiration(creds.Expiration(), DefaultExpiryWindow)
 		}
 		return stsWebIdentityCreds, err
 

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -104,7 +104,11 @@ func (m *IAM) Retrieve() (Value, error) {
 			},
 		}
 
-		return creds.Retrieve()
+		stsWebIdentityCreds, err := creds.Retrieve()
+		if err == nil {
+			m.SetExpiration(creds.Expiration(), 0)
+		}
+		return stsWebIdentityCreds, err
 
 	case len(os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")) > 0:
 		if len(endpoint) == 0 {

--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -174,3 +174,8 @@ func (m *STSWebIdentity) Retrieve() (Value, error) {
 		SignerType:      SignatureV4,
 	}, nil
 }
+
+// Expiration returns the expiration time of the credentials
+func (m *STSWebIdentity) Expiration() time.Time {
+	return m.expiration
+}


### PR DESCRIPTION
When using the STSWebIdentity credentials provider from the IAM
credentials provider, we need to set the expiry time of the credentials.

We therefore expose the expiry time in the STSWebIdentity credentials
provider so that it can be used by the IAM credentials provider.

Calls to IsExpired() on the IAM credentials provider will then work as
they would have if it had been called on the underlying STSWebIdentity
provider.  Therefore caching the credentials as intended.

Fixes minio/minio-go#1321