### PR TITLE
Add new method to get a STSWebIdentity credential assuming a role

### DIFF
--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -103,6 +103,27 @@ func NewSTSWebIdentity(stsEndpoint string, getWebIDTokenExpiry func() (*WebIdent
 	}), nil
 }
 
+// NewSTSWebIdentityWithAssumeRole is similar to NewSTSWebIdentity but allows to
+// specify a role to assume.
+func NewSTSWebIdentityWithAssumeRole(stsEndpoint string, getWebIDTokenExpiry func() (*WebIdentityToken, error),
+	roleARN string, roleSessionName string) (*Credentials, error) {
+	if stsEndpoint == "" {
+		return nil, errors.New("STS endpoint cannot be empty")
+	}
+	if getWebIDTokenExpiry == nil {
+		return nil, errors.New("Web ID token and expiry retrieval function should be defined")
+	}
+	return New(&STSWebIdentity{
+		Client: &http.Client{
+			Transport: http.DefaultTransport,
+		},
+		STSEndpoint:         stsEndpoint,
+		GetWebIDTokenExpiry: getWebIDTokenExpiry,
+		roleARN:             roleARN,
+		roleSessionName:     roleSessionName,
+	}), nil
+}
+
 func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSessionName string,
 	getWebIDTokenExpiry func() (*WebIdentityToken, error)) (AssumeRoleWithWebIdentityResponse, error) {
 	idToken, err := getWebIDTokenExpiry()


### PR DESCRIPTION
Hi,

The purpose of this PR is to be able to use a role in one AWS account which has no abilities except assuming a second role in a different account which has the correct policy to manage S3 buckets.

I've yet to test it but If someone sees this and thinks this is already possible then I would appreciate if you could show me how it can be done.

Otherwise I'd welcome your inputs about this :)

Regards.