### PR TITLE
Add 200 to possible response codes for putBucketPolicy

### DIFF
--- a/api-bucket-policy.go
+++ b/api-bucket-policy.go
@@ -63,7 +63,7 @@ func (c Client) putBucketPolicy(ctx context.Context, bucketName, policy string) 
 		return err
 	}
 	if resp != nil {
-		if resp.StatusCode != http.StatusNoContent {
+		if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
 			return httpRespToErrorResponse(resp, bucketName, "")
 		}
 	}


### PR DESCRIPTION
Hi guys,

we are working with Ceph and are getting a 200 instead of a 204 for `putBucketPolicy` if successful.

Even though Amazon defines a 200 as response status code in their documentation, they even have a 204 in their response example: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketPolicy.html

I could not find a test for PutBucketPolicy, so let me know if I should add one.