### PR TITLE
Do not retry request Do() error in some cases

### DIFF
--- a/api.go
+++ b/api.go
@@ -595,12 +595,11 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 		// Initiate the request.
 		res, err = c.do(req)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return nil, err
+			if isRequestErrorRetryable(err) {
+				// Retry the request
+				continue
 			}
-
-			// Retry the request
-			continue
+			return nil, err
 		}
 
 		// For any known successful http status, return quickly.


### PR DESCRIPTION
Do not retry the request if:
- The client is not able to trust the public certificate received from
  the server
- If the server is HTTP but we sent a https request