### PR TITLE
Add Policy to STSAssumeRoleOptions

### DIFF
--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -94,6 +94,8 @@ type STSAssumeRoleOptions struct {
 	AccessKey string
 	SecretKey string
 
+	Policy string // Optional to assign a policy to the assumed role
+
 	Location        string // Optional commonly needed with AWS STS.
 	DurationSeconds int    // Optional defaults to 1 hour.
 
@@ -156,6 +158,9 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 		v.Set("DurationSeconds", strconv.Itoa(opts.DurationSeconds))
 	} else {
 		v.Set("DurationSeconds", strconv.Itoa(defaultDurationSeconds))
+	}
+	if opts.Policy != "" {
+		v.Set("Policy", opts.Policy)
 	}
 
 	u, err := url.Parse(endpoint)


### PR DESCRIPTION
Allow the policy to be specified when invoking the STS AssumeRole API.

Note that the STS AssumeRole implementation in minio already supports assigning a policy.  This change simply provide a way in which to invoke it.  Also note this has been tested locally and works as expected with different types of policies.