### PR TITLE
fix xml tag name in replication rule

### DIFF
--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -470,7 +470,7 @@ type Destination struct {
 type And struct {
 	XMLName xml.Name `xml:"And,omitempty" json:"-"`
 	Prefix  string   `xml:"Prefix,omitempty" json:"Prefix,omitempty"`
-	Tags    []Tag    `xml:"Tags,omitempty" json:"Tags,omitempty"`
+	Tags    []Tag    `xml:"Tag,omitempty" json:"Tag,omitempty"`
 }
 
 // isEmpty returns true if Tags field is null


### PR DESCRIPTION
tags are not being set correctly in replication rule when accompanied by prefix.
e.g. 
```
 mc replicate add source/bucket/prefix --tags "dept=finance&location=sfo" --arn "arn:minio:replication::11fd2086-c581-41d4-a46c-b4b88fc61997:bucket" --priority 15 --remote-bucket bucket 
```
