### PR TITLE
tagSet.String() shows the encoded form of all tags

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -136,12 +136,11 @@ type tagSet struct {
 }
 
 func (tags tagSet) String() string {
-	s := []string{}
+	vals := make(url.Values)
 	for key, value := range tags.tagMap {
-		s = append(s, key+"="+value)
+		vals.Set(key, value)
 	}
-
-	return strings.Join(s, "&")
+	return vals.Encode()
 }
 
 func (tags *tagSet) remove(key string) {


### PR DESCRIPTION
It does not make sense to show a list of tags while key/value
are not encoded.

e.g.  key==val, you don't know if '=' belongs to the key or to the value