### PR TITLE
return us-east-1 when endpoint is cloudflare

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -127,8 +127,11 @@ func processBucketLocationResponse(resp *http.Response, bucketName string) (buck
 			// succeed if possible based on their policy.
 			switch errResp.Code {
 			case "NotImplemented":
-				if errResp.Server == "AmazonSnowball" {
+				switch errResp.Server {
+				case "AmazonSnowball":
 					return "snowball", nil
+				case "cloudflare":
+					return "us-east-1", nil
 				}
 			case "AuthorizationHeaderMalformed":
 				fallthrough


### PR DESCRIPTION
https://blog.cloudflare.com/r2-open-beta/ 

> When you create a bucket, you won’t see a region selector. Our vision for R2 includes automatically globally distributed storage, where R2 seamlessly places each object into the storage region closest to where the request comes from. Today, R2 primarily stores data in North America, which can lead to higher latencies when accessing content from other regions. We’ll first look to address this by adding additional regions where objects can be created, before adding automatic migration of existing objects across regions. Similar to what we’ve built with [jurisdictional restrictions for Durable Objects](https://blog.cloudflare.com/supporting-jurisdictional-restrictions-for-durable-objects/), we’ll also enable restricting where an R2 bucket places data to comply with privacy regulations.