### PR TITLE
lifecycle: Fix marshaling expiration date/days

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1578,10 +1578,12 @@ __Example__
 ```go
 config := lifecycle.NewConfiguration()
 config.Rules = []lifecycle.Rule{
-  ID:     "expire-bucket",
-  Status: "Enabled",
-  Expiration: lifecycle.Expiration{
-     Days: 365,
+  {
+    ID:     "expire-bucket",
+    Status: "Enabled",
+    Expiration: lifecycle.Expiration{
+       Days: 365,
+    },
   },
 }
 

--- a/examples/s3/setbucketlifecycle.go
+++ b/examples/s3/setbucketlifecycle.go
@@ -50,10 +50,12 @@ func main() {
 	// Set lifecycle on a bucket
 	config := lifecycle.NewConfiguration()
 	config.Rules = []lifecycle.Rule{
-		ID:     "expire-bucket",
-		Status: "Enabled",
-		Expiration: lifecycle.Expiration{
-			Days: 365,
+		{
+			ID:     "expire-bucket",
+			Status: "Enabled",
+			Expiration: lifecycle.Expiration{
+				Days: 365,
+			},
 		},
 	}
 	err = s3Client.SetBucketLifecycle(context.Background(), "my-bucketname", config)

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -180,11 +180,11 @@ type ExpirationDays int
 
 // MarshalXML encodes number of days to expire if it is non-zero and
 // encodes empty string otherwise
-func (eDays *ExpirationDays) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
-	if *eDays == ExpirationDays(0) {
+func (eDays ExpirationDays) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if eDays == 0 {
 		return nil
 	}
-	return e.EncodeElement(int(*eDays), startElement)
+	return e.EncodeElement(int(eDays), startElement)
 }
 
 // ExpirationDate is a embedded type containing time.Time to unmarshal
@@ -195,8 +195,8 @@ type ExpirationDate struct {
 
 // MarshalXML encodes expiration date if it is non-zero and encodes
 // empty string otherwise
-func (eDate *ExpirationDate) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
-	if *eDate == (ExpirationDate{time.Time{}}) {
+func (eDate ExpirationDate) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if eDate.Time.IsZero() {
 		return nil
 	}
 	return e.EncodeElement(eDate.Format(time.RFC3339), startElement)


### PR DESCRIPTION
Setting a new bucket lifecycle was not working properly, the reason
is that a zero time.Time is still parsed in expiration date. Fixing it.