### PR TITLE
convert LDAP/JWT Identity from query to form body

### DIFF
--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -137,9 +137,13 @@ func initEcsTaskTestServer(expireOn string) *httptest.Server {
 
 func initStsTestServer(expireOn string) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		required := []string{"RoleArn", "RoleSessionName", "WebIdentityToken", "Version"}
 		for _, field := range required {
-			if _, ok := r.URL.Query()[field]; !ok {
+			if _, ok := r.Form[field]; !ok {
 				http.Error(w, fmt.Sprintf("%s missing", field), http.StatusBadRequest)
 				return
 			}

--- a/pkg/credentials/sts_client_grants.go
+++ b/pkg/credentials/sts_client_grants.go
@@ -1,6 +1,6 @@
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2019 MinIO, Inc.
+ * Copyright 2019-2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -122,12 +123,14 @@ func getClientGrantsCredentials(clnt *http.Client, endpoint string,
 	if err != nil {
 		return AssumeRoleWithClientGrantsResponse{}, err
 	}
-	u.RawQuery = v.Encode()
 
-	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return AssumeRoleWithClientGrantsResponse{}, err
 	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	resp, err := clnt.Do(req)
 	if err != nil {
 		return AssumeRoleWithClientGrantsResponse{}, err

--- a/pkg/credentials/sts_custom_identity.go
+++ b/pkg/credentials/sts_custom_identity.go
@@ -89,12 +89,12 @@ func (c *CustomTokenIdentity) Retrieve() (value Value, err error) {
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
 	if err != nil {
-		return value, stripPassword(err)
+		return value, err
 	}
 
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		return value, stripPassword(err)
+		return value, err
 	}
 
 	defer resp.Body.Close()

--- a/pkg/credentials/sts_ldap_identity.go
+++ b/pkg/credentials/sts_ldap_identity.go
@@ -1,6 +1,6 @@
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2019-2021 MinIO, Inc.
+ * Copyright 2019-2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -105,22 +106,6 @@ func LDAPIdentityExpiryOpt(d time.Duration) LDAPIdentityOpt {
 	}
 }
 
-func stripPassword(err error) error {
-	urlErr, ok := err.(*url.Error)
-	if ok {
-		u, _ := url.Parse(urlErr.URL)
-		if u == nil {
-			return urlErr
-		}
-		values := u.Query()
-		values.Set("LDAPPassword", "xxxxx")
-		u.RawQuery = values.Encode()
-		urlErr.URL = u.String()
-		return urlErr
-	}
-	return err
-}
-
 // NewLDAPIdentityWithSessionPolicy returns new credentials object that uses
 // LDAP Identity with a specified session policy. The `policy` parameter must be
 // a JSON string specifying the policy document.
@@ -156,16 +141,16 @@ func (k *LDAPIdentity) Retrieve() (value Value, err error) {
 		v.Set("DurationSeconds", fmt.Sprintf("%d", int(k.RequestedExpiry.Seconds())))
 	}
 
-	u.RawQuery = v.Encode()
-
-	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
-		return value, stripPassword(err)
+		return value, err
 	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := k.Client.Do(req)
 	if err != nil {
-		return value, stripPassword(err)
+		return value, err
 	}
 
 	defer resp.Body.Close()

--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -1,6 +1,6 @@
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2019 MinIO, Inc.
+ * Copyright 2019-2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -139,12 +140,12 @@ func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSession
 		return AssumeRoleWithWebIdentityResponse{}, err
 	}
 
-	u.RawQuery = v.Encode()
-
-	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return AssumeRoleWithWebIdentityResponse{}, err
 	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := clnt.Do(req)
 	if err != nil {


### PR DESCRIPTION
HTTP calls get logged through proxies, avoid
sensitive data getting logged by using request
body instead of query params.