### PR TITLE
Fix - context timeout not launched on get bucket location #1413

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -97,12 +97,12 @@ func (c Client) getBucketLocation(ctx context.Context, bucketName string) (strin
 	}
 
 	// Initialize a new request.
-	req, err := c.getBucketLocationRequest(bucketName)
+	req, err := c.getBucketLocationRequest(ctx, bucketName)
 	if err != nil {
 		return "", err
 	}
 
-	req = req.WithContext(ctx)
+	//req = req.WithContext(ctx)
 	// Initiate the request.
 	resp, err := c.do(req)
 	defer closeResponse(resp)
@@ -170,7 +170,7 @@ func processBucketLocationResponse(resp *http.Response, bucketName string) (buck
 }
 
 // getBucketLocationRequest - Wrapper creates a new getBucketLocation request.
-func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, error) {
+func (c Client) getBucketLocationRequest(ctx context.Context, bucketName string) (*http.Request, error) {
 	// Set location query.
 	urlValues := make(url.Values)
 	urlValues.Set("location", "")
@@ -199,7 +199,7 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 	}
 
 	// Get a new HTTP request for the method.
-	req, err := http.NewRequest(http.MethodGet, urlStr, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -102,6 +102,7 @@ func (c Client) getBucketLocation(ctx context.Context, bucketName string) (strin
 		return "", err
 	}
 
+	req = req.WithContext(ctx)
 	// Initiate the request.
 	resp, err := c.do(req)
 	defer closeResponse(resp)

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -102,7 +102,6 @@ func (c Client) getBucketLocation(ctx context.Context, bucketName string) (strin
 		return "", err
 	}
 
-	//req = req.WithContext(ctx)
 	// Initiate the request.
 	resp, err := c.do(req)
 	defer closeResponse(resp)

--- a/bucket-cache_test.go
+++ b/bucket-cache_test.go
@@ -19,6 +19,7 @@ package minio
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"io/ioutil"
 	"net/http"
@@ -236,7 +237,7 @@ func TestGetBucketLocationRequest(t *testing.T) {
 			}
 		}
 
-		actualReq, err := client.getBucketLocationRequest(testCase.bucketName)
+		actualReq, err := client.getBucketLocationRequest(context.Background(), testCase.bucketName)
 		if err != nil && testCase.shouldPass {
 			t.Errorf("Test %d: Expected to pass, but failed with: <ERROR> %s", i+1, err.Error())
 		}


### PR DESCRIPTION
Using context on request, in order to handle context timeouts 