### PR TITLE
replication: add source-proxy header if opts set

### DIFF
--- a/api-get-options.go
+++ b/api-get-options.go
@@ -28,6 +28,7 @@ import (
 //AdvancedGetOptions for internal use by MinIO server - not intended for client use.
 type AdvancedGetOptions struct {
 	ReplicationDeleteMarker bool
+	ReplicationProxyRequest bool
 }
 
 // GetObjectOptions are used to specify additional headers or options
@@ -52,6 +53,11 @@ func (o GetObjectOptions) Header() http.Header {
 	}
 	if o.ServerSideEncryption != nil && o.ServerSideEncryption.Type() == encrypt.SSEC {
 		o.ServerSideEncryption.Marshal(headers)
+	}
+	// this header is set for active-active replication scenario where GET/HEAD
+	// to site A is proxy'd to site B if object/version missing on site A.
+	if o.Internal.ReplicationProxyRequest {
+		headers.Set(minIOBucketReplicationProxyRequest, "true")
 	}
 	return headers
 }

--- a/constants.go
+++ b/constants.go
@@ -87,4 +87,5 @@ const (
 
 	minIOBucketSourceETag              = "X-Minio-Source-Etag"
 	minIOBucketReplicationDeleteMarker = "X-Minio-Source-DeleteMarker"
+	minIOBucketReplicationProxyRequest = "X-Minio-Source-Proxy-Request"
 )


### PR DESCRIPTION
- this is basically needed in a two way replication scenario and needs to be set to stop lookup in other site unless this header is sent by other site.