### PR TITLE
lifecycle: Fix parsing Tag in documents

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -146,7 +146,7 @@ type Filter struct {
 	XMLName xml.Name `xml:"Filter" json:"-"`
 	And     And      `xml:"And,omitempty" json:"And,omitempty"`
 	Prefix  string   `xml:"Prefix,omitempty" json:"Prefix,omitempty"`
-	Tag     Tag      `xml:"Tag,omitempty" json:"-"`
+	Tag     Tag      `xml:"Tag,omitempty" json:"Tag,omitempty"`
 }
 
 // MarshalXML - produces the xml representation of the Filter struct


### PR DESCRIPTION
Tag was omitted while parsing a lifecycle document in JSON format
because Tag field was unintentionally omitted in field description.

This causes an issue in mc ilm command.