### PR TITLE
Remove `Range` header after `Seek` to origin

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -199,6 +199,9 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 							opts.SetRange(req.Offset, req.Offset+int64(len(req.Buffer))-1)
 						} else if req.Offset > 0 { // Range is set with respect to the offset.
 							opts.SetRange(req.Offset, 0)
+						} else {
+							// Remove range header if already set
+							delete(opts.headers, "Range")
 						}
 						httpReader, objectInfo, _, err = c.getObject(ctx, bucketName, objectName, opts)
 						if err != nil {


### PR DESCRIPTION
When reading data using `ReadAt()` and seeking to the origin using `Seek(0, 0)` afterwards, the old `Range` header is still included in the request. This causes any subsequent `Read()` operation to start at the offset previously passed to `ReadAt()`.

The commit in this PR fixes that behaviour.