### PR TITLE
restore: Accept http code 202 and 200 as valid response

### DIFF
--- a/api-restore.go
+++ b/api-restore.go
@@ -175,7 +175,7 @@ func (c *Client) RestoreObject(ctx context.Context, bucketName, objectName, vers
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
 		return httpRespToErrorResponse(resp, bucketName, "")
 	}
 	return nil


### PR DESCRIPTION
202 to indicate that the server initiated the restore operation
200 to indicate that the server already initiated the restore operatn

But both can be considered a valid response if we don't want to break
the existing API.

https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html