### PR TITLE
Add new header for replication requests

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -220,6 +220,9 @@ func (c Client) copyObjectDo(ctx context.Context, srcBucket, srcObject, destBuck
 	if dstOpts.Internal.SourceETag != "" {
 		headers.Set(minIOBucketSourceETag, dstOpts.Internal.SourceETag)
 	}
+	if dstOpts.Internal.ReplicationRequest {
+		headers.Set(minIOBucketReplicationRequest, "")
+	}
 	if len(dstOpts.UserTags) != 0 {
 		headers.Set(amzTaggingHeader, s3utils.TagEncode(dstOpts.UserTags))
 	}

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -55,10 +55,11 @@ func (r ReplicationStatus) Empty() bool {
 // AdvancedPutOptions for internal use - to be utilized by replication, ILM transition
 // implementation on MinIO server
 type AdvancedPutOptions struct {
-	SourceVersionID   string
-	SourceETag        string
-	ReplicationStatus ReplicationStatus
-	SourceMTime       time.Time
+	SourceVersionID    string
+	SourceETag         string
+	ReplicationStatus  ReplicationStatus
+	SourceMTime        time.Time
+	ReplicationRequest bool
 }
 
 // PutObjectOptions represents options specified by user for PutObject call
@@ -151,6 +152,9 @@ func (opts PutObjectOptions) Header() (header http.Header) {
 	}
 	if opts.Internal.SourceETag != "" {
 		header.Set(minIOBucketSourceETag, opts.Internal.SourceETag)
+	}
+	if opts.Internal.ReplicationRequest {
+		header.Set(minIOBucketReplicationRequest, "")
 	}
 	if len(opts.UserTags) != 0 {
 		header.Set(amzTaggingHeader, s3utils.TagEncode(opts.UserTags))

--- a/api-remove.go
+++ b/api-remove.go
@@ -64,6 +64,7 @@ type AdvancedRemoveOptions struct {
 	ReplicationDeleteMarker bool
 	ReplicationStatus       ReplicationStatus
 	ReplicationMTime        time.Time
+	ReplicationRequest      bool
 }
 
 // RemoveObjectOptions represents options specified by user for RemoveObject call
@@ -111,6 +112,9 @@ func (c Client) removeObject(ctx context.Context, bucketName, objectName string,
 	}
 	if !opts.Internal.ReplicationStatus.Empty() {
 		headers.Set(amzBucketReplicationStatus, string(opts.Internal.ReplicationStatus))
+	}
+	if opts.Internal.ReplicationRequest {
+		headers.Set(minIOBucketReplicationRequest, "")
 	}
 	// Execute DELETE on objectName.
 	resp, err := c.executeMethod(ctx, http.MethodDelete, requestMetadata{

--- a/constants.go
+++ b/constants.go
@@ -88,4 +88,5 @@ const (
 	minIOBucketSourceETag              = "X-Minio-Source-Etag"
 	minIOBucketReplicationDeleteMarker = "X-Minio-Source-DeleteMarker"
 	minIOBucketReplicationProxyRequest = "X-Minio-Source-Proxy-Request"
+	minIOBucketReplicationRequest      = "X-Minio-Source-Replication-Request"
 )


### PR DESCRIPTION
for PUT/COPY/DELETE api calls to target cluster
where replica is to be created.

- This is to distinguish server side replication
requests clearly from any mirroring of
replicated object versions by `mc mirror`.