### PR TITLE
Return object's version id in StatObject()

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -66,6 +66,8 @@ const (
 	amzTaggingHeader          = "X-Amz-Tagging"
 	amzTaggingHeaderDirective = "X-Amz-Tagging-Directive"
 
+	amzVersionID = "X-Amz-Version-Id"
+
 	// Object legal hold header
 	amzLegalHoldHeader = "X-Amz-Object-Lock-Legal-Hold"
 

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -837,6 +837,10 @@ func testStatObjectWithVersioning() {
 			logError(testName, function, args, startTime, "", "error during HEAD object", err)
 			return
 		}
+		if statInfo.VersionID == "" || statInfo.VersionID != results[i].VersionID {
+			logError(testName, function, args, startTime, "", "error during HEAD object, unexpected version id", err)
+			return
+		}
 		if statInfo.ETag != results[i].ETag {
 			logError(testName, function, args, startTime, "", "error during HEAD object, unexpected ETag", err)
 			return

--- a/utils.go
+++ b/utils.go
@@ -272,6 +272,7 @@ func ToObjectInfo(bucketName string, objectName string, h http.Header) (ObjectIn
 		LastModified: date,
 		ContentType:  contentType,
 		Expires:      expTime,
+		VersionID:    h.Get(amzVersionID),
 		// Extract only the relevant header keys describing the object.
 		// following function filters out a list of standard set of keys
 		// which are not part of object metadata.


### PR DESCRIPTION
This commit returns the content of x-amz-version-id header in the
response of the S3 request, so that information will be part of the
returned ObjectInfo structure.

A test is added as well.