### PR TITLE
Add PresignOptions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1169,19 +1169,31 @@ if err != nil {
 ## 4. Presigned operations
 
 <a name="PresignedGetObject"></a>
-### PresignedGetObject(ctx context.Context, bucketName, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error)
+### PresignedGetObject(ctx context.Context, bucketName, objectName string, expiry time.Duration, opts minio.PresignOptions) (*url.URL, error)
 Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The maximum expiry is 604800 seconds (i.e. 7 days) and minimum is 1 second. 
 
 __Parameters__
 
 
-|Param   |Type   |Description   |
-|:---|:---| :---|
-|`ctx`  | _context.Context_  | Custom context for timeout/cancellation of the call|
-|`bucketName`  | _string_  |Name of the bucket   |
-|`objectName` | _string_  |Name of the object   |
-|`expiry` | _time.Duration_  |Expiry of presigned URL in seconds   |
-|`reqParams` | _url.Values_  |Additional response header overrides supports _response-expires_, _response-content-type_, _response-cache-control_, _response-content-disposition_.  |
+| Param        | Type                    | Description                                                                        |
+|:-------------|:------------------------|:-----------------------------------------------------------------------------------|
+| `ctx`        | _context.Context_       | Custom context for timeout/cancellation of the call                                |
+| `bucketName` | _string_                | Name of the bucket                                                                 |
+| `objectName` | _string_                | Name of the object                                                                 |
+| `expiry`     | _time.Duration_         | Expiry of presigned URL in seconds                                                 |
+| `opts`       | _minio.PresignOptions_  | Options for Pre-Signing requests specifying additional options like object version |
+
+
+__minio.PresignOptions__
+
+| Field            | Type                | Description                                                                                                                                          |
+|:-----------------|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `opts.ReqParams` | _url.Values_        | Additional response header overrides supports _response-expires_, _response-content-type_, _response-cache-control_, _response-content-disposition_. |
+| `opts.VersionID` | _string_            | Version ID of the object to delete                                                                                                                   |
+| `opts.Region`    | _string_            | To against what region should the url should be signed                                                                                               |
+| `opts.Header()`  | _map[string]string_ | Returns the headers built on this options                                                                                                            |
+| `opts.Set()`     | _function_          | Allows to set custom headers                                                                                                                         |
+
 
 
 __Example__
@@ -1210,12 +1222,12 @@ NOTE: you can upload to S3 only with specified object name.
 __Parameters__
 
 
-|Param   |Type   |Description   |
-|:---|:---| :---|
-|`ctx`  | _context.Context_  | Custom context for timeout/cancellation of the call|
-|`bucketName`  | _string_  |Name of the bucket   |
-|`objectName` | _string_  |Name of the object   |
-|`expiry` | _time.Duration_  |Expiry of presigned URL in seconds |
+| Param       | Type              | Description                                         |
+|:------------|:------------------|:----------------------------------------------------|
+| `ctx`       | _context.Context_ | Custom context for timeout/cancellation of the call |
+| `bucketName`| _string_          | Name of the bucket                                  |
+| `objectName`| _string_          | Name of the object                                  |
+| `expiry`    | _time.Duration_   | Expiry of presigned URL in seconds                  |
 
 
 __Example__
@@ -1233,18 +1245,30 @@ fmt.Println("Successfully generated presigned URL", presignedURL)
 ```
 
 <a name="PresignedHeadObject"></a>
-### PresignedHeadObject(ctx context.Context, bucketName, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error)
+### PresignedHeadObject(ctx context.Context, bucketName, objectName string, expiry time.Duration, opts minio.PresignOptions) (*url.URL, error)
 Generates a presigned URL for HTTP HEAD operations. Browsers/Mobile clients may point to this URL to directly get metadata from objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The default expiry is set to 7 days.
 
 __Parameters__
 
-|Param   |Type   |Description   |
-|:---|:---| :---|
-|`ctx`  | _context.Context_  | Custom context for timeout/cancellation of the call|
-|`bucketName`  | _string_  |Name of the bucket   |
-|`objectName` | _string_  |Name of the object   |
-|`expiry` | _time.Duration_  |Expiry of presigned URL in seconds   |
-|`reqParams` | _url.Values_  |Additional response header overrides supports _response-expires_, _response-content-type_, _response-cache-control_, _response-content-disposition_.  |
+| Param        | Type                   | Description                                                                        |
+|:-------------|:-----------------------|:-----------------------------------------------------------------------------------|
+| `ctx`        | _context.Context_      | Custom context for timeout/cancellation of the call                                |
+| `bucketName` | _string_               | Name of the bucket                                                                 |
+| `objectName` | _string_               | Name of the object                                                                 |
+| `expiry`     | _time.Duration_        | Expiry of presigned URL in seconds                                                 |
+| `opts`       | _minio.PresignOptions_ | Options for Pre-Signing requests specifying additional options like object version |
+
+
+__minio.PresignOptions__
+
+| Field            | Type                | Description                                                                                                                                          |
+|:-----------------|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `opts.ReqParams` | _url.Values_        | Additional response header overrides supports _response-expires_, _response-content-type_, _response-cache-control_, _response-content-disposition_. |
+| `opts.VersionID` | _string_            | Version ID of the object to delete                                                                                                                   |
+| `opts.Region`    | _string_            | To against what region should the url should be signed                                                                                               |
+| `opts.Header()`  | _map[string]string_ | Returns the headers built on this options                                                                                                            |
+| `opts.Set()`     | _function_          | Allows to set custom headers                                                                                                                         |
+
 
 
 __Example__

--- a/examples/s3/presignedgetobject.go
+++ b/examples/s3/presignedgetobject.go
@@ -51,8 +51,12 @@ func main() {
 	reqParams := make(url.Values)
 	reqParams.Set("response-content-disposition", "attachment; filename=\"your-filename.txt\"")
 
+	opts := minio.PreSignOptions{
+		ReqParams: reqParams,
+	}
+
 	// Gernerate presigned get object url.
-	presignedURL, err := s3Client.PresignedGetObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, reqParams)
+	presignedURL, err := s3Client.PresignedGetObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, opts)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/s3/presignedheadobject.go
+++ b/examples/s3/presignedheadobject.go
@@ -51,8 +51,12 @@ func main() {
 	reqParams := make(url.Values)
 	reqParams.Set("response-content-disposition", "attachment; filename=\"your-filename.txt\"")
 
+	opts := minio.PreSignOptions{
+		ReqParams: reqParams,
+	}
+
 	// Gernerate presigned get object url.
-	presignedURL, err := s3Client.PresignedHeadObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, reqParams)
+	presignedURL, err := s3Client.PresignedHeadObject(context.Background(), "my-bucketname", "my-objectname", time.Duration(1000)*time.Second, opts)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -6014,7 +6014,7 @@ func testFunctional() {
 		"objectName": "",
 		"expires":    3600 * time.Second,
 	}
-	if _, err = c.PresignedHeadObject(context.Background(), bucketName, "", 3600*time.Second, nil); err == nil {
+	if _, err = c.PresignedHeadObject(context.Background(), bucketName, "", 3600*time.Second, minio.PreSignOptions{}); err == nil {
 		logError(testName, function, args, startTime, "", "PresignedHeadObject success", err)
 		return
 	}
@@ -6027,7 +6027,7 @@ func testFunctional() {
 		"objectName": objectName,
 		"expires":    3600 * time.Second,
 	}
-	presignedHeadURL, err := c.PresignedHeadObject(context.Background(), bucketName, objectName, 3600*time.Second, nil)
+	presignedHeadURL, err := c.PresignedHeadObject(context.Background(), bucketName, objectName, 3600*time.Second, minio.PreSignOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedHeadObject failed", err)
 		return
@@ -6076,7 +6076,7 @@ func testFunctional() {
 		"objectName": "",
 		"expires":    3600 * time.Second,
 	}
-	_, err = c.PresignedGetObject(context.Background(), bucketName, "", 3600*time.Second, nil)
+	_, err = c.PresignedGetObject(context.Background(), bucketName, "", 3600*time.Second, minio.PreSignOptions{})
 	if err == nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject success", err)
 		return
@@ -6090,7 +6090,7 @@ func testFunctional() {
 		"objectName": objectName,
 		"expires":    3600 * time.Second,
 	}
-	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, nil)
+	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, minio.PreSignOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
 		return
@@ -6132,7 +6132,11 @@ func testFunctional() {
 		"expires":    3600 * time.Second,
 		"reqParams":  reqParams,
 	}
-	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, reqParams)
+
+	opts := minio.PreSignOptions{
+		ReqParams: reqParams,
+	}
+	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, opts)
 
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
@@ -6238,7 +6242,10 @@ func testFunctional() {
 		"expires":      3600 * time.Second,
 		"extraHeaders": presignExtraHeaders,
 	}
-	presignedURL, err := c.PresignHeader(context.Background(), "PUT", bucketName, objectName+"-presign-custom", 3600*time.Second, nil, presignExtraHeaders)
+	opts = minio.PreSignOptions{}
+	opts.Set("mysecret", "abcxxx")
+
+	presignedURL, err := c.PresignHeader(context.Background(), "PUT", bucketName, objectName+"-presign-custom", 3600*time.Second, opts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "Presigned failed", err)
 		return
@@ -10916,7 +10923,7 @@ func testFunctionalV2() {
 		"objectName": objectName,
 		"expires":    3600 * time.Second,
 	}
-	presignedHeadURL, err := c.PresignedHeadObject(context.Background(), bucketName, objectName, 3600*time.Second, nil)
+	presignedHeadURL, err := c.PresignedHeadObject(context.Background(), bucketName, objectName, 3600*time.Second, minio.PreSignOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedHeadObject failed", err)
 		return
@@ -10966,7 +10973,7 @@ func testFunctionalV2() {
 		"objectName": objectName,
 		"expires":    3600 * time.Second,
 	}
-	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, nil)
+	presignedGetURL, err := c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, minio.PreSignOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
 		return
@@ -11005,7 +11012,12 @@ func testFunctionalV2() {
 	reqParams.Set("response-content-disposition", "attachment; filename=\"test.txt\"")
 	// Generate presigned GET object url.
 	args["reqParams"] = reqParams
-	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, reqParams)
+
+	opts := minio.PreSignOptions{
+		ReqParams: reqParams,
+	}
+
+	presignedGetURL, err = c.PresignedGetObject(context.Background(), bucketName, objectName, 3600*time.Second, opts)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PresignedGetObject failed", err)
 		return
@@ -11106,7 +11118,10 @@ func testFunctionalV2() {
 		"expires":      3600 * time.Second,
 		"extraHeaders": presignExtraHeaders,
 	}
-	_, err = c.PresignHeader(context.Background(), "PUT", bucketName, objectName+"-presign-custom", 3600*time.Second, nil, presignExtraHeaders)
+	opts = minio.PreSignOptions{}
+	opts.Set("mysecret", "abcxxx")
+
+	_, err = c.PresignHeader(context.Background(), "PUT", bucketName, objectName+"-presign-custom", 3600*time.Second, opts)
 	if err == nil {
 		logError(testName, function, args, startTime, "", "Presigned with extra headers succeeded", err)
 		return


### PR DESCRIPTION
This PR adds `PresignOptions` to `PresignedGetObject`, `PresignedHeadObject`, `PresignHeader` and `presignURL`

Any other function using `presignURL` will pass an empty `PresignOptions`

`PresignOptions` mimics the possible configurations the same way `GetObject` exposes via `GetObjectOptions`

The main need for this is to allow to configure the Region (or Bucket Location) before the signed request is created which avoids doing a round trip to whatever the endpoint is to figure out the bucket location.

This allows to sign URL to whichever endpoint the MinIO Client is configured to.

Signed-off-by: Daniel Valdivia <hola@danielvaldivia.com>