### PR TITLE
Add opts for replication deletes

### DIFF
--- a/api-get-options.go
+++ b/api-get-options.go
@@ -28,9 +28,10 @@ import (
 // GetObjectOptions are used to specify additional headers or options
 // during GET requests.
 type GetObjectOptions struct {
-	headers              map[string]string
-	ServerSideEncryption encrypt.ServerSide
-	VersionID            string
+	headers                 map[string]string
+	ServerSideEncryption    encrypt.ServerSide
+	VersionID               string
+	ReplicationDeleteMarker bool
 }
 
 // StatObjectOptions are used to specify additional headers or options

--- a/api-remove.go
+++ b/api-remove.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
@@ -60,8 +61,11 @@ func (c Client) RemoveBucket(ctx context.Context, bucketName string) error {
 
 // RemoveObjectOptions represents options specified by user for RemoveObject call
 type RemoveObjectOptions struct {
-	GovernanceBypass bool
-	VersionID        string
+	GovernanceBypass        bool
+	VersionID               string
+	ReplicationDeleteMarker bool
+	ReplicationStatus       ReplicationStatus
+	ReplicationMTime        time.Time
 }
 
 // RemoveObject removes an object from a bucket.
@@ -88,6 +92,15 @@ func (c Client) RemoveObject(ctx context.Context, bucketName, objectName string,
 	if opts.GovernanceBypass {
 		// Set the bypass goverenance retention header
 		headers.Set(amzBypassGovernance, "true")
+	}
+	if opts.ReplicationDeleteMarker {
+		headers.Set(minIOBucketReplicationDeleteMarker, "true")
+	}
+	if !opts.ReplicationMTime.IsZero() {
+		headers.Set(minIOBucketReplicationSourceMTime, opts.ReplicationMTime.Format(time.RFC3339))
+	}
+	if !opts.ReplicationStatus.Empty() {
+		headers.Set(amzBucketReplicationStatus, string(opts.ReplicationStatus))
 	}
 	// Execute DELETE on objectName.
 	resp, err := c.executeMethod(ctx, http.MethodDelete, requestMetadata{

--- a/api-stat.go
+++ b/api-stat.go
@@ -78,27 +78,35 @@ func (c Client) statObject(ctx context.Context, bucketName, objectName string, o
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return ObjectInfo{}, err
 	}
+	headers := opts.Header()
+	if opts.ReplicationDeleteMarker {
+		headers.Set(minIOBucketReplicationDeleteMarker, "true")
+	}
 
 	urlValues := make(url.Values)
 	if opts.VersionID != "" {
 		urlValues.Set("versionId", opts.VersionID)
 	}
-
 	// Execute HEAD on objectName.
 	resp, err := c.executeMethod(ctx, http.MethodHead, requestMetadata{
 		bucketName:       bucketName,
 		objectName:       objectName,
 		queryValues:      urlValues,
 		contentSHA256Hex: emptySHA256Hex,
-		customHeader:     opts.Header(),
+		customHeader:     headers,
 	})
 	defer closeResponse(resp)
 	if err != nil {
 		return ObjectInfo{}, err
 	}
+	deleteMarker := resp.Header.Get(amzDeleteMarker) == "true"
+
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-			return ObjectInfo{}, httpRespToErrorResponse(resp, bucketName, objectName)
+			return ObjectInfo{
+				VersionID:      resp.Header.Get(amzVersionID),
+				IsDeleteMarker: deleteMarker,
+			}, httpRespToErrorResponse(resp, bucketName, objectName)
 		}
 	}
 

--- a/constants.go
+++ b/constants.go
@@ -70,6 +70,7 @@ const (
 	amzTaggingCount      = "X-Amz-Tagging-Count"
 	amzExpiration        = "X-Amz-Expiration"
 	amzReplicationStatus = "X-Amz-Replication-Status"
+	amzDeleteMarker      = "X-Amz-Delete-Marker"
 
 	// Object legal hold header
 	amzLegalHoldHeader = "X-Amz-Object-Lock-Legal-Hold"
@@ -82,6 +83,7 @@ const (
 	// Replication status
 	amzBucketReplicationStatus = "X-Amz-Replication-Status"
 	// Minio specific Replication extension
-	minIOBucketReplicationSourceMTime = "X-Minio-Source-Mtime"
-	minIOBucketReplicationETag        = "X-Minio-Source-Etag"
+	minIOBucketReplicationSourceMTime  = "X-Minio-Source-Mtime"
+	minIOBucketReplicationETag         = "X-Minio-Source-Etag"
+	minIOBucketReplicationDeleteMarker = "X-Minio-Source-DeleteMarker"
 )

--- a/docs/API.md
+++ b/docs/API.md
@@ -454,7 +454,7 @@ __minio.GetObjectOptions__
 |Field | Type | Description |
 |:---|:---|:---|
 | `opts.ServerSideEncryption` | _encrypt.ServerSide_ | Interface provided by `encrypt` package to specify server-side-encryption. (For more information see https://godoc.org/github.com/minio/minio-go/v7) |
-
+| `opts.ReplicationDeleteMarker`                | _bool_               | Specify if object being deleted is a deletemarker.This option is intended for internal use by MinIO server to extend the replication API implementation by AWS. This option should not be set unless the application is aware of intended use.
 __Return Value__
 
 
@@ -849,6 +849,9 @@ __minio.RemoveObjectOptions__
 |:--- |:--- | :--- |
 | `opts.GovernanceBypass` | _bool_ |Set the bypass governance header to delete an object locked with GOVERNANCE mode|
 | `opts.VersionID` | _string_ |Version ID of the object to delete|
+| `opts.ReplicationDeleteMarker`                | _bool_               | Specify if object being deleted is a deletemarker.This option is intended for internal use by MinIO server to extend the replication API implementation by AWS. This option should not be set unless the application is aware of intended use.
+| `opts.ReplicationMTime`                | _time.Time_               | Preserve source modTime on the replicated object. This option is intended for internal use only by MinIO server to comply with AWS bucket replication implementation. This option should not be set unless the application is aware of intended use.
+| `opts.ReplicationStatus`                | _string_               | Specify replication status of object being removed.This option is intended for internal use by MinIO server to extend the replication API implementation by AWS. This option should not be set unless the application is aware of intended use.
 
 
 ```go

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -46,17 +46,19 @@ const (
 
 // Options represents options to set a replication configuration rule
 type Options struct {
-	Op           OptionType
-	ID           string
-	Prefix       string
-	RuleStatus   string
-	Priority     string
-	TagString    string
-	StorageClass string
-	RoleArn      string
-	DestBucket   string
-	IsTagSet     bool
-	IsSCSet      bool
+	Op                     OptionType
+	ID                     string
+	Prefix                 string
+	RuleStatus             string
+	Priority               string
+	TagString              string
+	StorageClass           string
+	RoleArn                string
+	DestBucket             string
+	IsTagSet               bool
+	IsSCSet                bool
+	ReplicateDeletes       string // replicate versioned deletes
+	ReplicateDeleteMarkers string // replicate soft deletes
 }
 
 // Tags returns a slice of tags for a rule
@@ -152,6 +154,30 @@ func (c *Config) AddRule(opts Options) error {
 			return fmt.Errorf("destination bucket needs to be in Arn format")
 		}
 	}
+	dmStatus := Disabled
+	if opts.ReplicateDeleteMarkers != "" {
+		switch opts.ReplicateDeleteMarkers {
+		case "enable":
+			dmStatus = Enabled
+		case "disable":
+			dmStatus = Disabled
+		default:
+			return fmt.Errorf("ReplicateDeleteMarkers should be either enable|disable")
+		}
+	}
+
+	vDeleteStatus := Disabled
+	if opts.ReplicateDeletes != "" {
+		switch opts.ReplicateDeletes {
+		case "enable":
+			vDeleteStatus = Enabled
+		case "disable":
+			vDeleteStatus = Disabled
+		default:
+			return fmt.Errorf("ReplicateDeletes should be either enable|disable")
+		}
+	}
+
 	newRule := Rule{
 		ID:       opts.ID,
 		Priority: priority,
@@ -161,7 +187,8 @@ func (c *Config) AddRule(opts Options) error {
 			Bucket:       destBucket,
 			StorageClass: opts.StorageClass,
 		},
-		DeleteMarkerReplication: DeleteMarkerReplication{Status: Disabled},
+		DeleteMarkerReplication: DeleteMarkerReplication{Status: dmStatus},
+		DeleteReplication:       DeleteReplication{Status: vDeleteStatus},
 	}
 
 	// validate rule after overlaying priority for pre-existing rule being disabled.
@@ -244,6 +271,30 @@ func (c *Config) EditRule(opts Options) error {
 			return fmt.Errorf("Rule state should be either [enable|disable]")
 		}
 	}
+	// set DeleteMarkerReplication rule status for edit option
+	if opts.ReplicateDeleteMarkers != "" {
+		switch opts.ReplicateDeleteMarkers {
+		case "enable":
+			newRule.DeleteMarkerReplication.Status = Enabled
+		case "disable":
+			newRule.DeleteMarkerReplication.Status = Disabled
+		default:
+			return fmt.Errorf("ReplicateDeleteMarkers state should be either [enable|disable]")
+		}
+	}
+
+	// set DeleteReplication rule status for edit option. This is a MinIO specific
+	// option to replicate versioned deletes
+	if opts.ReplicateDeletes != "" {
+		switch opts.ReplicateDeletes {
+		case "enable":
+			newRule.DeleteReplication.Status = Enabled
+		case "disable":
+			newRule.DeleteReplication.Status = Disabled
+		default:
+			return fmt.Errorf("ReplicateDeletes state should be either [enable|disable]")
+		}
+	}
 
 	if opts.IsSCSet {
 		newRule.Destination.StorageClass = opts.StorageClass
@@ -314,6 +365,7 @@ type Rule struct {
 	Status                  Status                  `xml:"Status"`
 	Priority                int                     `xml:"Priority"`
 	DeleteMarkerReplication DeleteMarkerReplication `xml:"DeleteMarkerReplication"`
+	DeleteReplication       DeleteReplication       `xml:"DeleteReplication"`
 	Destination             Destination             `xml:"Destination"`
 	Filter                  Filter                  `xml:"Filter" json:"Filter"`
 }
@@ -470,7 +522,7 @@ type Destination struct {
 type And struct {
 	XMLName xml.Name `xml:"And,omitempty" json:"-"`
 	Prefix  string   `xml:"Prefix,omitempty" json:"Prefix,omitempty"`
-	Tags    []Tag    `xml:"Tags,omitempty" json:"Tags,omitempty"`
+	Tags    []Tag    `xml:"Tag,omitempty" json:"Tag,omitempty"`
 }
 
 // isEmpty returns true if Tags field is null
@@ -494,5 +546,16 @@ type DeleteMarkerReplication struct {
 
 // IsEmpty returns true if DeleteMarkerReplication is not set
 func (d DeleteMarkerReplication) IsEmpty() bool {
+	return len(d.Status) == 0
+}
+
+// DeleteReplication - whether versioned deletes are replicated - this
+// is a MinIO specific extension
+type DeleteReplication struct {
+	Status Status `xml:"Status" json:"Status"` // should be set to "Disabled" by default
+}
+
+// IsEmpty returns true if DeleteReplication is not set
+func (d DeleteReplication) IsEmpty() bool {
 	return len(d.Status) == 0
 }

--- a/utils.go
+++ b/utils.go
@@ -297,6 +297,8 @@ func ToObjectInfo(bucketName string, objectName string, h http.Header) (ObjectIn
 	// extract lifecycle expiry date and rule ID
 	expTime, ruleID := amzExpirationToExpiryDateRuleID(h.Get(amzExpiration))
 
+	deleteMarker := h.Get(amzDeleteMarker) == "true"
+
 	// Save object metadata info.
 	return ObjectInfo{
 		ETag:              etag,
@@ -306,6 +308,7 @@ func ToObjectInfo(bucketName string, objectName string, h http.Header) (ObjectIn
 		ContentType:       contentType,
 		Expires:           expiry,
 		VersionID:         h.Get(amzVersionID),
+		IsDeleteMarker:    deleteMarker,
 		ReplicationStatus: h.Get(amzReplicationStatus),
 		Expiration:        expTime,
 		ExpirationRuleID:  ruleID,


### PR DESCRIPTION
Enhancing StatObjectOptions, RemoveObjectOptions
for propagating replication deletes.

This PR also enhances replication pkg to
toggle DeleteMarker replication flag, intended
for `mc replicate set/add` commands