### PR TITLE
Add fips build tag support

### DIFF
--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -19,6 +19,7 @@ package credentials
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
 	"errors"
@@ -31,7 +32,6 @@ import (
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/signer"
-	sha256 "github.com/minio/sha256-simd"
 )
 
 // AssumeRoleResponse contains the result of successful AssumeRole request.

--- a/pkg/encrypt/fips_disabled.go
+++ b/pkg/encrypt/fips_disabled.go
@@ -1,0 +1,24 @@
+//go:build !fips
+// +build !fips
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2018 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package encrypt
+
+// FIPS is true if 'fips' build tag was specified.
+const FIPS = false

--- a/pkg/encrypt/fips_disabled.go
+++ b/pkg/encrypt/fips_disabled.go
@@ -3,7 +3,7 @@
 
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2018 MinIO, Inc.
+ * Copyright 2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/encrypt/fips_enabled.go
+++ b/pkg/encrypt/fips_enabled.go
@@ -1,0 +1,24 @@
+//go:build fips
+// +build fips
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2018 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package encrypt
+
+// FIPS is true if 'fips' build tag was specified.
+const FIPS = true

--- a/pkg/encrypt/fips_enabled.go
+++ b/pkg/encrypt/fips_enabled.go
@@ -3,7 +3,7 @@
 
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2018 MinIO, Inc.
+ * Copyright 2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/signer/utils.go
+++ b/pkg/signer/utils.go
@@ -19,10 +19,9 @@ package signer
 
 import (
 	"crypto/hmac"
+	"crypto/sha256"
 	"net/http"
 	"strings"
-
-	"github.com/minio/sha256-simd"
 )
 
 // unsignedPayload - value to be set to X-Amz-Content-Sha256 header when

--- a/utils.go
+++ b/utils.go
@@ -20,6 +20,7 @@ package minio
 import (
 	"context"
 	"crypto/md5"
+	fipssha256 "crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/xml"
@@ -39,6 +40,7 @@ import (
 	"time"
 
 	md5simd "github.com/minio/md5-simd"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/sha256-simd"
 )
@@ -520,6 +522,9 @@ func newMd5Hasher() md5simd.Hasher {
 }
 
 func newSHA256Hasher() md5simd.Hasher {
+	if encrypt.FIPS {
+		return &hashWrapper{Hash: fipssha256.New(), isSHA256: true}
+	}
 	return &hashWrapper{Hash: sha256Pool.Get().(hash.Hash), isSHA256: true}
 }
 


### PR DESCRIPTION
Change signer to always use stdlib "crypto/sha256". The simd versions isn't for these payloads anyway.

Change default sha256 hasher to stdlib when fips is enabled.

Fixes #1697