### PR TITLE
append minio. to ListObjectsOptions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -297,7 +297,7 @@ ctx, cancel := context.WithCancel(context.Background())
 
 defer cancel()
 
-objectCh := minioClient.ListObjects(ctx, "mybucket", ListObjectsOptions{
+objectCh := minioClient.ListObjects(ctx, "mybucket", minio.ListObjectsOptions{
        Prefix: "myprefix",
        Recursive: true,
 })


### PR DESCRIPTION
while using the api I copied and paste from the documentation and realized the example was incorrect which led to an error saying ListObjectsOptions was undefined. changing it to minio.ListObjectsOptions like the rest of the examples fixed the compile-time error.