### PR TITLE
lifecycle: And xml tag should always show both Prefix & Tag

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -142,9 +142,9 @@ func (t Transition) MarshalXML(en *xml.Encoder, startElement xml.StartElement) e
 
 // And And Rule for LifecycleTag, to be used in LifecycleRuleFilter
 type And struct {
-	XMLName xml.Name `xml:"And,omitempty" json:"-"`
-	Prefix  string   `xml:"Prefix,omitempty" json:"Prefix,omitempty"`
-	Tags    []Tag    `xml:"Tag,omitempty" json:"Tags,omitempty"`
+	XMLName xml.Name `xml:"And" json:"-"`
+	Prefix  string   `xml:"Prefix" json:"Prefix,omitempty"`
+	Tags    []Tag    `xml:"Tag" json:"Tags,omitempty"`
 }
 
 // IsEmpty returns true if Tags field is null


### PR DESCRIPTION
<And> is lifecycle is used when you want to specify a prefix and tag or
multiple tags with empty prefix (Prefix tag inside And should always be
there even if it is empty). Therefore, fields inside <And> should
always be visible for the S3 server, hence removing omitempty from xml
tag.

Signed-off-by: Anis Elleuch <anis@min.io>