### PR TITLE
Provide AWS S3 China Dual-Stack Endpoints

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -95,6 +95,9 @@ var amazonS3HostDot = regexp.MustCompile(`^s3.(.*?).amazonaws.com$`)
 // amazonS3ChinaHost - regular expression used to determine if the arg is s3 china host.
 var amazonS3ChinaHost = regexp.MustCompile(`^s3.(cn.*?).amazonaws.com.cn$`)
 
+// amazonS3ChinaHostDualStack - regular expression used to determine if the arg is s3 china host dualstack.
+var amazonS3ChinaHostDualStack = regexp.MustCompile(`^s3.dualstack.(cn.*?).amazonaws.com.cn$`)
+
 // Regular expression used to determine if the arg is elb host.
 var elbAmazonRegex = regexp.MustCompile(`elb(.*?).amazonaws.com$`)
 
@@ -125,6 +128,10 @@ func GetRegionFromURL(endpointURL url.URL) string {
 		return parts[1]
 	}
 	parts = amazonS3ChinaHost.FindStringSubmatch(endpointURL.Host)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	parts = amazonS3ChinaHostDualStack.FindStringSubmatch(endpointURL.Host)
 	if len(parts) > 1 {
 		return parts[1]
 	}

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -39,7 +39,15 @@ func TestGetRegionFromURL(t *testing.T) {
 			expectedRegion: "cn-north-1",
 		},
 		{
+			u:              url.URL{Host: "s3.dualstack.cn-north-1.amazonaws.com.cn"},
+			expectedRegion: "cn-north-1",
+		},
+		{
 			u:              url.URL{Host: "s3.cn-northwest-1.amazonaws.com.cn"},
+			expectedRegion: "cn-northwest-1",
+		},
+		{
+			u:              url.URL{Host: "s3.dualstack.cn-northwest-1.amazonaws.com.cn"},
 			expectedRegion: "cn-northwest-1",
 		},
 		{

--- a/s3-endpoints.go
+++ b/s3-endpoints.go
@@ -42,8 +42,8 @@ var awsS3EndpointMap = map[string]string{
 	"sa-east-1":      "s3.dualstack.sa-east-1.amazonaws.com",
 	"us-gov-west-1":  "s3.dualstack.us-gov-west-1.amazonaws.com",
 	"us-gov-east-1":  "s3.dualstack.us-gov-east-1.amazonaws.com",
-	"cn-north-1":     "s3.cn-north-1.amazonaws.com.cn",
-	"cn-northwest-1": "s3.cn-northwest-1.amazonaws.com.cn",
+	"cn-north-1":     "s3.dualstack.cn-north-1.amazonaws.com.cn",
+	"cn-northwest-1": "s3.dualstack.cn-northwest-1.amazonaws.com.cn",
 }
 
 // getS3Endpoint get Amazon S3 endpoint based on the bucket location.


### PR DESCRIPTION
Adds IPv6 support to the China regions.

https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-s3-adds-support-ipv6-protocol-beijing-sinnet-ningxia-nwcd/

Related to #1055 