### PR TITLE
Use 1s timeout for fetching imdsv2 token

### DIFF
--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -19,6 +19,7 @@ package credentials
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -254,7 +255,10 @@ func getEcsTaskCredentials(client *http.Client, endpoint string, token string) (
 }
 
 func fetchIMDSToken(client *http.Client, endpoint string) (string, error) {
-	req, err := http.NewRequest(http.MethodPut, endpoint+tokenPath, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint+tokenPath, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
https://github.com/minio/minio-go/pull/1489 introduced IMDSv2 support. Similar to the issues described in the official AWS SDK (https://github.com/aws/aws-sdk-go/issues/2972), the IAM credential provider potentially introduces a several minute delay.

The AWS SDK solved this by setting a 1s timeout for the metadata service request. This PR adds the same timeout.

Closes https://github.com/minio/minio-go/issues/1625