### PR TITLE
fix: add startAfter support for listing operations

### DIFF
--- a/core.go
+++ b/core.go
@@ -52,7 +52,7 @@ func (c Core) ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
 // ListObjectsV2 - Lists all the objects at a prefix, similar to ListObjects() but uses
 // continuationToken instead of marker to support iteration over the results.
 func (c Core) ListObjectsV2(bucketName, objectPrefix, continuationToken string, fetchOwner bool, delimiter string, maxkeys int) (ListBucketV2Result, error) {
-	return c.listObjectsV2Query(context.Background(), bucketName, objectPrefix, continuationToken, fetchOwner, false, delimiter, maxkeys, nil)
+	return c.listObjectsV2Query(context.Background(), bucketName, objectPrefix, continuationToken, fetchOwner, false, delimiter, "", maxkeys, nil)
 }
 
 // CopyObject - copies an object from source object to destination object on server side.


### PR DESCRIPTION
use startAfter as marker when using ListObjectsV1

fixes https://github.com/minio/minio/issues/12611