### PR TITLE
fix: avoid send on a closed channel race, cancel inner context.

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -66,6 +66,7 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 	go func() {
 		defer close(reqCh)
 		defer close(resCh)
+		defer cancel()
 
 		// Used to verify if etag of object has changed since last read.
 		var etag string
@@ -83,7 +84,10 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 				return
 
 			// Gather incoming request.
-			case req := <-reqCh:
+			case req, ok := <-reqCh:
+				if !ok {
+					return
+				}
 				// If this is the first request we may not need to do a getObject request yet.
 				if req.isFirstReq {
 					// First request is a Read/ReadAt.


### PR DESCRIPTION
    ```
    panic: send on closed channel
    
    goroutine 3833084 [running]:
    github.com/minio/minio-go/v7.(*Object).doGetRequest(_, {{0xc003930000, 0x2000, 0x2000}, 0x2000, 0x0, 0x1, 0x0, 0x1, 0x0, ...})
            github.com/minio/minio-go/v7@v7.0.30-0.20220623010642-40b13d984ae3/api-get-object.go:315 +0xdc
    github.com/minio/minio-go/v7.(*Object).Read(0xc0b1792c40, {0xc003930000?, 0x10?, 0xc001356800?})
            github.com/minio/minio-go/v7@v7.0.30-0.20220623010642-40b13d984ae3/api-get-object.go:395 +0x248
    io.discard.ReadFrom({}, {0x4c8e0e0, 0xc0b1792c40})
            io/io.go:610 +0x72
    io.copyBuffer({0x4c94f00, 0x5fab600}, {0x4c8e0e0, 0xc0b1792c40}, {0x0, 0x0, 0x0})
            io/io.go:412 +0x14b
    io.Copy(...)
            io/io.go:385
    github.com/minio/minio/cmd.selfSpeedtest.func4(0x28)
            github.com/minio/minio/cmd/perf-tests.go:163 +0x4d5
    created by github.com/minio/minio/cmd.selfSpeedtest
            github.com/minio/minio/cmd/perf-tests.go:137 +0x966
    ```
