### PR TITLE
replication: Allow null version to be specified in options

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -243,8 +243,10 @@ func (c *Client) copyObjectDo(ctx context.Context, srcBucket, srcObject, destBuc
 		customHeader: headers,
 	}
 	if dstOpts.Internal.SourceVersionID != "" {
-		if _, err := uuid.Parse(dstOpts.Internal.SourceVersionID); err != nil {
-			return ObjectInfo{}, errInvalidArgument(err.Error())
+		if dstOpts.Internal.SourceVersionID != nullVersionID {
+			if _, err := uuid.Parse(dstOpts.Internal.SourceVersionID); err != nil {
+				return ObjectInfo{}, errInvalidArgument(err.Error())
+			}
 		}
 		urlValues := make(url.Values)
 		urlValues.Set("versionId", dstOpts.Internal.SourceVersionID)

--- a/api-put-object-common.go
+++ b/api-put-object-common.go
@@ -26,6 +26,8 @@ import (
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
 
+const nullVersionID = "null"
+
 // Verify if reader is *minio.Object
 func isObject(reader io.Reader) (ok bool) {
 	_, ok = reader.(*Object)

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -200,8 +200,10 @@ func (c *Client) initiateMultipartUpload(ctx context.Context, bucketName, object
 	urlValues.Set("uploads", "")
 
 	if opts.Internal.SourceVersionID != "" {
-		if _, err := uuid.Parse(opts.Internal.SourceVersionID); err != nil {
-			return initiateMultipartUploadResult{}, errInvalidArgument(err.Error())
+		if opts.Internal.SourceVersionID != nullVersionID {
+			if _, err := uuid.Parse(opts.Internal.SourceVersionID); err != nil {
+				return initiateMultipartUploadResult{}, errInvalidArgument(err.Error())
+			}
 		}
 		urlValues.Set("versionId", opts.Internal.SourceVersionID)
 	}

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -452,8 +452,10 @@ func (c *Client) putObjectDo(ctx context.Context, bucketName, objectName string,
 		contentSHA256Hex: sha256Hex,
 	}
 	if opts.Internal.SourceVersionID != "" {
-		if _, err := uuid.Parse(opts.Internal.SourceVersionID); err != nil {
-			return UploadInfo{}, errInvalidArgument(err.Error())
+		if opts.Internal.SourceVersionID != nullVersionID {
+			if _, err := uuid.Parse(opts.Internal.SourceVersionID); err != nil {
+				return UploadInfo{}, errInvalidArgument(err.Error())
+			}
 		}
 		urlValues := make(url.Values)
 		urlValues.Set("versionId", opts.Internal.SourceVersionID)


### PR DESCRIPTION
This is for supporting existing object replication