### PR TITLE
Add transfer progress timeout

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -144,6 +144,7 @@ func (a *reqAliveChecker) Read(p []byte) (n int, err error) {
 			a.reset = update
 			go func() {
 				t := time.NewTimer(a.timeout)
+				defer t.Stop()
 				for {
 					select {
 					case _, ok := <-update:

--- a/transport.go
+++ b/transport.go
@@ -1,9 +1,6 @@
-//go:build go1.7 || go1.8
-// +build go1.7 go1.8
-
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2017-2018 MinIO, Inc.
+ * Copyright 2017-2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +18,15 @@
 package minio
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
+	"sync/atomic"
 	"time"
 )
 
@@ -81,4 +81,186 @@ var DefaultTransport = func(secure bool) (*http.Transport, error) {
 		}
 	}
 	return tr, nil
+}
+
+// transportTimeoutWrapper wraps a transport to time out on request and response body transfers.
+func transportTimeoutWrapper(tripper http.RoundTripper, timeout time.Duration) http.RoundTripper {
+	if timeout <= 0 {
+		return tripper
+	}
+	return &transportTimeout{parent: tripper, timeout: timeout}
+}
+
+type transportTimeout struct {
+	parent  http.RoundTripper
+	timeout time.Duration
+}
+
+func (t *transportTimeout) RoundTrip(request *http.Request) (*http.Response, error) {
+	request, ctx, cancel := newReqAliveChecker(request, t.timeout)
+	resp, err := t.parent.RoundTrip(request)
+	if err != nil {
+		cancel()
+		return resp, err
+	}
+	return newRespAliveChecker(ctx, cancel, resp, t.timeout), nil
+}
+
+// newReqAliveChecker will perform timeout checks between read calls.
+// This will measure time between body reads.
+// When the timeout is exceeded the request will be canceled.
+// A new request and context is returned.
+//
+func newReqAliveChecker(req *http.Request, timeout time.Duration) (request *http.Request, ctx context.Context, cancel context.CancelFunc) {
+	ctx, cancel = context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	if req.Body == nil || timeout <= 0 {
+		return req, ctx, cancel
+	}
+	req.Body = &reqAliveChecker{timeout: timeout, rc: req.Body, ctx: ctx, cancel: cancel}
+	return req, ctx, cancel
+}
+
+type reqAliveChecker struct {
+	timedOut uint32
+	timeout  time.Duration
+	rc       io.ReadCloser
+
+	reset  chan struct{}
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (a *reqAliveChecker) Read(p []byte) (n int, err error) {
+	if atomic.LoadUint32(&a.timedOut) == 1 {
+		return 0, context.DeadlineExceeded
+	}
+	n, err = a.rc.Read(p)
+	// Start on first request
+	if err == nil {
+		if a.reset == nil {
+			update := make(chan struct{}, 1)
+			a.reset = update
+			go func() {
+				t := time.NewTimer(a.timeout)
+				for {
+					select {
+					case _, ok := <-update:
+						if !ok {
+							// Close was called...
+							return
+						}
+						// Reset on update...
+						t.Reset(a.timeout)
+					case <-a.ctx.Done():
+						atomic.StoreUint32(&a.timedOut, 1)
+						a.cancel()
+					case <-t.C:
+						atomic.StoreUint32(&a.timedOut, 1)
+						a.cancel()
+					}
+				}
+			}()
+		} else {
+			a.reset <- struct{}{}
+		}
+	}
+	return n, err
+}
+
+func (a *reqAliveChecker) Close() error {
+	if a.reset != nil {
+		close(a.reset)
+		a.reset = nil
+	}
+	return a.rc.Close()
+}
+
+// newRespAliveChecker will check reads for individual timeouts.
+// Any timeout <= 0 will disable timeouts and just return rc.
+// When a timeout is hit context.DeadlineExceeded is returned from the reader.
+// The context of the original request (if available) should still be canceled
+// to release resources of call if possible.
+func newRespAliveChecker(ctx context.Context, cancel context.CancelFunc, resp *http.Response, timeout time.Duration) *http.Response {
+	if resp == nil {
+		return nil
+	}
+	if timeout <= 0 || resp.Body == nil {
+		return resp
+	}
+	resp.Body = &respAliveChecker{rc: resp.Body, timeout: timeout,
+		comms:  make(chan readResponse, 1),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	return resp
+}
+
+type respAliveChecker struct {
+	timeout  time.Duration
+	rc       io.ReadCloser
+	comms    chan readResponse
+	timedOut bool
+
+	// When wrapping
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+type readResponse struct {
+	n   int
+	err error
+}
+
+func (a *respAliveChecker) Read(p []byte) (n int, err error) {
+	if a.timedOut {
+		return 0, context.DeadlineExceeded
+	}
+	go func() {
+		var res readResponse
+		res.n, res.err = a.rc.Read(p)
+		a.comms <- res
+	}()
+	// Default nil, never fires
+	var done <-chan struct{}
+	if a.ctx != nil {
+		done = a.ctx.Done()
+	}
+	select {
+	case <-done:
+		if a.cancel != nil {
+			a.cancel()
+		}
+		a.timedOut = true
+		return 0, a.ctx.Err()
+	case <-time.After(a.timeout):
+		a.timedOut = true
+		if a.cancel != nil {
+			a.cancel()
+		}
+		return 0, context.DeadlineExceeded
+	case v := <-a.comms:
+		return v.n, v.err
+	}
+}
+
+func (a *respAliveChecker) Close() error {
+	if a.timedOut {
+		select {
+		case <-a.comms:
+			// Read returned.
+		default:
+			// We are still blocked on a read.
+			// Spawn a goroutine that waits for the request to finish before we Close.
+			for range a.comms {
+				a.rc.Close()
+			}
+			return context.DeadlineExceeded
+		}
+	} else if a.cancel != nil {
+		a.cancel()
+	}
+	return a.rc.Close()
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,3 +1,20 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2017-2022 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package minio
 
 import (

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,97 @@
+package minio
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func Test_transportTimeoutWrapper_Response(t *testing.T) {
+	t.Parallel()
+	// We need a reasonably long timeout to ensure it is caught.
+	wait := time.Second
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+		w.(http.Flusher).Flush()
+		time.Sleep(wait)
+	}))
+	defer ts.Close()
+
+	started := time.Now()
+	client := http.Client{Transport: transportTimeoutWrapper(http.DefaultTransport, wait/2)}
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(res.Body)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("expected DeadlineExceeded, got", err)
+	}
+	err = res.Body.Close()
+	if err != context.DeadlineExceeded {
+		t.Fatal("expected DeadlineExceeded, got", err)
+	}
+	if time.Since(started) >= wait {
+		t.Fatalf("Took longer (%v) than double timeout (%v)", time.Since(started), wait)
+	}
+	t.Log("timeout took", time.Since(started))
+}
+
+type fakeRoundtripper struct {
+	// Read this many bytes from input...
+	readFirst int
+	// ... then wait this long.
+	wait time.Duration
+}
+
+func (f fakeRoundtripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	ctx := request.Context()
+	defer request.Body.Close()
+	var buf = make([]byte, f.readFirst)
+	_, err := io.ReadFull(request.Body, buf)
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		return nil, request.Context().Err()
+	case <-time.NewTimer(f.wait).C:
+	}
+	_, err = io.Copy(io.Discard, request.Body)
+	return nil, err
+}
+
+func Test_transportTimeoutWrapper_Request(t *testing.T) {
+	// Seems like `httptest.NewServer` buffers bodies, so we cannot use it.
+	// Resort to manual testing
+	t.Parallel()
+	// We need a reasonably long timeout to ensure it is caught.
+	const wait = time.Second
+	const size = 10000
+
+	transport := transportTimeoutWrapper(fakeRoundtripper{readFirst: size, wait: wait}, wait/2)
+	client := http.Client{Transport: transport}
+
+	req, err := http.NewRequest("GET", "", bytes.NewBuffer(make([]byte, size*2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, err = client.Do(req)
+	if time.Since(started) >= wait {
+		t.Fatalf("Took longer (%v) than double timeout (%v)", time.Since(started), wait)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("expected timeout, got", err)
+	}
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -47,9 +47,43 @@ func Test_transportTimeoutWrapper_Response(t *testing.T) {
 	t.Log("timeout took", time.Since(started))
 }
 
+func Test_transportTimeoutWrapper_ResponseTrickle(t *testing.T) {
+	t.Parallel()
+	// We need a reasonably long timeout to ensure it is caught.
+	wait := time.Second
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for i := 0; i < 4; i++ {
+			fmt.Fprintln(w, "Hello, client")
+			w.(http.Flusher).Flush()
+			time.Sleep(wait / 4)
+		}
+	}))
+	defer ts.Close()
+
+	client := http.Client{Transport: transportTimeoutWrapper(http.DefaultTransport, wait/2)}
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal("got error", err)
+	}
+	err = res.Body.Close()
+	if err != nil {
+		t.Fatal("got error", err)
+	}
+}
+
 type fakeRoundtripper struct {
-	// Read this many bytes from input...
-	readFirst int
+	// This many times...
+	times int
+	// read this many bytes from input...
+	readEach int
 	// ... then wait this long.
 	wait time.Duration
 }
@@ -57,18 +91,20 @@ type fakeRoundtripper struct {
 func (f fakeRoundtripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	ctx := request.Context()
 	defer request.Body.Close()
-	var buf = make([]byte, f.readFirst)
-	_, err := io.ReadFull(request.Body, buf)
-	if err != nil {
-		return nil, err
+	var buf = make([]byte, f.readEach)
+	for i := 0; i < f.times; i++ {
+		_, err := io.ReadFull(request.Body, buf)
+		if err != nil {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, request.Context().Err()
+		case <-time.NewTimer(f.wait).C:
+		}
 	}
-	select {
-	case <-ctx.Done():
-		return nil, request.Context().Err()
-	case <-time.NewTimer(f.wait).C:
-	}
-	_, err = io.Copy(io.Discard, request.Body)
-	return nil, err
+	_, err := io.Copy(io.Discard, request.Body)
+	return &http.Response{}, err
 }
 
 func Test_transportTimeoutWrapper_Request(t *testing.T) {
@@ -79,7 +115,7 @@ func Test_transportTimeoutWrapper_Request(t *testing.T) {
 	const wait = time.Second
 	const size = 10000
 
-	transport := transportTimeoutWrapper(fakeRoundtripper{readFirst: size, wait: wait}, wait/2)
+	transport := transportTimeoutWrapper(fakeRoundtripper{readEach: size, wait: wait, times: 1}, wait/2)
 	client := http.Client{Transport: transport}
 
 	req, err := http.NewRequest("GET", "", bytes.NewBuffer(make([]byte, size*2)))
@@ -93,5 +129,27 @@ func Test_transportTimeoutWrapper_Request(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatal("expected timeout, got", err)
+	}
+}
+
+func Test_transportTimeoutWrapper_RequestTrickle(t *testing.T) {
+	// Seems like `httptest.NewServer` buffers bodies, so we cannot use it.
+	// Resort to manual testing
+	t.Parallel()
+	// We need a reasonably long timeout to ensure it is caught.
+	const wait = time.Second
+	const size = 10000
+
+	// Read every wait / 2, timeout is wait.
+	transport := transportTimeoutWrapper(fakeRoundtripper{readEach: size / 2, wait: wait / 2, times: 4}, wait)
+	client := http.Client{Transport: transport}
+
+	req, err := http.NewRequest("GET", "", bytes.NewBuffer(make([]byte, size*2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Fatal("got error", err)
 	}
 }


### PR DESCRIPTION
Add default 5 minute timeout for transfer progress for sending and receiving bodies.

Proposed fix for https://github.com/minio/mc/issues/4133
