### PR TITLE
Add date if not present and there is no "X-Amz-Date"

### DIFF
--- a/pkg/signer/request-signature-v2.go
+++ b/pkg/signer/request-signature-v2.go
@@ -136,8 +136,8 @@ func SignV2(req http.Request, accessKeyID, secretAccessKey string, virtualHost b
 	// Initial time.
 	d := time.Now().UTC()
 
-	// Add date if not present.
-	if date := req.Header.Get("Date"); date == "" {
+	// Add date if not present and there is no "X-Amz-Date".
+	if date := req.Header.Get("Date"); date == ""  && req.Header.Get("X-Amz-Date") == "" {
 		req.Header.Set("Date", d.Format(http.TimeFormat))
 	}
 


### PR DESCRIPTION
Upon receiving the request, Amazon S3 re-creates the string to sign using information in the Authorization header and the date header. It then verifies with authentication service the signatures match. The request date can be specified by using either the HTTP Date or the x-amz-date header. If both headers are present, x-amz-date takes precedence.