### PR TITLE
Allow to pass headers in Presigned API

### DIFF
--- a/api-presigned.go
+++ b/api-presigned.go
@@ -66,11 +66,11 @@ func (c *Client) presignURL(ctx context.Context, method string, bucketName strin
 // data without credentials. URL can have a maximum expiry of
 // upto 7days or a minimum of 1sec. Additionally you can override
 // a set of response headers using the query parameters.
-func (c *Client) PresignedGetObject(ctx context.Context, bucketName string, objectName string, expires time.Duration, reqParams url.Values) (u *url.URL, err error) {
+func (c *Client) PresignedGetObject(ctx context.Context, bucketName string, objectName string, expires time.Duration, reqParams url.Values, extraHeaders http.Header) (u *url.URL, err error) {
 	if err = s3utils.CheckValidObjectName(objectName); err != nil {
 		return nil, err
 	}
-	return c.presignURL(ctx, http.MethodGet, bucketName, objectName, expires, reqParams, nil)
+	return c.presignURL(ctx, http.MethodGet, bucketName, objectName, expires, reqParams, extraHeaders)
 }
 
 // PresignedHeadObject - Returns a presigned URL to access
@@ -87,11 +87,11 @@ func (c *Client) PresignedHeadObject(ctx context.Context, bucketName string, obj
 // PresignedPutObject - Returns a presigned URL to upload an object
 // without credentials. URL can have a maximum expiry of upto 7days
 // or a minimum of 1sec.
-func (c *Client) PresignedPutObject(ctx context.Context, bucketName string, objectName string, expires time.Duration) (u *url.URL, err error) {
+func (c *Client) PresignedPutObject(ctx context.Context, bucketName string, objectName string, expires time.Duration, reqParams url.Values, extraHeaders http.Header) (u *url.URL, err error) {
 	if err = s3utils.CheckValidObjectName(objectName); err != nil {
 		return nil, err
 	}
-	return c.presignURL(ctx, http.MethodPut, bucketName, objectName, expires, nil, nil)
+	return c.presignURL(ctx, http.MethodPut, bucketName, objectName, expires, reqParams, extraHeaders)
 }
 
 // PresignHeader - similar to Presign() but allows including HTTP headers that

--- a/docs/API.md
+++ b/docs/API.md
@@ -1169,7 +1169,7 @@ if err != nil {
 ## 4. Presigned operations
 
 <a name="PresignedGetObject"></a>
-### PresignedGetObject(ctx context.Context, bucketName, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error)
+### PresignedGetObject(ctx context.Context, bucketName, objectName string, expiry time.Duration, reqParams url.Values, extraHeaders http.Header) (*url.URL, error)
 Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The maximum expiry is 604800 seconds (i.e. 7 days) and minimum is 1 second. 
 
 __Parameters__
@@ -1182,7 +1182,7 @@ __Parameters__
 |`objectName` | _string_  |Name of the object   |
 |`expiry` | _time.Duration_  |Expiry of presigned URL in seconds   |
 |`reqParams` | _url.Values_  |Additional response header overrides supports _response-expires_, _response-content-type_, _response-cache-control_, _response-content-disposition_.  |
-
+|`extraHeaders` | _map[string]string_ | Additional header passed to the HTTP request |
 
 __Example__
 
@@ -1193,7 +1193,7 @@ reqParams := make(url.Values)
 reqParams.Set("response-content-disposition", "attachment; filename=\"your-filename.txt\"")
 
 // Generates a presigned url which expires in a day.
-presignedURL, err := minioClient.PresignedGetObject(context.Background(), "mybucket", "myobject", time.Second * 24 * 60 * 60, reqParams)
+presignedURL, err := minioClient.PresignedGetObject(context.Background(), "mybucket", "myobject", time.Second * 24 * 60 * 60, reqParams, nil)
 if err != nil {
     fmt.Println(err)
     return
@@ -1202,7 +1202,7 @@ fmt.Println("Successfully generated presigned URL", presignedURL)
 ```
 
 <a name="PresignedPutObject"></a>
-### PresignedPutObject(ctx context.Context, bucketName, objectName string, expiry time.Duration) (*url.URL, error)
+### PresignedPutObject(ctx context.Context, bucketName string, objectName string, expires time.Duration, reqParams url.Values, extraHeaders http.Header) (*url.URL, error)
 Generates a presigned URL for HTTP PUT operations. Browsers/Mobile clients may point to this URL to upload objects directly to a bucket even if it is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The default expiry is set to 7 days.
 
 NOTE: you can upload to S3 only with specified object name.
@@ -1216,7 +1216,8 @@ __Parameters__
 |`bucketName`  | _string_  |Name of the bucket   |
 |`objectName` | _string_  |Name of the object   |
 |`expiry` | _time.Duration_  |Expiry of presigned URL in seconds |
-
+|`reqParams` | _url.Values_  |Additional response header overrides supports _response-expires_, _response-content-type_, _response-cache-control_, _response-content-disposition_.  |
+|`extraHeaders` | _map[string]string_ | Additional header passed to the HTTP request |
 
 __Example__
 
@@ -1224,7 +1225,7 @@ __Example__
 ```go
 // Generates a url which expires in a day.
 expiry := time.Second * 24 * 60 * 60 // 1 day.
-presignedURL, err := minioClient.PresignedPutObject(context.Background(), "mybucket", "myobject", expiry)
+presignedURL, err := minioClient.PresignedPutObject(context.Background(), "mybucket", "myobject", expiry, nil, nil)
 if err != nil {
     fmt.Println(err)
     return

--- a/examples/s3/presignedgetobject.go
+++ b/examples/s3/presignedgetobject.go
@@ -52,7 +52,7 @@ func main() {
 	reqParams.Set("response-content-disposition", "attachment; filename=\"your-filename.txt\"")
 
 	// Gernerate presigned get object url.
-	presignedURL, err := s3Client.PresignedGetObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, reqParams)
+	presignedURL, err := s3Client.PresignedGetObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, reqParams, nil)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/presignedputobjectencrypted.go
+++ b/examples/s3/presignedputobjectencrypted.go
@@ -46,9 +46,18 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	presignedURL, err := s3Client.PresignedPutObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, nil, nil)
+	//Require server side encrytpion of type SSE-KMS
+	extraHeadersSSEKMS := map[string][]string{
+		"x-amz-server-side-encryption":                {"aws:kms"},
+		"x-amz-server-side-encryption-aws-kms-key-id": {"alias/YOUR_KMS_KEY_ALIAS"},
+	}
+
+	//Generate a put URL for an object and enforce KMS encryption. 
+	presignedURL, err := s3Client.PresignedPutObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, nil, extraHeadersSSEKMS)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	log.Println(presignedURL)
+	log.Println("Successfully generated presigned URL", presignedURL)
+	// Remember that to put the object you will need to precise the headers again in your post request. 
+	// e.g. curl -X PUT -d @/tmp/data.txt -H "x-amz-server-side-encryption: aws:kms" -H "x-amz-server-side-encryption-aws-kms-key-id: alias/YOUR_KMS_KEY_ALIAS" $presignedURL
 }

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -6067,28 +6067,28 @@ func testFunctional() {
 	}
 	resp.Body.Close()
 
-	function = "PresignedGetObject(bucketName, objectName, expires, reqParams)"
+	function = "PresignedGetObject(bucketName, objectName, expires, reqParams, extraHeaders)"
 	functionAll += ", " + function
 	args = map[string]interface{}{
 		"bucketName": bucketName,
 		"objectName": "",
 		"expires":    3600 * time.Second,
 	}
-	_, err = c.PresignedGetObject(context.Background(), bucketName, "", 3600*time.Second, nil)
+	_, err = c.PresignedGetObject(context.Background(), bucketName, "", 3600*time.Second, nil, nil)
 	if err == nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject success", err)
 		return
 	}
 
 	// Generate presigned GET object url.
-	function = "PresignedGetObject(bucketName, objectName, expires, reqParams)"
+	function = "PresignedGetObject(bucketName, objectName, expires, reqParams, extraHeaders)"
 	functionAll += ", " + function
 	args = map[string]interface{}{
 		"bucketName": bucketName,
 		"objectName": objectName,
 		"expires":    3600 * time.Second,
 	}
-	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, nil)
+	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, nil, nil)
 
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
@@ -6131,7 +6131,7 @@ func testFunctional() {
 		"expires":    3600 * time.Second,
 		"reqParams":  reqParams,
 	}
-	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, reqParams)
+	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, reqParams, nil)
 
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
@@ -6168,27 +6168,27 @@ func testFunctional() {
 		return
 	}
 
-	function = "PresignedPutObject(bucketName, objectName, expires)"
+	function = "PresignedPutObject(bucketName, objectName, expires, reqParams, extraHeaders)"
 	functionAll += ", " + function
 	args = map[string]interface{}{
 		"bucketName": bucketName,
 		"objectName": "",
 		"expires":    3600 * time.Second,
 	}
-	_, err = c.PresignedPutObject(context.Background(), bucketName, "", 3600*time.Second)
+	_, err = c.PresignedPutObject(context.Background(), bucketName, "", 3600*time.Second, nil, nil)
 	if err == nil {
 		logError(testName, function, args, startTime, "", "PresignedPutObject success", err)
 		return
 	}
 
-	function = "PresignedPutObject(bucketName, objectName, expires)"
+	function = "PresignedPutObject(bucketName, objectName, expires, reqParams, extraHeaders)"
 	functionAll += ", " + function
 	args = map[string]interface{}{
 		"bucketName": bucketName,
 		"objectName": objectName + "-presigned",
 		"expires":    3600 * time.Second,
 	}
-	presignedPutURL, err := c.PresignedPutObject(context.Background(), bucketName, objectName+"-presigned", 3600*time.Second)
+	presignedPutURL, err := c.PresignedPutObject(context.Background(), bucketName, objectName+"-presigned", 3600*time.Second, nil, nil)
 
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedPutObject failed", err)
@@ -10957,14 +10957,14 @@ func testFunctionalV2() {
 	resp.Body.Close()
 
 	// Generate presigned GET object url.
-	function = "PresignedGetObject(bucketName, objectName, expires, reqParams)"
+	function = "PresignedGetObject(bucketName, objectName, expires, reqParams, extraHeaders)"
 	functionAll += ", " + function
 	args = map[string]interface{}{
 		"bucketName": bucketName,
 		"objectName": objectName,
 		"expires":    3600 * time.Second,
 	}
-	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, nil)
+	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, nil, nil)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
 		return
@@ -11003,7 +11003,7 @@ func testFunctionalV2() {
 	reqParams.Set("response-content-disposition", "attachment; filename=\"test.txt\"")
 	// Generate presigned GET object url.
 	args["reqParams"] = reqParams
-	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, reqParams)
+	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, reqParams, nil)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
 		return
@@ -11048,7 +11048,7 @@ func testFunctionalV2() {
 		"objectName": objectName + "-presigned",
 		"expires":    3600 * time.Second,
 	}
-	presignedPutURL, err := c.PresignedPutObject(context.Background(), bucketName, objectName+"-presigned", 3600*time.Second)
+	presignedPutURL, err := c.PresignedPutObject(context.Background(), bucketName, objectName+"-presigned", 3600*time.Second, nil, nil)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedPutObject failed", err)
 		return


### PR DESCRIPTION
- Allow to pass extraHeaders to PresignedPutObject and PresignedGetObject
- Allow to pass reqParams to PresignedPutObject
- Add an example to illustrate the use of passing extraHeaders with PresignedPutObject. 

This feature will allow to create presigned URLs with extra headers. With this we can pass the headers necessary for KMS encryption in an AWS S3 setting. 

