### PR TITLE
fix: remote target is permanently marked offline by mistake

### DIFF
--- a/api.go
+++ b/api.go
@@ -384,13 +384,11 @@ func (c *Client) HealthCheck(hcDuration time.Duration) (context.CancelFunc, erro
 					gctx, gcancel := context.WithTimeout(context.Background(), 3*time.Second)
 					_, err := c.getBucketLocation(gctx, probeBucketName)
 					gcancel()
-					if IsNetworkOrHostDown(err, false) {
-						// Still network errors do not need to do anything.
-						continue
-					}
-					switch ToErrorResponse(err).Code {
-					case "NoSuchBucket", "AccessDenied", "":
-						atomic.CompareAndSwapInt32(&c.healthStatus, offline, online)
+					if !IsNetworkOrHostDown(err, false) {
+						switch ToErrorResponse(err).Code {
+						case "NoSuchBucket", "AccessDenied", "":
+							atomic.CompareAndSwapInt32(&c.healthStatus, offline, online)
+						}
 					}
 				}
 


### PR DESCRIPTION
### Issue

The steps to reproduce the issue are as follows:
1. Stop the remote target.
2. Upload a file to local target and we will see in the log that `remote target is offline`.
3. Wait a while to ensure that a health check is performed.
4. Start the remote target and verify that it is accessible.
5. No matter how long we wait, the local target always considers the remote target to be offline.

### Reason

When the remote target or network is down, the health check timer will not be reset. So even if the remote target or network recovers later, it will be permanently marked offline by mistake.