### PR TITLE
Send single DELETE requests if object name has xml invalid chars

### DIFF
--- a/api-remove.go
+++ b/api-remove.go
@@ -196,7 +196,7 @@ func (c Client) RemoveObjects(ctx context.Context, bucketName string, objectsCh 
 
 // Return true if the character is within the allowed characters in an XML 1.0 document
 // The list of allowed characters can be found here: https://www.w3.org/TR/xml/#charsets
-func isXMLValidChar(r rune) (inrange bool) {
+func validXMLChar(r rune) (ok bool) {
 	return r == 0x09 ||
 		r == 0x0A ||
 		r == 0x0D ||

--- a/api-remove.go
+++ b/api-remove.go
@@ -207,7 +207,7 @@ func validXMLChar(r rune) (ok bool) {
 
 func hasInvalidXMLChar(str string) bool {
 	for _, s := range str {
-		if !isXMLValidChar(s) {
+		if !validXMLChar(s) {
 			return true
 		}
 	}
@@ -234,7 +234,7 @@ func (c Client) removeObjects(ctx context.Context, bucketName string, objectsCh 
 
 		// Try to gather 1000 entries
 		for object := range objectsCh {
-			if hasXMLInvalidChar(object.Key) {
+			if hasInvalidXMLChar(object.Key) {
 				// Use single DELETE so the object name will be in the request URL instead of the multi-delete XML document.
 				err := c.removeObject(ctx, bucketName, object.Key, RemoveObjectOptions{GovernanceBypass: opts.GovernanceBypass})
 				if err != nil {

--- a/api-remove.go
+++ b/api-remove.go
@@ -205,7 +205,7 @@ func validXMLChar(r rune) (ok bool) {
 		r >= 0x10000 && r <= 0x10FFFF
 }
 
-func hasXMLInvalidChar(str string) bool {
+func hasInvalidXMLChar(str string) bool {
 	for _, s := range str {
 		if !isXMLValidChar(s) {
 			return true


### PR DESCRIPTION
Currently, it is not possible to remove some objects using the multi
delete API if those objects contain some weird characters.

In an XML document, some characters are not allowed to be there and
there is no way to escape them in XML 1.0, currently used by S3.
Therefore, some objects that have those invalid characters won't be
deleted in a multi-delete request.

To solve this, we need to check for object names and send individual
DELETE requests. The object name will be encoded in the request URL and
can be removed as expected