### PR TITLE
Report non-XML formated error details

### DIFF
--- a/api-error-response.go
+++ b/api-error-response.go
@@ -101,11 +101,12 @@ const (
 	reportIssue = "Please report this issue at https://github.com/minio/minio-go/issues."
 )
 
-// xmlDecodeAndBody reads the whole body up to a certain limit and tries to XML
-// decode it. In any case the read body will be returned.
+// xmlDecodeAndBody reads the whole body up to 1MB and
+// tries to XML decode it into v.
+// The body that was read and any error from reading or decoding is returned.
 func xmlDecodeAndBody(bodyReader io.Reader, v interface{}) ([]byte, error) {
-	// read the whole body (up to a certain limit)
-	const maxBodyLength = int64(1024 * 1024)
+	// read the whole body (up to 1MB)
+	const maxBodyLength = 1 << 20
 	body, err := ioutil.ReadAll(io.LimitReader(bodyReader, maxBodyLength))
 	if err != nil {
 		return nil, err
@@ -174,6 +175,9 @@ func httpRespToErrorResponse(resp *http.Response, bucketName, objectName string)
 			msg := resp.Status
 			if len(errBody) > 0 {
 				msg = string(errBody)
+				if len(msg) > 1024 {
+					msg = msg[:1024] + "..."
+				}
 			}
 			errResp = ErrorResponse{
 				StatusCode: resp.StatusCode,

--- a/api-error-response_test.go
+++ b/api-error-response_test.go
@@ -112,6 +112,7 @@ func TestHttpRespToErrorResponse(t *testing.T) {
 	genEmptyBodyResponse := func(statusCode int) *http.Response {
 		resp := &http.Response{
 			StatusCode: statusCode,
+			Status:     http.StatusText(statusCode),
 			Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		}
 		setCommonHeaders(resp)
@@ -181,6 +182,7 @@ func TestHttpRespToErrorResponse(t *testing.T) {
 		{"minio-bucket", "Asia/", inputResponses[3], expectedErrResponse[3]},
 		{"minio-bucket", "", inputResponses[4], expectedErrResponse[4]},
 		{"minio-bucket", "", inputResponses[5], expectedErrResponse[5]},
+		{"minio-bucket", "", inputResponses[6], expectedErrResponse[6]},
 		{"minio-bucket", "", inputResponses[7], expectedErrResponse[7]},
 		{"minio-bucket", "", inputResponses[8], expectedErrResponse[8]},
 	}


### PR DESCRIPTION
This avoids hiding further error context in the case when it is coming from a layer, which is not necessarily using the S3 XML error format.

Note: The separate commit also ensures an unrelated test case is called