### PR TITLE
refactor: Make StatObjectOptions as type alias to GetObjectOptions

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -357,7 +357,7 @@ func (c Client) ComposeObject(ctx context.Context, dst CopyDestOptions, srcs ...
 	var totalSize, totalParts int64
 	var err error
 	for i, src := range srcs {
-		opts := StatObjectOptions{GetObjectOptions{ServerSideEncryption: encrypt.SSE(src.Encryption), VersionID: src.VersionID}}
+		opts := StatObjectOptions{ServerSideEncryption: encrypt.SSE(src.Encryption), VersionID: src.VersionID}
 		srcObjectInfos[i], err = c.statObject(context.Background(), src.Bucket, src.Object, opts)
 		if err != nil {
 			return UploadInfo{}, err

--- a/api-get-object-file.go
+++ b/api-get-object-file.go
@@ -63,7 +63,7 @@ func (c Client) FGetObject(ctx context.Context, bucketName, objectName, filePath
 	}
 
 	// Gather md5sum.
-	objectStat, err := c.StatObject(ctx, bucketName, objectName, StatObjectOptions{opts})
+	objectStat, err := c.StatObject(ctx, bucketName, objectName, StatObjectOptions(opts))
 	if err != nil {
 		return err
 	}

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -121,7 +121,7 @@ func (c Client) GetObject(ctx context.Context, bucketName, objectName string, op
 
 						// Remove range header if already set, for stat Operations to get original file size.
 						delete(opts.headers, "Range")
-						objectInfo, err = c.statObject(ctx, bucketName, objectName, StatObjectOptions{opts})
+						objectInfo, err = c.statObject(ctx, bucketName, objectName, StatObjectOptions(opts))
 						if err != nil {
 							resCh <- getResponse{
 								Error: err,
@@ -144,7 +144,7 @@ func (c Client) GetObject(ctx context.Context, bucketName, objectName string, op
 					if etag != "" && !snowball {
 						opts.SetMatchETag(etag)
 					}
-					objectInfo, err := c.statObject(ctx, bucketName, objectName, StatObjectOptions{opts})
+					objectInfo, err := c.statObject(ctx, bucketName, objectName, StatObjectOptions(opts))
 					if err != nil {
 						resCh <- getResponse{
 							Error: err,

--- a/api-get-options.go
+++ b/api-get-options.go
@@ -35,9 +35,7 @@ type GetObjectOptions struct {
 
 // StatObjectOptions are used to specify additional headers or options
 // during GET info/stat requests.
-type StatObjectOptions struct {
-	GetObjectOptions
-}
+type StatObjectOptions = GetObjectOptions
 
 // Header returns the http.Header representation of the GET options.
 func (o GetObjectOptions) Header() http.Header {

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -831,7 +831,7 @@ func testStatObjectWithVersioning() {
 	}
 
 	for i := 0; i < len(results); i++ {
-		opts := minio.StatObjectOptions{minio.GetObjectOptions{VersionID: results[i].VersionID}}
+		opts := minio.StatObjectOptions{VersionID: results[i].VersionID}
 		statInfo, err := c.StatObject(context.Background(), bucketName, objectName, opts)
 		if err != nil {
 			logError(testName, function, args, startTime, "", "error during HEAD object", err)
@@ -7653,7 +7653,7 @@ func testSSECMultipartEncryptedToSSECCopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: srcencryption}})
+	objInfo, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{ServerSideEncryption: srcencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -7705,7 +7705,7 @@ func testSSECMultipartEncryptedToSSECCopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err = c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: dstencryption}})
+	objInfo, err = c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{ServerSideEncryption: dstencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -7809,7 +7809,7 @@ func testSSECEncryptedToSSECCopyObjectPart() {
 		logError(testName, function, args, startTime, "", "PutObject call failed", err)
 	}
 
-	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: srcencryption}})
+	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{ServerSideEncryption: srcencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -7865,7 +7865,7 @@ func testSSECEncryptedToSSECCopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: dstencryption}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{ServerSideEncryption: dstencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -7969,7 +7969,7 @@ func testSSECEncryptedToUnencryptedCopyPart() {
 		logError(testName, function, args, startTime, "", "PutObject call failed", err)
 	}
 
-	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: srcencryption}})
+	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{ServerSideEncryption: srcencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8024,7 +8024,7 @@ func testSSECEncryptedToUnencryptedCopyPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8129,7 +8129,7 @@ func testSSECEncryptedToSSES3CopyObjectPart() {
 		logError(testName, function, args, startTime, "", "PutObject call failed", err)
 	}
 
-	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: srcencryption}})
+	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{ServerSideEncryption: srcencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8186,7 +8186,7 @@ func testSSECEncryptedToSSES3CopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8343,7 +8343,7 @@ func testUnencryptedToSSECCopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: dstencryption}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{ServerSideEncryption: dstencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8496,7 +8496,7 @@ func testUnencryptedToUnencryptedCopyPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8651,7 +8651,7 @@ func testUnencryptedToSSES3CopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8754,7 +8754,7 @@ func testSSES3EncryptedToSSECCopyObjectPart() {
 		logError(testName, function, args, startTime, "", "PutObject call failed", err)
 	}
 
-	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: srcEncryption}})
+	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{ServerSideEncryption: srcEncryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8809,7 +8809,7 @@ func testSSES3EncryptedToSSECCopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: dstencryption}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{ServerSideEncryption: dstencryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8910,7 +8910,7 @@ func testSSES3EncryptedToUnencryptedCopyPart() {
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PutObject call failed", err)
 	}
-	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: srcEncryption}})
+	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{ServerSideEncryption: srcEncryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -8963,7 +8963,7 @@ func testSSES3EncryptedToUnencryptedCopyPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -9065,7 +9065,7 @@ func testSSES3EncryptedToSSES3CopyObjectPart() {
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PutObject call failed", err)
 	}
-	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{minio.GetObjectOptions{ServerSideEncryption: srcEncryption}})
+	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{ServerSideEncryption: srcEncryption})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}
@@ -9120,7 +9120,7 @@ func testSSES3EncryptedToSSES3CopyObjectPart() {
 	}
 
 	// Stat the object and check its length matches
-	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{minio.GetObjectOptions{}})
+	objInfo, err := c.StatObject(context.Background(), destBucketName, destObjectName, minio.StatObjectOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "StatObject call failed", err)
 	}


### PR DESCRIPTION
It is ugly to always pass GetObjectOptions{} inside StatObjectOptions{}
for any specific HEAD operation (such as a specific VersionID).

This commit will make StatObjectOptions as type alias to
GetObjectOptions