### PR TITLE
fix: prevent out of memory by explicitly allocating buffer

### DIFF
--- a/api-get-object-file.go
+++ b/api-get-object-file.go
@@ -107,7 +107,8 @@ func (c Client) FGetObject(ctx context.Context, bucketName, objectName, filePath
 	}
 
 	// Write to the part file.
-	if _, err = io.CopyN(filePart, objectReader, objectStat.Size); err != nil {
+	buffer := make([]byte, 1024 * 1024)
+	if _, err = io.CopyBuffer(filePart, io.LimitReader(objectReader, objectStat.Size), buffer); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR prevents out of memory errors by explicitly allocating a reasonably sized buffer.

The function io.CopyN allocates a buffer (indirectly in a helper function, see: https://golang.org/src/io/io.go#L413) with the same size as the provided value for param 'n'. 

Even for very large values of 'n' (read: downloading very large objects) this is usually not a problem as the required memory isn't allocated until it is actually written to. Because Reader.Read implementation are highly unlikely to use the entire buffer provided (or even a substantial part it for very large buffers), everything works just fine.

Under certain circumstances this large buffer however becomes a serious problem, leading to inevitable out of memory issues. Unfortunately this is quite difficult to reproduce as the number of bytes written by a single call to Reader.Read is largely outside the sphere of influence of a programmer.

What consistently triggered the problem in our setup was a combination of large objects (few dozens of GiBs), high bandwidth between client en server (10Gbps), plenty of cpu power available on the client side and a sudden increase in load on the server lowering the upload speed of individual requests. 