### PR TITLE
ignore Tenant in ListVersionsResult

### DIFF
--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -177,6 +177,7 @@ func (l *ListVersionsResult) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 					v.isDeleteMarker = true
 				}
 				l.Versions = append(l.Versions, v)
+			case "Tenant":
 			default:
 				return errors.New("unrecognized option:" + tagName)
 			}


### PR DESCRIPTION
Currently, mc-client can not list versions of files on a tenanted ceph-rgw bucket

```
$ mc ls mwentest1/objlocktest/testfile2  --versions
mc: <ERROR> Unable to list folder. unrecognized option:Tenant
```

Reason is, that ListVersionsResult from ceph contains a `Tenant` field:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <EncodingType>url</EncodingType>
   <Tenant>test</Tenant>
   <Name>objlocktest</Name>
   <Prefix />
   <MaxKeys>1000</MaxKeys>
   <IsTruncated>false</IsTruncated>
   <KeyMarker>testfile2</KeyMarker>
   <VersionIdMarker />
   <Version>
      <Key>testfile2</Key>
      <VersionId>NzbKDjj7Y7o60IWSTsCOqopmVaDNgjZ</VersionId>
      <IsLatest>true</IsLatest>
      <LastModified>2021-07-23T09:41:03.920Z</LastModified>
      <ETag>"f0f396aeb3e8cd021b6e958d6decbb1b"</ETag>
      <Size>2097152</Size>
      <StorageClass>STANDARD</StorageClass>
      <Owner>
         <ID>test$cd4eac58-46a5-b59f-4a31-2ec207baa817</ID>
         <DisplayName>cd4eac58-46a5-b59f-4a31-2ec207baa817</DisplayName>
      </Owner>
      <Type>Normal</Type>
   </Version>
</ListVersionsResult>
```

With this commit that `Tenant` field gets simply ignored and the versions can now be listed:

```
$ ./mc ls mwentest1/objlocktest/testfile2  --versions
[2021-07-23 11:41:03 CEST] 2.0MiB NzbKDjj7Y7o60IWSTsCOqopmVaDNgjZ v1 PUT testfile2

```