### PR TITLE
fix: use default IAM endpoint when fetching IMDSv2 token

### DIFF
--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -181,10 +181,6 @@ type ec2RoleCredRespBody struct {
 // be sent to fetch the rolling access credentials.
 // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 func getIAMRoleURL(endpoint string) (*url.URL, error) {
-	if endpoint == "" {
-		endpoint = defaultIAMRoleEndpoint
-	}
-
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -281,6 +277,10 @@ func fetchIMDSToken(client *http.Client, endpoint string) (string, error) {
 // If the credentials cannot be found, or there is an error
 // reading the response an error will be returned.
 func getCredentials(client *http.Client, endpoint string) (ec2RoleCredRespBody, error) {
+	if endpoint == "" {
+		endpoint = defaultIAMRoleEndpoint
+	}
+
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 	token, _ := fetchIMDSToken(client, endpoint)
 


### PR DESCRIPTION
If a custom IAM endpoint is not specified, the IAM credential provider did not use the default endpoint to fetch the IMDSv2 token. This changes sets the default earlier so it is used for fetching the token.