### PR TITLE
Faster header checks.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -397,19 +397,20 @@ func getDefaultLocation(u url.URL, regionOverride string) (location string) {
 	return region
 }
 
-var supportedHeaders = []string{
-	"content-type",
-	"cache-control",
-	"content-encoding",
-	"content-disposition",
-	"content-language",
-	"x-amz-website-redirect-location",
-	"x-amz-object-lock-mode",
-	"x-amz-metadata-directive",
-	"x-amz-object-lock-retain-until-date",
-	"expires",
-	"x-amz-replication-status",
+var supportedHeaders = map[string]bool{
+	"content-type":                        true,
+	"cache-control":                       true,
+	"content-encoding":                    true,
+	"content-disposition":                 true,
+	"content-language":                    true,
+	"x-amz-website-redirect-location":     true,
+	"x-amz-object-lock-mode":              true,
+	"x-amz-metadata-directive":            true,
+	"x-amz-object-lock-retain-until-date": true,
+	"expires":                             true,
+	"x-amz-replication-status":            true,
 	// Add more supported headers here.
+	// Must be lower case.
 }
 
 // isStorageClassHeader returns true if the header is a supported storage class header
@@ -419,34 +420,24 @@ func isStorageClassHeader(headerKey string) bool {
 
 // isStandardHeader returns true if header is a supported header and not a custom header
 func isStandardHeader(headerKey string) bool {
-	key := strings.ToLower(headerKey)
-	for _, header := range supportedHeaders {
-		if strings.ToLower(header) == key {
-			return true
-		}
-	}
-	return false
+	return supportedHeaders[strings.ToLower(headerKey)]
 }
 
 // sseHeaders is list of server side encryption headers
-var sseHeaders = []string{
-	"x-amz-server-side-encryption",
-	"x-amz-server-side-encryption-aws-kms-key-id",
-	"x-amz-server-side-encryption-context",
-	"x-amz-server-side-encryption-customer-algorithm",
-	"x-amz-server-side-encryption-customer-key",
-	"x-amz-server-side-encryption-customer-key-MD5",
+var sseHeaders = map[string]bool{
+	"x-amz-server-side-encryption":                    true,
+	"x-amz-server-side-encryption-aws-kms-key-id":     true,
+	"x-amz-server-side-encryption-context":            true,
+	"x-amz-server-side-encryption-customer-algorithm": true,
+	"x-amz-server-side-encryption-customer-key":       true,
+	"x-amz-server-side-encryption-customer-key-md5":   true,
+	// Add more supported headers here.
+	// Must be lower case.
 }
 
 // isSSEHeader returns true if header is a server side encryption header.
 func isSSEHeader(headerKey string) bool {
-	key := strings.ToLower(headerKey)
-	for _, h := range sseHeaders {
-		if strings.ToLower(h) == key {
-			return true
-		}
-	}
-	return false
+	return sseHeaders[strings.ToLower(headerKey)]
 }
 
 // isAmzHeader returns true if header is a x-amz-meta-* or x-amz-acl header.


### PR DESCRIPTION
Just do a single lookup instead of converting all headers.