### PR TITLE
replication: Use nano precision in modtime during copy & delete

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -215,7 +215,7 @@ func (c Client) copyObjectDo(ctx context.Context, srcBucket, srcObject, destBuck
 		headers.Set(amzBucketReplicationStatus, string(dstOpts.Internal.ReplicationStatus))
 	}
 	if !dstOpts.Internal.SourceMTime.IsZero() {
-		headers.Set(minIOBucketSourceMTime, dstOpts.Internal.SourceMTime.Format(time.RFC3339))
+		headers.Set(minIOBucketSourceMTime, dstOpts.Internal.SourceMTime.Format(time.RFC3339Nano))
 	}
 	if dstOpts.Internal.SourceETag != "" {
 		headers.Set(minIOBucketSourceETag, dstOpts.Internal.SourceETag)

--- a/api-remove.go
+++ b/api-remove.go
@@ -107,7 +107,7 @@ func (c Client) removeObject(ctx context.Context, bucketName, objectName string,
 		headers.Set(minIOBucketReplicationDeleteMarker, "true")
 	}
 	if !opts.Internal.ReplicationMTime.IsZero() {
-		headers.Set(minIOBucketSourceMTime, opts.Internal.ReplicationMTime.Format(time.RFC3339))
+		headers.Set(minIOBucketSourceMTime, opts.Internal.ReplicationMTime.Format(time.RFC3339Nano))
 	}
 	if !opts.Internal.ReplicationStatus.Empty() {
 		headers.Set(amzBucketReplicationStatus, string(opts.Internal.ReplicationStatus))


### PR DESCRIPTION
Send nano second precision of the source object during a copy object operation,
also ensure that the modtime of the replicated delete-marker also keeps its nano
second precision. 