### PR TITLE
Mint - Avoid invalid JSON output

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -11287,7 +11287,7 @@ func testRemoveObjects() {
 
 	_, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{})
 	if err != nil {
-		log.Fatalln(err)
+		logError(testName, function, args, startTime, "", "Error uploading object", err)
 	}
 
 	// Replace with smaller...
@@ -11297,7 +11297,7 @@ func testRemoveObjects() {
 
 	_, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{})
 	if err != nil {
-		log.Fatalln(err)
+		logError(testName, function, args, startTime, "", "Error uploading object", err)
 	}
 
 	t := time.Date(2030, time.April, 25, 14, 0, 0, 0, time.UTC)

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -11285,22 +11285,20 @@ func testRemoveObjects() {
 	var reader = getDataReader("datafile-129-MB")
 	defer reader.Close()
 
-	n, err := c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{})
+	_, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}
-	log.Println("Uploaded", objectName, " of size: ", n, "to bucket: ", bucketName, "Successfully.")
 
 	// Replace with smaller...
 	bufSize = dataFileMap["datafile-10-kB"]
 	reader = getDataReader("datafile-10-kB")
 	defer reader.Close()
 
-	n, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{})
+	_, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}
-	log.Println("Uploaded", objectName, " of size: ", n, "to bucket: ", bucketName, "Successfully.")
 
 	t := time.Date(2030, time.April, 25, 14, 0, 0, 0, time.UTC)
 	m := minio.RetentionMode(minio.Governance)


### PR DESCRIPTION
## Description

The console outputs have been removed.

 

## Motivation and Context

Testing with Mint Suite generates a log.json file. We want to process the file, but MinIO Go generates invalid JSON.
 

## How to test this PR?

Running the tests against a `minio server data{1...4}` should now return a valid JSON.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Optimization (provides speedup with no functional changes)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

 

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)

- [ ] Documentation updated

- [ ] Unit tests added/updated