### PR TITLE
Set versionID in core CopyObject if specified

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -202,7 +202,7 @@ func (opts CopySrcOptions) validate() (err error) {
 
 // Low level implementation of CopyObject API, supports only upto 5GiB worth of copy.
 func (c Client) copyObjectDo(ctx context.Context, srcBucket, srcObject, destBucket, destObject string,
-	metadata map[string]string, dstOpts PutObjectOptions) (ObjectInfo, error) {
+	metadata map[string]string, srcOpts CopySrcOptions, dstOpts PutObjectOptions) (ObjectInfo, error) {
 
 	// Build headers.
 	headers := make(http.Header)
@@ -240,7 +240,9 @@ func (c Client) copyObjectDo(ctx context.Context, srcBucket, srcObject, destBuck
 
 	// Set the source header
 	headers.Set("x-amz-copy-source", s3utils.EncodePath(srcBucket+"/"+srcObject))
-
+	if srcOpts.VersionID != "" {
+		headers.Set("x-amz-copy-source", s3utils.EncodePath(srcBucket+"/"+srcObject)+"?versionId="+srcOpts.VersionID)
+	}
 	// Send upload-part-copy request
 	resp, err := c.executeMethod(ctx, http.MethodPut, reqMetadata)
 	defer closeResponse(resp)

--- a/core.go
+++ b/core.go
@@ -56,8 +56,8 @@ func (c Core) ListObjectsV2(bucketName, objectPrefix, continuationToken string, 
 }
 
 // CopyObject - copies an object from source object to destination object on server side.
-func (c Core) CopyObject(ctx context.Context, sourceBucket, sourceObject, destBucket, destObject string, metadata map[string]string, dstOpts PutObjectOptions) (ObjectInfo, error) {
-	return c.copyObjectDo(ctx, sourceBucket, sourceObject, destBucket, destObject, metadata, dstOpts)
+func (c Core) CopyObject(ctx context.Context, sourceBucket, sourceObject, destBucket, destObject string, metadata map[string]string, srcOpts CopySrcOptions, dstOpts PutObjectOptions) (ObjectInfo, error) {
+	return c.copyObjectDo(ctx, sourceBucket, sourceObject, destBucket, destObject, metadata, srcOpts, dstOpts)
 }
 
 // CopyObjectPart - creates a part in a multipart upload by copying (a

--- a/core_test.go
+++ b/core_test.go
@@ -462,7 +462,7 @@ func TestCoreCopyObject(t *testing.T) {
 	cuploadInfo, err := c.CopyObject(context.Background(), bucketName, objectName, destBucketName, destObjectName, map[string]string{
 		"X-Amz-Metadata-Directive": "REPLACE",
 		"Content-Type":             "application/javascript",
-	}, PutObjectOptions{})
+	}, CopySrcOptions{}, PutObjectOptions{})
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName, destBucketName, destObjectName)
 	}


### PR DESCRIPTION
To copy a specific version, X-Amz-Copy-Source needs to have a
query string with source version id.