### PR TITLE
fix cond expression referring wrong error variable

### DIFF
--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -171,7 +171,7 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 				}
 
 				n, rerr := readFull(io.NewSectionReader(reader, readOffset, partSize), partsBuf[w-1][:partSize])
-				if rerr != nil && rerr != io.ErrUnexpectedEOF && err != io.EOF {
+				if rerr != nil && rerr != io.ErrUnexpectedEOF && rerr != io.EOF {
 					uploadedPartsCh <- uploadedPartRes{
 						Error: rerr,
 					}


### PR DESCRIPTION
fix conditional expression referring a wrong error variable. Its seems to be a typo not detected by the compiler because `err` is a previous declared variable (named return value)