### PR TITLE
Add support for S3 PrivateLink interface endpoints

### DIFF
--- a/api.go
+++ b/api.go
@@ -908,8 +908,8 @@ func (c *Client) makeTargetURL(bucketName, objectName, bucketLocation string, is
 			// http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html
 			host = c.s3AccelerateEndpoint
 		} else {
-			// Do not change the host if the endpoint URL is a FIPS S3 endpoint.
-			if !s3utils.IsAmazonFIPSEndpoint(*c.endpointURL) {
+			// Do not change the host if the endpoint URL is a FIPS S3 endpoint or a S3 PrivateLink interface endpoint
+			if !s3utils.IsAmazonFIPSEndpoint(*c.endpointURL) && !s3utils.IsAmazonPrivateLinkEndpoint(*c.endpointURL) {
 				// Fetch new host based on the bucket location.
 				host = getS3Endpoint(bucketLocation)
 			}

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -104,6 +104,9 @@ var elbAmazonRegex = regexp.MustCompile(`elb(.*?).amazonaws.com$`)
 // Regular expression used to determine if the arg is elb host in china.
 var elbAmazonCnRegex = regexp.MustCompile(`elb(.*?).amazonaws.com.cn$`)
 
+// amazonS3HostPrivateLink - regular expression used to determine if an arg is s3 host in AWS PrivateLink interface endpoints style
+var amazonS3HostPrivateLink = regexp.MustCompile(`^(?:bucket|accesspoint).vpce-.*?.s3.(.*?).vpce.amazonaws.com$`)
+
 // GetRegionFromURL - returns a region from url host.
 func GetRegionFromURL(endpointURL url.URL) string {
 	if endpointURL == sentinelURL {
@@ -136,6 +139,10 @@ func GetRegionFromURL(endpointURL url.URL) string {
 		return parts[1]
 	}
 	parts = amazonS3HostDot.FindStringSubmatch(endpointURL.Host)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	parts = amazonS3HostPrivateLink.FindStringSubmatch(endpointURL.Host)
 	if len(parts) > 1 {
 		return parts[1]
 	}
@@ -200,6 +207,15 @@ func IsAmazonFIPSUSEastWestEndpoint(endpointURL url.URL) bool {
 // See https://aws.amazon.com/compliance/fips.
 func IsAmazonFIPSEndpoint(endpointURL url.URL) bool {
 	return IsAmazonFIPSUSEastWestEndpoint(endpointURL) || IsAmazonFIPSGovCloudEndpoint(endpointURL)
+}
+
+// IsAmazonPrivateLinkEndpoint - Match if it is exactly Amazon S3 PrivateLink interface endpoint
+// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html.
+func IsAmazonPrivateLinkEndpoint(endpointURL url.URL) bool {
+	if endpointURL == sentinelURL {
+		return false
+	}
+	return amazonS3HostPrivateLink.MatchString(endpointURL.Host)
 }
 
 // IsGoogleEndpoint - Match if it is exactly Google cloud storage endpoint.

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -103,6 +103,18 @@ func TestGetRegionFromURL(t *testing.T) {
 				Host: "s3.kubernetesfrontendlb-caf78da2b1f7516c.elb.amazonaws.com.cn",
 			},
 		},
+		{
+			u: url.URL{
+				Host: "bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com",
+			},
+			expectedRegion: "us-east-1",
+		},
+		{
+			u: url.URL{
+				Host: "accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com",
+			},
+			expectedRegion: "us-east-1",
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -223,6 +235,8 @@ func TestIsAmazonEndpoint(t *testing.T) {
 		{"https://s3-us-west-1.amazonaws.com", true},
 		{"https://s3.us-west-1.amazonaws.com", true},
 		{"https://s3.dualstack.us-west-1.amazonaws.com", true},
+		{"https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com", true},
+		{"https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com", true},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
Add support for S3 endpoints defined in a virtual private cloud (VPC) by AWS PrivateLink for Amazon S3.
See [https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html)