### PR TITLE
[doc] fix presignURL Expires doc

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1156,7 +1156,7 @@ if err != nil {
 
 <a name="PresignedGetObject"></a>
 ### PresignedGetObject(ctx context.Context, bucketName, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error)
-Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The default expiry is set to 7 days.
+Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The maximum expiry is 604800 seconds (i.e. 7 days) and minimum is 1 second. 
 
 __Parameters__
 


### PR DESCRIPTION
minio-go client has no default expiry for presignURL, while minio-server has a default expiry(7 days).

