### PR TITLE
Returns error instead of  when an error is hit

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -638,7 +638,7 @@ func (c Client) getObject(ctx context.Context, bucketName, objectName string, op
 	objectStat, err := ToObjectInfo(bucketName, objectName, resp.Header)
 	if err != nil {
 		closeResponse(resp)
-		return nil, objectStat, resp.Header, nil
+		return nil, ObjectInfo{}, nil, err
 	}
 
 	// do not close body here, caller will close


### PR DESCRIPTION
Fixes #3219

We trip over if something goes wrong when `ToObjectInfo(bucketName, objectName, resp.Header)` function is called in `getObject()` and an error is returned. The problem was instead of returning the error, we were returning `nil` value.

To be able to mimic the condition, I've instigated an error immediately after `ToObjectInfo(bucketName, objectName, resp.Header)` is called.

```
	objectStat, err := ToObjectInfo(bucketName, objectName, resp.Header)
	err = errors.New("Error: Forced error here to reproduce the panic")
	if err != nil {
		closeResponse(resp)
		return nil, objectStat, resp.Header, nil
	}
```

It crashed when I ran my `test-getObject.go` script, which is exactly the same test with `examples/s3/getobject.go`. The only adjustment is to run against my local minio server instead of s3.

```
$ go run examples/s3/test-getobject.go 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x48d738]

goroutine 6 [running]:
io.ReadAtLeast(0x0, 0x0, 0xc000284300, 0x1a, 0x1a, 0x1a, 0x0, 0x0, 0xc0001cfaa0)
	/usr/local/go/src/io/io.go:310 +0x58
io.ReadFull(...)
	/usr/local/go/src/io/io.go:329
github.com/minio/minio-go/v7.Client.GetObject.func1(0xc0000323c0, 0xc000032420, 0xc000032480, 0xc000021e20, 0xc0001cfb30, 0xc000136370, 0x94d8e0, 0xc00002c110, 0x89f703, 0x4, ...)
	/home/ersan/work/src/github.com/minio/minio-go/api-get-object.go:195 +0xd99
created by github.com/minio/minio-go/v7.Client.GetObject
	/home/ersan/work/src/github.com/minio/minio-go/api-get-object.go:62 +0x346
exit status 2
```

If `resp.Body` value was returned instead of `nil`, it would still be ok and the program would exit gracefully instead of a panic and the error message would be : `read on closed response body`.

```
$ go run examples/s3/test-getobject.go 
2020/07/09 02:41:54 http: read on closed response body
exit status 1
```
However, the best thing is to stop at the right place when error happens.

```
$ go run examples/s3/test-getobject.go 
2020/07/09 02:10:55 Error: Forced error here to reproduce the panic
exit status 1
```
So, the fix is to return the error right away when it happens.
