### PR TITLE
versioning: Fix error parsing VersionIdMarker and NextVersionIdMarker

### DIFF
--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -89,6 +89,8 @@ type Version struct {
 }
 
 // ListVersionsResult is an element in the list object versions response
+// and has a special Unmarshaler because we need to preserver the order
+// of <Version>  and <DeleteMarker> in ListVersionsResult.Versions slice
 type ListVersionsResult struct {
 	Versions []Version
 
@@ -125,8 +127,7 @@ func (l *ListVersionsResult) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 			switch tagName {
 			case "Name", "Prefix",
 				"Delimiter", "EncodingType",
-				"KeyMarker", "VersionIdMarker",
-				"NextKeyMarker", "NextVersionIdMarker":
+				"KeyMarker", "NextKeyMarker":
 				var s string
 				if err = d.DecodeElement(&s, &se); err != nil {
 					return err
@@ -135,6 +136,20 @@ func (l *ListVersionsResult) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 				if v.IsValid() {
 					v.SetString(s)
 				}
+			case "VersionIdMarker":
+				// VersionIdMarker is a special case because of 'Id' instead of 'ID' in field name
+				var s string
+				if err = d.DecodeElement(&s, &se); err != nil {
+					return err
+				}
+				l.VersionIDMarker = s
+			case "NextVersionIdMarker":
+				// NextVersionIdMarker is a special case because of 'Id' instead of 'ID' in field name
+				var s string
+				if err = d.DecodeElement(&s, &se); err != nil {
+					return err
+				}
+				l.NextVersionIDMarker = s
 			case "IsTruncated": //        bool
 				var b bool
 				if err = d.DecodeElement(&b, &se); err != nil {

--- a/examples/s3/listobjectversions.go
+++ b/examples/s3/listobjectversions.go
@@ -45,14 +45,14 @@ func main() {
 		return
 	}
 
-	// Create a done channel to control 'ListObjects' go routine.
-	doneCh := make(chan struct{})
-
-	// Indicate to our routine to exit cleanly upon return.
-	defer close(doneCh)
+	opts := minio.ListObjectsOptions{
+		WithVersions: true,
+		Prefix:       "my-prefixname",
+		Recursive:    true,
+	}
 
 	// List all objects from a bucket-name with a matching prefix.
-	for objectVersion := range s3Client.ListObjectVersions(context.Background(), "my-bucketname", "my-prefixname", true, doneCh) {
+	for objectVersion := range s3Client.ListObjects(context.Background(), "my-bucketname", opts) {
 		if objectVersion.Err != nil {
 			fmt.Println(objectVersion.Err)
 			return


### PR DESCRIPTION
The response of ListObjectVersions API has a custom unmarshaler and we
were wrongly parsing VersionIdMarker and NextVersionIdMarker.

The old code was relying on the field names in ListVersionsResult
structure but we should not do that in case of VersionIdMarker and
NextVersionIdMarker.

Bonus change: Fix listobjectversions.go example