### PR TITLE
sts: Always slash expiry time by 80%

### DIFF
--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -38,8 +38,9 @@ import (
 // prior to the credentials actually expiring. This is beneficial
 // so race conditions with expiring credentials do not cause
 // request to fail unexpectedly due to ExpiredTokenException exceptions.
-// When set to -1, which is the default value, refreshing will be triggered
-// when 80% of the elapsed time until the actual expiration time is passed.
+// DefaultExpiryWindow can be used as parameter to (*Expiry).SetExpiration.
+// When used the tokens refresh will be triggered when 80% of the elapsed
+// time until the actual expiration time is passed.
 const DefaultExpiryWindow = -1
 
 // A IAM retrieves credentials from the EC2 service, and keeps track if

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -38,7 +38,9 @@ import (
 // prior to the credentials actually expiring. This is beneficial
 // so race conditions with expiring credentials do not cause
 // request to fail unexpectedly due to ExpiredTokenException exceptions.
-const DefaultExpiryWindow = time.Second * 10 // 10 secs
+// When set to -1, which is the default value, refreshing will be triggered
+// when 80% of the elapsed time until the actual expiration time is passed.
+const DefaultExpiryWindow = -1
 
 // A IAM retrieves credentials from the EC2 service, and keeps track if
 // those credentials are expired.


### PR DESCRIPTION
Not tested yet.

By default, STS expiration time is reduced by 10 seconds, but this is
not always good since an S3 call can be called near expiration time but
evaluated after the expiration time - the window here is 10 seconds
which can be not enough to upload some large data to an S3 server before
this latter rejects it with bad (expired) credentials.

This commit will always slash expiration time by 80% instead.