### PR TITLE
Fix headers passed while enabling versioning

### DIFF
--- a/api-bucket-versioning.go
+++ b/api-bucket-versioning.go
@@ -47,7 +47,6 @@ func (c *Client) SetBucketVersioning(ctx context.Context, bucketName string, con
 		bucketName:       bucketName,
 		queryValues:      urlValues,
 		contentBody:      bytes.NewReader(buf),
-		contentLength:    int64(len(buf)),
 		contentMD5Base64: sumMD5Base64(buf),
 		contentSHA256Hex: sum256Hex(buf),
 	}


### PR DESCRIPTION
I've used the below code to start a minio container and connect to it using go sdk, fails with ` A header you provided implies functionality that is not implemented`
I'm running minio container as per their docs with `docker run --rm -d -p 9000:9000 -p 9001:9001 quay.io/minio/minio server /data --console-address ":9001"`
```
package main

import (
	"context"
	"log"

	"github.com/minio/minio-go/v7"
	"github.com/minio/minio-go/v7/pkg/credentials"
)

func main() {
	var err error
	ctx := context.TODO()

	// create a minio client
	minioClient, err := minio.New("127.0.0.1:9000", &minio.Options{
		Creds:  credentials.NewStaticV4("minioadmin", "minioadmin", ""),
		Secure: false,
	})
	if err != nil {
		log.Fatal(err)
	}

	// create a test bucket
	testBucketName := "rps--ci--test-bucket"
	if err = minioClient.MakeBucket(ctx, testBucketName, minio.MakeBucketOptions{}); err != nil {
		log.Fatal(err)
	}

	// enable versioning on test bucket
	if err = minioClient.EnableVersioning(ctx, testBucketName); err != nil {
		log.Fatal(err)
	}
}
```