### PR TITLE
Allow setting SourceVersionID for multipart uploads

### DIFF
--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -32,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
@@ -197,6 +198,13 @@ func (c Client) initiateMultipartUpload(ctx context.Context, bucketName, objectN
 	// Initialize url queries.
 	urlValues := make(url.Values)
 	urlValues.Set("uploads", "")
+
+	if opts.Internal.SourceVersionID != "" {
+		if _, err := uuid.Parse(opts.Internal.SourceVersionID); err != nil {
+			return initiateMultipartUploadResult{}, errInvalidArgument(err.Error())
+		}
+		urlValues.Set("versionId", opts.Internal.SourceVersionID)
+	}
 
 	// Set ContentType header.
 	customHeader := opts.Header()


### PR DESCRIPTION
Currently SourceVersionID works for streaming PutObject only.
This patch allows using SourceVersionID for multipart uploads.