### PR TITLE
encrypt: fix SSE-KMS HTTP context header

### DIFF
--- a/pkg/encrypt/server-side.go
+++ b/pkg/encrypt/server-side.go
@@ -34,7 +34,7 @@ const (
 	// sseKmsKeyID is the AWS SSE-KMS key id.
 	sseKmsKeyID = sseGenericHeader + "-Aws-Kms-Key-Id"
 	// sseEncryptionContext is the AWS SSE-KMS Encryption Context data.
-	sseEncryptionContext = sseGenericHeader + "-Encryption-Context"
+	sseEncryptionContext = sseGenericHeader + "-Context"
 
 	// sseCustomerAlgorithm is the AWS SSE-C algorithm HTTP header key.
 	sseCustomerAlgorithm = sseGenericHeader + "-Customer-Algorithm"


### PR DESCRIPTION
This commit fixes a bug in the SSE-KMS.
The current SSE-KMS implementation sets
the wrong header for the SSE-KMS context.

Now, the correct header is set:
```
X-Amz-Server-Side-Encryption-Context
```