### PR TITLE
Fix IsAmazonFIPSGovCloudEndpoint method

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -171,6 +171,7 @@ func IsAmazonFIPSGovCloudEndpoint(endpointURL url.URL) bool {
 		return false
 	}
 	return endpointURL.Host == "s3-fips-us-gov-west-1.amazonaws.com" ||
+		endpointURL.Host == "s3-fips.us-gov-west-1.amazonaws.com" ||
 		endpointURL.Host == "s3-fips.dualstack.us-gov-west-1.amazonaws.com"
 }
 

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -55,6 +55,10 @@ func TestGetRegionFromURL(t *testing.T) {
 			expectedRegion: "us-gov-west-1",
 		},
 		{
+			u:              url.URL{Host: "s3-fips.us-gov-west-1.amazonaws.com"},
+			expectedRegion: "us-gov-west-1",
+		},
+		{
 			u:              url.URL{Host: "s3-us-gov-west-1.amazonaws.com"},
 			expectedRegion: "us-gov-west-1",
 		},

--- a/utils_test.go
+++ b/utils_test.go
@@ -118,6 +118,7 @@ func TestIsValidEndpointURL(t *testing.T) {
 		{"https://s3.cn-north-1.amazonaws.com.cn", nil, true},
 		{"https://s3-us-gov-west-1.amazonaws.com", nil, true},
 		{"https://s3-fips-us-gov-west-1.amazonaws.com", nil, true},
+		{"https://s3-fips.us-gov-west-1.amazonaws.com", nil, true},
 		{"https://s3.amazonaws.com/", nil, true},
 		{"https://storage.googleapis.com/", nil, true},
 		{"https://z3.amazonaws.com", nil, true},


### PR DESCRIPTION
 ## Description
 The check for amazon fips govcloud endpoint is not correct (maybe outdated?)
If we look at https://aws.amazon.com/compliance/fips/ the correct endpoint is:
 `s3-fips.us-gov-west-1.amazonaws.com`
instead of
`s3-fips-us-gov-west-1.amazonaws.com`

This cause the region to be set to `fips.us-gov-west-1` instead of `us-gov-west-1` when using `s3-fips.us-gov-west-1.amazonaws.com` endpoint.
 
 ## Motivation and Context
 Trying to connect to `s3-fips.us-gov-west-1.amazonaws.com` returns a malformed header error
```
"The authorization header is malformed; the region 'fips.us-gov-west-1' is wrong; expecting 'us-east-1'"
``` 

P.S: The error is also wrong about the expecting region but it's a different issue

 ## How to test this PR?
Try to connect to `s3-fips.us-gov-west-1.amazonaws.com`, ensure the region is set to `us-gov-west-1`
 
 ## Types of changes
 * [x]  Bug fix (non-breaking change which fixes an issue)
 * [ ]  New feature (non-breaking change which adds functionality)
 * [ ]  Optimization (provides speedup with no functional changes)
 * [x]  Breaking change (fix or feature that would cause existing functionality to change)
 
Technically it's a breaking change if the previous endpoint was used. I'm not sure if it's an initial typo or if the endpoint has changed on AWS side. As the endpoint is no longer listed in aws doc I suppose it doesn't exist anyway so there would be no impact here

 ## Checklist:
 * [ ]  Fixes a regression (If yes, please add `commit-id` or `PR #` here)
 * [ ]  Documentation updated
 * [x]  Unit tests added/updated

