### PR TITLE
policy: Removing a bucket policy should return an error

### DIFF
--- a/api-bucket-policy.go
+++ b/api-bucket-policy.go
@@ -87,6 +87,11 @@ func (c *Client) removeBucketPolicy(ctx context.Context, bucketName string) erro
 	if err != nil {
 		return err
 	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return httpRespToErrorResponse(resp, bucketName, "")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Currently removing a policy from bucket does not return an error for any
error, such as AccessDenied.

This commit fixes this behavior.

Fixes https://github.com/minio/minio-go/issues/1608