### PR TITLE
api-put-object-streaming: Removed unnecessary `partBuf` copy to save allocations; no race detected.

### DIFF
--- a/api.go
+++ b/api.go
@@ -379,7 +379,6 @@ func (c *Client) HealthCheck(hcDuration time.Duration) (context.CancelFunc, erro
 				atomic.StoreInt32(&c.healthStatus, unknown)
 				return
 			case <-timer.C:
-				timer.Reset(duration)
 				// Do health check the first time and ONLY if the connection is marked offline
 				if c.IsOffline() {
 					gctx, gcancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -394,6 +393,8 @@ func (c *Client) HealthCheck(hcDuration time.Duration) (context.CancelFunc, erro
 						atomic.CompareAndSwapInt32(&c.healthStatus, offline, online)
 					}
 				}
+
+				timer.Reset(duration)
 			}
 		}
 	}(hcDuration)

--- a/hook-reader.go
+++ b/hook-reader.go
@@ -20,6 +20,7 @@ package minio
 import (
 	"fmt"
 	"io"
+	"sync"
 )
 
 // hookReader hooks additional reader in the source stream. It is
@@ -27,6 +28,7 @@ import (
 // notified about the exact number of bytes read from the primary
 // source on each Read operation.
 type hookReader struct {
+	mu     sync.RWMutex
 	source io.Reader
 	hook   io.Reader
 }
@@ -34,6 +36,9 @@ type hookReader struct {
 // Seek implements io.Seeker. Seeks source first, and if necessary
 // seeks hook if Seek method is appropriately found.
 func (hr *hookReader) Seek(offset int64, whence int) (n int64, err error) {
+	hr.mu.Lock()
+	defer hr.mu.Unlock()
+
 	// Verify for source has embedded Seeker, use it.
 	sourceSeeker, ok := hr.source.(io.Seeker)
 	if ok {
@@ -43,18 +48,21 @@ func (hr *hookReader) Seek(offset int64, whence int) (n int64, err error) {
 		}
 	}
 
-	// Verify if hook has embedded Seeker, use it.
-	hookSeeker, ok := hr.hook.(io.Seeker)
-	if ok {
-		var m int64
-		m, err = hookSeeker.Seek(offset, whence)
-		if err != nil {
-			return 0, err
-		}
-		if n != m {
-			return 0, fmt.Errorf("hook seeker seeked %d bytes, expected source %d bytes", m, n)
+	if hr.hook != nil {
+		// Verify if hook has embedded Seeker, use it.
+		hookSeeker, ok := hr.hook.(io.Seeker)
+		if ok {
+			var m int64
+			m, err = hookSeeker.Seek(offset, whence)
+			if err != nil {
+				return 0, err
+			}
+			if n != m {
+				return 0, fmt.Errorf("hook seeker seeked %d bytes, expected source %d bytes", m, n)
+			}
 		}
 	}
+
 	return n, nil
 }
 
@@ -62,14 +70,19 @@ func (hr *hookReader) Seek(offset int64, whence int) (n int64, err error) {
 // value 'n' number of bytes are reported through the hook. Returns
 // error for all non io.EOF conditions.
 func (hr *hookReader) Read(b []byte) (n int, err error) {
+	hr.mu.RLock()
+	defer hr.mu.RUnlock()
+
 	n, err = hr.source.Read(b)
 	if err != nil && err != io.EOF {
 		return n, err
 	}
-	// Progress the hook with the total read bytes from the source.
-	if _, herr := hr.hook.Read(b[:n]); herr != nil {
-		if herr != io.EOF {
-			return n, herr
+	if hr.hook != nil {
+		// Progress the hook with the total read bytes from the source.
+		if _, herr := hr.hook.Read(b[:n]); herr != nil {
+			if herr != io.EOF {
+				return n, herr
+			}
 		}
 	}
 	return n, err
@@ -79,7 +92,10 @@ func (hr *hookReader) Read(b []byte) (n int, err error) {
 // reports the data read from the source to the hook.
 func newHook(source, hook io.Reader) io.Reader {
 	if hook == nil {
-		return source
+		return &hookReader{source: source}
 	}
-	return &hookReader{source, hook}
+	return &hookReader{
+		source: source,
+		hook:   hook,
+	}
 }


### PR DESCRIPTION
Hi and thanks for the great work so far. 👋🏽 

Following our discussion in https://github.com/minio/mc/issues/3376#issuecomment-806013131 I performed extended testing, benchmarking and profiling to figure out what's best for `minio-go` and the Thanos [issue](https://github.com/thanos-io/thanos/issues/3967). 

Proving tests:
* Race [test](https://github.com/thanos-io/thanos/pull/5474/files#diff-5e00ccdab4b3bcb9f66b512babda69ce310f217029f01a669c612c995f9e1f31R29)
* [Benchmark](https://github.com/thanos-io/thanos/pull/5474/files#diff-5e00ccdab4b3bcb9f66b512babda69ce310f217029f01a669c612c995f9e1f31R83)

No matter how hard I tried, I could not reproduce ANY race the [fix](https://github.com/minio/minio-go/pull/1357) was made for. I even try to trigger retries, and all works fine for Linux `*os.File`. I tried to look for any repro tests on your side but none was provided to prove that there is indeed any race. Perhaps the race was detected on certain OS? (windows/MacOS?)

The benchmarks show significant allocation problems while copying large files (PartSize 64MB). I also optimize naive chunk preallocations.

```
benchstat v1.txt v2-upgr.txt
name       old time/op    new time/op    delta
Upload-12     300ms ± 7%     283ms ± 7%     ~     (p=0.310 n=5+5)

name       old alloc/op   new alloc/op   delta
Upload-12    69.3MB ± 0%     0.5MB ± 3%  -99.23%  (p=0.008 n=5+5)

name       old allocs/op  new allocs/op  delta
Upload-12     3.33k ± 2%     3.16k ± 1%   -5.01%  (p=0.008 n=5+5)
```

I know you reduced default PartSize to 16MB (from 128MB) to reduce default allocation spread, but this is still unacceptable and 16MB part size have other tradeoffs (latency). So in this PR I propose to revert that fix and optimize allocations. I would love to be e able to use minio-go in Thanos and related projects, but we need this path to be leaner. One of the components Thanos sidecar is usually deployed with limited mem (100-200 MB), so optimizations in this library matters.

Perhaps if you don't want to accept this PR because you are afraid of (IMO unproven) potential races, you would be happy with adding extra option to `Put` API like `ReuseReader`? 

I am happy to be proven wrong that we indeed have raced here (e.g I did not test other OS than Linux), but we can't accept 60x allocation regression for unexisting race. Let me know what do you think, thanks! 🤗 
 
This version is also proposed to be used in Thanos: https://github.com/thanos-io/thanos/pull/5474

Fixes: https://github.com/thanos-io/thanos/issues/3967
Fixes: https://github.com/thanos-io/thanos/issues/5393
