### PR TITLE
Remove doneCh from ListenBucketNotification and ListIncompleteUploads

### DIFF
--- a/api-notification.go
+++ b/api-notification.go
@@ -136,7 +136,7 @@ type NotificationInfo struct {
 }
 
 // ListenBucketNotification listen for bucket events, this is a MinIO specific API
-func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix, suffix string, events []string, doneCh <-chan struct{}) <-chan NotificationInfo {
+func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix, suffix string, events []string) <-chan NotificationInfo {
 	notificationInfoCh := make(chan NotificationInfo, 1)
 	const notificationCapacity = 1024 * 1024
 	notificationEventBuffer := make([]byte, notificationCapacity)
@@ -150,7 +150,7 @@ func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix
 			case notificationInfoCh <- NotificationInfo{
 				Err: err,
 			}:
-			case <-doneCh:
+			case <-ctx.Done():
 			}
 			return
 		}
@@ -161,7 +161,7 @@ func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix
 			case notificationInfoCh <- NotificationInfo{
 				Err: errAPINotSupported("Listening for bucket notification is specific only to `minio` server endpoints"),
 			}:
-			case <-doneCh:
+			case <-ctx.Done():
 			}
 			return
 		}
@@ -192,7 +192,7 @@ func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix
 				case notificationInfoCh <- NotificationInfo{
 					Err: err,
 				}:
-				case <-doneCh:
+				case <-ctx.Done():
 				}
 				return
 			}
@@ -204,7 +204,7 @@ func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix
 				case notificationInfoCh <- NotificationInfo{
 					Err: errResponse,
 				}:
-				case <-doneCh:
+				case <-ctx.Done():
 				}
 				return
 			}
@@ -227,7 +227,7 @@ func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix
 					case notificationInfoCh <- NotificationInfo{
 						Err: err,
 					}:
-					case <-doneCh:
+					case <-ctx.Done():
 						return
 					}
 					closeResponse(resp)
@@ -236,7 +236,7 @@ func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix
 				// Send notificationInfo
 				select {
 				case notificationInfoCh <- notificationInfo:
-				case <-doneCh:
+				case <-ctx.Done():
 					closeResponse(resp)
 					return
 				}
@@ -247,7 +247,7 @@ func (c Client) ListenBucketNotification(ctx context.Context, bucketName, prefix
 				case notificationInfoCh <- NotificationInfo{
 					Err: err,
 				}:
-				case <-doneCh:
+				case <-ctx.Done():
 					return
 				}
 			}

--- a/docs/API.md
+++ b/docs/API.md
@@ -382,7 +382,7 @@ for object := range objectCh {
 ```
 
 <a name="ListIncompleteUploads"></a>
-### ListIncompleteUploads(ctx context.Context, bucketName, prefix string, recursive bool, doneCh chan struct{}) <- chan ObjectMultipartInfo
+### ListIncompleteUploads(ctx context.Context, bucketName, prefix string, recursive bool) <- chan ObjectMultipartInfo
 Lists partially uploaded objects in a bucket.
 
 
@@ -395,7 +395,6 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket |
 | `prefix` |_string_   | Prefix of objects that are partially uploaded |
 | `recursive`  | _bool_  |`true` indicates recursive style listing and `false` indicates directory style listing delimited by '/'.  |
-|`doneCh`  | _chan struct{}_ | A message on this channel ends the ListenIncompleteUploads iterator.  |
 
 
 __Return Value__
@@ -416,14 +415,8 @@ __Example__
 
 
 ```go
-// Create a done channel to control 'ListObjects' go routine.
-doneCh := make(chan struct{})
-
-// Indicate to our routine to exit cleanly upon return.
-defer close(doneCh)
-
 isRecursive := true // Recursively list everything at 'myprefix'
-multiPartObjectCh := minioClient.ListIncompleteUploads(context.Background(), "mybucket", "myprefix", isRecursive, doneCh)
+multiPartObjectCh := minioClient.ListIncompleteUploads(context.Background(), "mybucket", "myprefix", isRecursive)
 for multiPartObject := range multiPartObjectCh {
     if multiPartObject.Err != nil {
         fmt.Println(multiPartObject.Err)
@@ -1732,7 +1725,7 @@ if err != nil {
 ```
 
 <a name="ListenBucketNotification"></a>
-### ListenBucketNotification(context context.Context, bucketName, prefix, suffix string, events []string, doneCh <-chan struct{}) <-chan NotificationInfo
+### ListenBucketNotification(context context.Context, bucketName, prefix, suffix string, events []string) <-chan NotificationInfo
 ListenBucketNotification API receives bucket notification events through the notification channel. The returned notification channel has two fields 'Records' and 'Err'.
 
 - 'Records' holds the notifications received from the server.
@@ -1749,7 +1742,6 @@ __Parameters__
 |`prefix`  | _string_ | Object key prefix to filter notifications for  |
 |`suffix`  | _string_ | Object key suffix to filter notifications for  |
 |`events`  | _[]string_ | Enables notifications for specific event types |
-|`doneCh`  | _chan struct{}_ | A message on this channel ends the ListenBucketNotification iterator  |
 
 __Return Values__
 
@@ -1768,18 +1760,12 @@ __Example__
 
 
 ```go
-// Create a done channel to control 'ListenBucketNotification' go routine.
-doneCh := make(chan struct{})
-
-// Indicate a background go-routine to exit cleanly upon return.
-defer close(doneCh)
-
 // Listen for bucket notifications on "mybucket" filtered by prefix, suffix and events.
 for notificationInfo := range minioClient.ListenBucketNotification(context.Background(), "mybucket", "myprefix/", ".mysuffix", []string{
     "s3:ObjectCreated:*",
     "s3:ObjectAccessed:*",
     "s3:ObjectRemoved:*",
-    }, doneCh) {
+    }) {
     if notificationInfo.Err != nil {
         fmt.Println(notificationInfo.Err)
     }

--- a/examples/minio/listenbucketnotification.go
+++ b/examples/minio/listenbucketnotification.go
@@ -42,18 +42,12 @@ func main() {
 
 	// s3Client.TraceOn(os.Stderr)
 
-	// Create a done channel to control 'ListenBucketNotification' go routine.
-	doneCh := make(chan struct{})
-
-	// Indicate to our routine to exit cleanly upon return.
-	defer close(doneCh)
-
 	// Listen for bucket notifications on "mybucket" filtered by prefix, suffix and events.
 	for notificationInfo := range minioClient.ListenBucketNotification(context.Background(), "YOUR-BUCKET", "PREFIX", "SUFFIX", []string{
 		"s3:ObjectCreated:*",
 		"s3:ObjectAccessed:*",
 		"s3:ObjectRemoved:*",
-	}, doneCh) {
+	}) {
 		if notificationInfo.Err != nil {
 			log.Fatalln(notificationInfo.Err)
 		}

--- a/examples/s3/listincompleteuploads.go
+++ b/examples/s3/listincompleteuploads.go
@@ -41,14 +41,8 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Create a done channel to control 'ListObjects' go routine.
-	doneCh := make(chan struct{})
-
-	// Indicate to our routine to exit cleanly upon return.
-	defer close(doneCh)
-
 	// List all multipart uploads from a bucket-name with a matching prefix.
-	for multipartObject := range s3Client.ListIncompleteUploads(context.Background(), "my-bucketname", "my-prefixname", true, doneCh) {
+	for multipartObject := range s3Client.ListIncompleteUploads(context.Background(), "my-bucketname", "my-prefixname", true) {
 		if multipartObject.Err != nil {
 			fmt.Println(multipartObject.Err)
 			return

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -159,7 +159,7 @@ func cleanupBucket(bucketName string, c *minio.Client) error {
 			}
 		}
 	}
-	for objPartInfo := range c.ListIncompleteUploads(context.Background(), bucketName, "", true, doneCh) {
+	for objPartInfo := range c.ListIncompleteUploads(context.Background(), bucketName, "", true) {
 		if objPartInfo.Err != nil {
 			return objPartInfo.Err
 		}
@@ -4445,7 +4445,7 @@ func testFunctional() {
 		"isRecursive": isRecursive,
 	}
 
-	for objIncompl := range c.ListIncompleteUploads(context.Background(), bucketName, objectName, isRecursive, doneCh) {
+	for objIncompl := range c.ListIncompleteUploads(context.Background(), bucketName, objectName, isRecursive) {
 		if objIncompl.Key != "" {
 			incompObjNotFound = false
 			break
@@ -9170,7 +9170,7 @@ func testFunctionalV2() {
 		"objectName":  objectName,
 		"isRecursive": isRecursive,
 	}
-	for objIncompl := range c.ListIncompleteUploads(context.Background(), bucketName, objectName, isRecursive, doneCh) {
+	for objIncompl := range c.ListIncompleteUploads(context.Background(), bucketName, objectName, isRecursive) {
 		if objIncompl.Key != "" {
 			incompObjNotFound = false
 			break


### PR DESCRIPTION
Remove doneCh close channel because context.Context is already passed
to the concerned functions.