### PR TITLE
Add PutObject checksums

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -84,6 +84,12 @@ type UploadInfo struct {
 	// not to be confused with `Expires` HTTP header.
 	Expiration       time.Time
 	ExpirationRuleID string
+
+	// Verified checksum values, if any.
+	ChecksumCRC32  string
+	ChecksumCRC32C string
+	ChecksumSHA1   string
+	ChecksumSHA256 string
 }
 
 // RestoreInfo contains information of the restore operation of an archived object
@@ -147,6 +153,12 @@ type ObjectInfo struct {
 	ExpirationRuleID string
 
 	Restore *RestoreInfo
+
+	// Checksum values
+	ChecksumCRC32  string
+	ChecksumCRC32C string
+	ChecksumSHA1   string
+	ChecksumSHA256 string
 
 	// Error
 	Err error `json:"-"`

--- a/api-get-options.go
+++ b/api-get-options.go
@@ -38,6 +38,12 @@ type GetObjectOptions struct {
 	ServerSideEncryption encrypt.ServerSide
 	VersionID            string
 	PartNumber           int
+
+	// Include any checksums, if object was uploaded with checksum.
+	// For multipart objects this is a checksum of part checksums.
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+	Checksum bool
+
 	// To be not used by external applications
 	Internal AdvancedGetOptions
 }
@@ -59,6 +65,9 @@ func (o GetObjectOptions) Header() http.Header {
 	// to site A is proxy'd to site B if object/version missing on site A.
 	if o.Internal.ReplicationProxyRequest != "" {
 		headers.Set(minIOBucketReplicationProxyRequest, o.Internal.ReplicationProxyRequest)
+	}
+	if o.Checksum {
+		headers.Set("x-amz-checksum-mode", "ENABLED")
 	}
 	return headers
 }

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -205,13 +205,12 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 		// Add hash of hashes.
 		crc.Reset()
 		crc.Write(crcBytes)
-		opts.UserMetadata["X-Amz-Checksum-Crc32c"] = base64.StdEncoding.EncodeToString(crc.Sum(nil))
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Crc32c": base64.StdEncoding.EncodeToString(crc.Sum(nil))}
 	}
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
 	}
-	delete(opts.UserMetadata, "X-Amz-Checksum-Crc32c")
 
 	uploadInfo.Size = totalUploadedSize
 	return uploadInfo, nil

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -79,6 +80,14 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 		return UploadInfo{}, err
 	}
 
+	// Choose hash algorithms to be calculated by hashCopyN,
+	// avoid sha256 with non-v4 signature request or
+	// HTTPS connection.
+	hashAlgos, hashSums := c.hashMaterials(opts.SendContentMd5, !opts.DisableContentSha256)
+	if len(hashSums) == 0 {
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Algorithm": "CRC32C"}
+	}
+
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {
@@ -100,12 +109,12 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 	// Create a buffer.
 	buf := make([]byte, partSize)
 
+	// Create checksums
+	// CRC32C is ~50% faster on AMD64 @ 30GB/s
+	var crcBytes []byte
+	customHeader := make(http.Header)
+	crc := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	for partNumber <= totalPartsCount {
-		// Choose hash algorithms to be calculated by hashCopyN,
-		// avoid sha256 with non-v4 signature request or
-		// HTTPS connection.
-		hashAlgos, hashSums := c.hashMaterials(opts.SendContentMd5, !opts.DisableContentSha256)
-
 		length, rErr := readFull(reader, buf)
 		if rErr == io.EOF && partNumber > 1 {
 			break
@@ -131,18 +140,23 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 			md5Base64 string
 			sha256Hex string
 		)
+
 		if hashSums["md5"] != nil {
 			md5Base64 = base64.StdEncoding.EncodeToString(hashSums["md5"])
 		}
 		if hashSums["sha256"] != nil {
 			sha256Hex = hex.EncodeToString(hashSums["sha256"])
 		}
+		if len(hashSums) == 0 {
+			crc.Reset()
+			crc.Write(buf[:length])
+			cSum := crc.Sum(nil)
+			customHeader.Set("x-amz-checksum-crc32c", base64.StdEncoding.EncodeToString(cSum))
+			crcBytes = append(crcBytes, cSum...)
+		}
 
 		// Proceed to upload the part.
-		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID, rd, partNumber,
-			md5Base64, sha256Hex, int64(length),
-			opts.ServerSideEncryption,
-			!opts.DisableContentSha256)
+		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID, rd, partNumber, md5Base64, sha256Hex, int64(length), opts.ServerSideEncryption, !opts.DisableContentSha256, customHeader)
 		if uerr != nil {
 			return UploadInfo{}, uerr
 		}
@@ -171,15 +185,25 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 			return UploadInfo{}, errInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
-			ETag:       part.ETag,
-			PartNumber: part.PartNumber,
+			ETag:           part.ETag,
+			PartNumber:     part.PartNumber,
+			ChecksumCRC32:  part.ChecksumCRC32,
+			ChecksumCRC32C: part.ChecksumCRC32C,
+			ChecksumSHA1:   part.ChecksumSHA1,
+			ChecksumSHA256: part.ChecksumSHA256,
 		})
 	}
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
-
-	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, PutObjectOptions{})
+	opts = PutObjectOptions{}
+	if len(crcBytes) > 0 {
+		// Add hash of hashes.
+		crc.Reset()
+		crc.Write(crcBytes)
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Crc32c": base64.StdEncoding.EncodeToString(crc.Sum(nil))}
+	}
+	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
 	}
@@ -242,9 +266,7 @@ func (c *Client) initiateMultipartUpload(ctx context.Context, bucketName, object
 }
 
 // uploadPart - Uploads a part in a multipart upload.
-func (c *Client) uploadPart(ctx context.Context, bucketName, objectName, uploadID string, reader io.Reader,
-	partNumber int, md5Base64, sha256Hex string, size int64, sse encrypt.ServerSide, streamSha256 bool,
-) (ObjectPart, error) {
+func (c *Client) uploadPart(ctx context.Context, bucketName string, objectName string, uploadID string, reader io.Reader, partNumber int, md5Base64 string, sha256Hex string, size int64, sse encrypt.ServerSide, streamSha256 bool, customHeader http.Header) (ObjectPart, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return ObjectPart{}, err
@@ -273,7 +295,9 @@ func (c *Client) uploadPart(ctx context.Context, bucketName, objectName, uploadI
 	urlValues.Set("uploadId", uploadID)
 
 	// Set encryption headers, if any.
-	customHeader := make(http.Header)
+	if customHeader == nil {
+		customHeader = make(http.Header)
+	}
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
 	// Server-side encryption is supported by the S3 Multipart Upload actions.
 	// Unless you are using a customer-provided encryption key, you don't need
@@ -306,11 +330,17 @@ func (c *Client) uploadPart(ctx context.Context, bucketName, objectName, uploadI
 		}
 	}
 	// Once successfully uploaded, return completed part.
-	objPart := ObjectPart{}
+	h := resp.Header
+	objPart := ObjectPart{
+		ChecksumCRC32:  h.Get("x-amz-checksum-crc32"),
+		ChecksumCRC32C: h.Get("x-amz-checksum-crc32c"),
+		ChecksumSHA1:   h.Get("x-amz-checksum-sha1"),
+		ChecksumSHA256: h.Get("x-amz-checksum-sha256"),
+	}
 	objPart.Size = size
 	objPart.PartNumber = partNumber
 	// Trim off the odd double quotes from ETag in the beginning and end.
-	objPart.ETag = trimEtag(resp.Header.Get("ETag"))
+	objPart.ETag = trimEtag(h.Get("ETag"))
 	return objPart, nil
 }
 

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"net/url"
@@ -184,12 +185,7 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 				sectionReader := newHook(io.NewSectionReader(reader, readOffset, partSize), opts.Progress)
 
 				// Proceed to upload the part.
-				objPart, err := c.uploadPart(ctx, bucketName, objectName,
-					uploadID, sectionReader, uploadReq.PartNum,
-					"", "", partSize,
-					opts.ServerSideEncryption,
-					!opts.DisableContentSha256,
-				)
+				objPart, err := c.uploadPart(ctx, bucketName, objectName, uploadID, sectionReader, uploadReq.PartNum, "", "", partSize, opts.ServerSideEncryption, !opts.DisableContentSha256, nil)
 				if err != nil {
 					uploadedPartsCh <- uploadedPartRes{
 						Error: err,
@@ -260,6 +256,10 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 		return UploadInfo{}, err
 	}
 
+	if !opts.SendContentMd5 {
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Algorithm": "CRC32C"}
+	}
+
 	// Calculate the optimal parts info for a given size.
 	totalPartsCount, partSize, lastPartSize, err := OptimalPartInfo(size, opts.PartSize)
 	if err != nil {
@@ -270,6 +270,7 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 	if err != nil {
 		return UploadInfo{}, err
 	}
+	opts.UserMetadata = nil
 
 	// Aborts the multipart upload if the function returns
 	// any error, since we do not resume we should purge
@@ -280,6 +281,14 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 			c.abortMultipartUpload(ctx, bucketName, objectName, uploadID)
 		}
 	}()
+
+	// Create checksums
+	// CRC32C is ~50% faster on AMD64 @ 30GB/s
+	var crcBytes []byte
+	customHeader := make(http.Header)
+	crc := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	md5Hash := c.md5Hasher()
+	defer md5Hash.Close()
 
 	// Total data read and written to server. should be equal to 'size' at the end of the call.
 	var totalUploadedSize int64
@@ -292,7 +301,6 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 
 	// Avoid declaring variables in the for loop
 	var md5Base64 string
-	var hookReader io.Reader
 
 	// Part number always starts with '1'.
 	var partNumber int
@@ -303,37 +311,34 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 			partSize = lastPartSize
 		}
 
-		if opts.SendContentMd5 {
-			length, rerr := readFull(reader, buf)
-			if rerr == io.EOF && partNumber > 1 {
-				break
-			}
-
-			if rerr != nil && rerr != io.ErrUnexpectedEOF && err != io.EOF {
-				return UploadInfo{}, rerr
-			}
-
-			// Calculate md5sum.
-			hash := c.md5Hasher()
-			hash.Write(buf[:length])
-			md5Base64 = base64.StdEncoding.EncodeToString(hash.Sum(nil))
-			hash.Close()
-
-			// Update progress reader appropriately to the latest offset
-			// as we read from the source.
-			hookReader = newHook(bytes.NewReader(buf[:length]), opts.Progress)
-		} else {
-			// Update progress reader appropriately to the latest offset
-			// as we read from the source.
-			hookReader = newHook(reader, opts.Progress)
+		length, rerr := readFull(reader, buf)
+		if rerr == io.EOF && partNumber > 1 {
+			break
 		}
 
-		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID,
-			io.LimitReader(hookReader, partSize),
-			partNumber, md5Base64, "", partSize,
-			opts.ServerSideEncryption,
-			!opts.DisableContentSha256,
-		)
+		if rerr != nil && rerr != io.ErrUnexpectedEOF && err != io.EOF {
+			return UploadInfo{}, rerr
+		}
+
+		// Calculate md5sum.
+		if opts.SendContentMd5 {
+			md5Hash.Reset()
+			md5Hash.Write(buf[:length])
+			md5Base64 = base64.StdEncoding.EncodeToString(md5Hash.Sum(nil))
+		} else {
+			// Add CRC32C instead.
+			crc.Reset()
+			crc.Write(buf[:length])
+			cSum := crc.Sum(nil)
+			customHeader.Set("x-amz-checksum-crc32c", base64.StdEncoding.EncodeToString(cSum))
+			crcBytes = append(crcBytes, cSum...)
+		}
+
+		// Update progress reader appropriately to the latest offset
+		// as we read from the source.
+		hooked := newHook(bytes.NewReader(buf[:length]), opts.Progress)
+
+		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID, hooked, partNumber, md5Base64, "", partSize, opts.ServerSideEncryption, !opts.DisableContentSha256, customHeader)
 		if uerr != nil {
 			return UploadInfo{}, uerr
 		}
@@ -363,15 +368,26 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 			return UploadInfo{}, errInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
-			ETag:       part.ETag,
-			PartNumber: part.PartNumber,
+			ETag:           part.ETag,
+			PartNumber:     part.PartNumber,
+			ChecksumCRC32:  part.ChecksumCRC32,
+			ChecksumCRC32C: part.ChecksumCRC32C,
+			ChecksumSHA1:   part.ChecksumSHA1,
+			ChecksumSHA256: part.ChecksumSHA256,
 		})
 	}
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
 
-	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, PutObjectOptions{})
+	opts = PutObjectOptions{}
+	if len(crcBytes) > 0 {
+		// Add hash of hashes.
+		crc.Reset()
+		crc.Write(crcBytes)
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Crc32c": base64.StdEncoding.EncodeToString(crc.Sum(nil))}
+	}
+	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
 	}
@@ -490,14 +506,20 @@ func (c *Client) putObjectDo(ctx context.Context, bucketName, objectName string,
 
 	// extract lifecycle expiry date and rule ID
 	expTime, ruleID := amzExpirationToExpiryDateRuleID(resp.Header.Get(amzExpiration))
-
+	h := resp.Header
 	return UploadInfo{
 		Bucket:           bucketName,
 		Key:              objectName,
-		ETag:             trimEtag(resp.Header.Get("ETag")),
-		VersionID:        resp.Header.Get(amzVersionID),
+		ETag:             trimEtag(h.Get("ETag")),
+		VersionID:        h.Get(amzVersionID),
 		Size:             size,
 		Expiration:       expTime,
 		ExpirationRuleID: ruleID,
+
+		// Checksum values
+		ChecksumCRC32:  h.Get("x-amz-checksum-crc32"),
+		ChecksumCRC32C: h.Get("x-amz-checksum-crc32c"),
+		ChecksumSHA1:   h.Get("x-amz-checksum-sha1"),
+		ChecksumSHA256: h.Get("x-amz-checksum-sha256"),
 	}, nil
 }

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -387,13 +387,12 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 		// Add hash of hashes.
 		crc.Reset()
 		crc.Write(crcBytes)
-		opts.UserMetadata["X-Amz-Checksum-Crc32c"] = base64.StdEncoding.EncodeToString(crc.Sum(nil))
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Crc32c": base64.StdEncoding.EncodeToString(crc.Sum(nil))}
 	}
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
 	}
-	delete(opts.UserMetadata, "X-Amz-Checksum-Crc32c")
 
 	uploadInfo.Size = totalUploadedSize
 	return uploadInfo, nil

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -412,13 +412,12 @@ func (c *Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketNam
 		// Add hash of hashes.
 		crc.Reset()
 		crc.Write(crcBytes)
-		opts.UserMetadata["X-Amz-Checksum-Crc32c"] = base64.StdEncoding.EncodeToString(crc.Sum(nil))
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Crc32c": base64.StdEncoding.EncodeToString(crc.Sum(nil))}
 	}
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
 	}
-	delete(opts.UserMetadata, "X-Amz-Checksum-Crc32c")
 
 	uploadInfo.Size = totalUploadedSize
 	return uploadInfo, nil

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -261,6 +261,12 @@ type ObjectPart struct {
 
 	// Size of the uploaded part data.
 	Size int64
+
+	// Checksum values of each part.
+	ChecksumCRC32  string
+	ChecksumCRC32C string
+	ChecksumSHA1   string
+	ChecksumSHA256 string
 }
 
 // ListObjectPartsResult container for ListObjectParts response.
@@ -299,6 +305,12 @@ type completeMultipartUploadResult struct {
 	Bucket   string
 	Key      string
 	ETag     string
+
+	// Checksum values, hash of hashes of parts.
+	ChecksumCRC32  string
+	ChecksumCRC32C string
+	ChecksumSHA1   string
+	ChecksumSHA256 string
 }
 
 // CompletePart sub container lists individual part numbers and their
@@ -309,6 +321,12 @@ type CompletePart struct {
 	// Part number identifies the part.
 	PartNumber int
 	ETag       string
+
+	// Checksum values
+	ChecksumCRC32  string
+	ChecksumCRC32C string
+	ChecksumSHA1   string
+	ChecksumSHA256 string
 }
 
 // completeMultipartUpload container for completing multipart upload.

--- a/core.go
+++ b/core.go
@@ -89,7 +89,7 @@ func (c Core) ListMultipartUploads(ctx context.Context, bucket, prefix, keyMarke
 // PutObjectPart - Upload an object part.
 func (c Core) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data io.Reader, size int64, md5Base64, sha256Hex string, sse encrypt.ServerSide) (ObjectPart, error) {
 	streamSha256 := true
-	return c.uploadPart(ctx, bucket, object, uploadID, data, partID, md5Base64, sha256Hex, size, sse, streamSha256)
+	return c.uploadPart(ctx, bucket, object, uploadID, data, partID, md5Base64, sha256Hex, size, sse, streamSha256, nil)
 }
 
 // ListObjectParts - List uploaded parts of an incomplete upload.x

--- a/utils.go
+++ b/utils.go
@@ -376,6 +376,12 @@ func ToObjectInfo(bucketName string, objectName string, h http.Header) (ObjectIn
 		UserTags:     userTags,
 		UserTagCount: tagCount,
 		Restore:      restore,
+
+		// Checksum values
+		ChecksumCRC32:  h.Get("x-amz-checksum-crc32"),
+		ChecksumCRC32C: h.Get("x-amz-checksum-crc32c"),
+		ChecksumSHA1:   h.Get("x-amz-checksum-sha1"),
+		ChecksumSHA256: h.Get("x-amz-checksum-sha256"),
 	}, nil
 }
 
@@ -501,7 +507,7 @@ func isSSEHeader(headerKey string) bool {
 func isAmzHeader(headerKey string) bool {
 	key := strings.ToLower(headerKey)
 
-	return strings.HasPrefix(key, "x-amz-meta-") || strings.HasPrefix(key, "x-amz-grant-") || key == "x-amz-acl" || isSSEHeader(headerKey)
+	return strings.HasPrefix(key, "x-amz-meta-") || strings.HasPrefix(key, "x-amz-grant-") || key == "x-amz-acl" || isSSEHeader(headerKey) || strings.HasPrefix(key, "x-amz-checksum-")
 }
 
 var (


### PR DESCRIPTION
Single part, checksums must be done manually for now until we have trailing headers.

For multipart we add CRC32C if we don't already send a checksum and we read the content before sending.

Also serves as test for https://github.com/minio/minio/pull/15433 - but should be backwards compatible.

# AWS S3 tests

## Single Part
```
{"args":{"bucketName":"minio-go-test-gyprb0a1v4l9x05q","objectName":"i3d5m60tguye3hkgxe1o3gcijmynm0","opts":"minio.PutObjectOptions{UserMetadata: metadata, Progress: progress}"},"duration":246249,"function":"PutObject(bucketName, objectName, reader,size, opts)","name":"minio-go: testPutObjectWithChecksums","status":"PASS"}
```

# Multipart

```
These send checksum:
	testPutObjectWithMetadata()
	testPutObjectReadAt()
	testPutObjectsUnknownV2()
	testPutObjectNoLengthV2()

go build functional_tests.go   && ./functional_tests
CHECKSUM: 1yLc4A==
{"args":{"bucketName":"minio-go-test-duyyipdmn2jt2axy","metadata":{"Content-Type":["custom/contenttype"],"X-Amz-Meta-CustomKey":["extra  spaces  in   value"]},"objectName":"zn2pdxznyk6rg46yx2jfifgtemt2u9","opts":"minio.PutObjectOptions{UserMetadata: metadata, Progress: progress}"},"duration":71907,"function":"PutObject(bucketName, objectName, reader,size, opts)","name":"minio-go: testPutObjectWithMetadata","status":"PASS"}
CHECKSUM: 1yLc4A==
{"args":{"bucketName":"minio-go-test-d9smpwyxtqnxcxug","objectContentType":"binary/octet-stream","objectName":"fjuqzickiy94a5i2e1od5exi41bvyh","opts":"objectContentType"},"duration":87869,"function":"PutObject(bucketName, objectName, reader, opts)","name":"minio-go: testPutObjectReadAt","status":"PASS"}
CHECKSUM: 73DecA==
CHECKSUM: 73DecA==
CHECKSUM: 73DecA==
CHECKSUM: 73DecA==
{"args":{"bucketName":"minio-go-test-zlq0e6ayw0hgzmhh","objectName":"minio-go-test-zlq0e6ayw0hgzmhhunique4","opts":"","size":""},"duration":3278,"function":"PutObject(bucketName, objectName, reader,size,opts)","name":"minio-go: testPutObjectsUnknownV2","status":"PASS"}
CHECKSUM: LEgalg==
{"args":{"bucketName":"minio-go-test-f5fssd4wb3opahi0","objectName":"minio-go-test-f5fssd4wb3opahi0unique","opts":"","size":135266304},"duration":46122,"function":"PutObject(bucketName, objectName, reader, size, opts)","name":"minio-go: testPutObjectNoLengthV2","status":"PASS"}	
```

Seems we are compatible with S3.