### PR TITLE
Add trailing header checksums

### DIFF
--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -159,8 +159,9 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 			crcBytes = append(crcBytes, cSum...)
 		}
 
+		p := uploadPartParams{bucketName: bucketName, objectName: objectName, uploadID: uploadID, reader: rd, partNumber: partNumber, md5Base64: md5Base64, sha256Hex: sha256Hex, size: int64(length), sse: opts.ServerSideEncryption, streamSha256: !opts.DisableContentSha256, customHeader: customHeader}
 		// Proceed to upload the part.
-		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID, rd, partNumber, md5Base64, sha256Hex, int64(length), opts.ServerSideEncryption, !opts.DisableContentSha256, customHeader)
+		objPart, uerr := c.uploadPart(ctx, p)
 		if uerr != nil {
 			return UploadInfo{}, uerr
 		}
@@ -269,57 +270,73 @@ func (c *Client) initiateMultipartUpload(ctx context.Context, bucketName, object
 	return initiateMultipartUploadResult, nil
 }
 
+type uploadPartParams struct {
+	bucketName   string
+	objectName   string
+	uploadID     string
+	reader       io.Reader
+	partNumber   int
+	md5Base64    string
+	sha256Hex    string
+	size         int64
+	sse          encrypt.ServerSide
+	streamSha256 bool
+	customHeader http.Header
+	trailer      http.Header
+}
+
 // uploadPart - Uploads a part in a multipart upload.
-func (c *Client) uploadPart(ctx context.Context, bucketName string, objectName string, uploadID string, reader io.Reader, partNumber int, md5Base64 string, sha256Hex string, size int64, sse encrypt.ServerSide, streamSha256 bool, customHeader http.Header) (ObjectPart, error) {
+func (c *Client) uploadPart(ctx context.Context, p uploadPartParams) (ObjectPart, error) {
 	// Input validation.
-	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
+	if err := s3utils.CheckValidBucketName(p.bucketName); err != nil {
 		return ObjectPart{}, err
 	}
-	if err := s3utils.CheckValidObjectName(objectName); err != nil {
+	if err := s3utils.CheckValidObjectName(p.objectName); err != nil {
 		return ObjectPart{}, err
 	}
-	if size > maxPartSize {
-		return ObjectPart{}, errEntityTooLarge(size, maxPartSize, bucketName, objectName)
+	if p.size > maxPartSize {
+		return ObjectPart{}, errEntityTooLarge(p.size, maxPartSize, p.bucketName, p.objectName)
 	}
-	if size <= -1 {
-		return ObjectPart{}, errEntityTooSmall(size, bucketName, objectName)
+	if p.size <= -1 {
+		return ObjectPart{}, errEntityTooSmall(p.size, p.bucketName, p.objectName)
 	}
-	if partNumber <= 0 {
+	if p.partNumber <= 0 {
 		return ObjectPart{}, errInvalidArgument("Part number cannot be negative or equal to zero.")
 	}
-	if uploadID == "" {
+	if p.uploadID == "" {
 		return ObjectPart{}, errInvalidArgument("UploadID cannot be empty.")
 	}
 
 	// Get resources properly escaped and lined up before using them in http request.
 	urlValues := make(url.Values)
 	// Set part number.
-	urlValues.Set("partNumber", strconv.Itoa(partNumber))
+	urlValues.Set("partNumber", strconv.Itoa(p.partNumber))
 	// Set upload id.
-	urlValues.Set("uploadId", uploadID)
+	urlValues.Set("uploadId", p.uploadID)
 
 	// Set encryption headers, if any.
-	if customHeader == nil {
-		customHeader = make(http.Header)
+	if p.customHeader == nil {
+		p.customHeader = make(http.Header)
 	}
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
 	// Server-side encryption is supported by the S3 Multipart Upload actions.
 	// Unless you are using a customer-provided encryption key, you don't need
 	// to specify the encryption parameters in each UploadPart request.
-	if sse != nil && sse.Type() == encrypt.SSEC {
-		sse.Marshal(customHeader)
+	if p.sse != nil && p.sse.Type() == encrypt.SSEC {
+		p.sse.Marshal(p.customHeader)
 	}
 
 	reqMetadata := requestMetadata{
-		bucketName:       bucketName,
-		objectName:       objectName,
+		bucketName:       p.bucketName,
+		objectName:       p.objectName,
 		queryValues:      urlValues,
-		customHeader:     customHeader,
-		contentBody:      reader,
-		contentLength:    size,
-		contentMD5Base64: md5Base64,
-		contentSHA256Hex: sha256Hex,
-		streamSha256:     streamSha256,
+		customHeader:     p.customHeader,
+		contentBody:      p.reader,
+		contentLength:    p.size,
+		contentMD5Base64: p.md5Base64,
+		contentSHA256Hex: p.sha256Hex,
+		streamSha256:     p.streamSha256,
+		trailer:          p.trailer,
 	}
 
 	// Execute PUT on each part.
@@ -330,7 +347,7 @@ func (c *Client) uploadPart(ctx context.Context, bucketName string, objectName s
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return ObjectPart{}, httpRespToErrorResponse(resp, bucketName, objectName)
+			return ObjectPart{}, httpRespToErrorResponse(resp, p.bucketName, p.objectName)
 		}
 	}
 	// Once successfully uploaded, return completed part.
@@ -341,8 +358,8 @@ func (c *Client) uploadPart(ctx context.Context, bucketName string, objectName s
 		ChecksumSHA1:   h.Get("x-amz-checksum-sha1"),
 		ChecksumSHA256: h.Get("x-amz-checksum-sha256"),
 	}
-	objPart.Size = size
-	objPart.PartNumber = partNumber
+	objPart.Size = p.size
+	objPart.PartNumber = p.partNumber
 	// Trim off the odd double quotes from ETag in the beginning and end.
 	objPart.ETag = trimEtag(h.Get("ETag"))
 	return objPart, nil

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -107,11 +107,19 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 		return UploadInfo{}, err
 	}
 
+	withChecksum := c.trailingHeaderSupport
+	if withChecksum {
+		if opts.UserMetadata == nil {
+			opts.UserMetadata = make(map[string]string, 1)
+		}
+		opts.UserMetadata["X-Amz-Checksum-Algorithm"] = "CRC32C"
+	}
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
 	if err != nil {
 		return UploadInfo{}, err
 	}
+	delete(opts.UserMetadata, "X-Amz-Checksum-Algorithm")
 
 	// Aborts the multipart upload in progress, if the
 	// function returns any error, since we do not resume
@@ -177,14 +185,32 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 				// As a special case if partNumber is lastPartNumber, we
 				// calculate the offset based on the last part size.
 				if uploadReq.PartNum == lastPartNumber {
-					readOffset = (size - lastPartSize)
+					readOffset = size - lastPartSize
 					partSize = lastPartSize
 				}
 
 				sectionReader := newHook(io.NewSectionReader(reader, readOffset, partSize), opts.Progress)
+				var trailer = make(http.Header, 1)
+				if withChecksum {
+					crc := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+					trailer.Set("x-amz-checksum-crc32c", base64.StdEncoding.EncodeToString(crc.Sum(nil)))
+					sectionReader = newHashReaderWrapper(sectionReader, crc, func(hash []byte) {
+						trailer.Set("x-amz-checksum-crc32c", base64.StdEncoding.EncodeToString(hash))
+					})
+				}
 
 				// Proceed to upload the part.
-				p := uploadPartParams{bucketName: bucketName, objectName: objectName, uploadID: uploadID, reader: sectionReader, partNumber: uploadReq.PartNum, size: partSize, sse: opts.ServerSideEncryption, streamSha256: !opts.DisableContentSha256}
+				p := uploadPartParams{bucketName: bucketName,
+					objectName:   objectName,
+					uploadID:     uploadID,
+					reader:       sectionReader,
+					partNumber:   uploadReq.PartNum,
+					size:         partSize,
+					sse:          opts.ServerSideEncryption,
+					streamSha256: !opts.DisableContentSha256,
+					sha256Hex:    "",
+					trailer:      trailer,
+				}
 				objPart, err := c.uploadPart(ctx, p)
 				if err != nil {
 					uploadedPartsCh <- uploadedPartRes{
@@ -222,8 +248,12 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 			// Update the totalUploadedSize.
 			totalUploadedSize += uploadRes.Size
 			complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
-				ETag:       uploadRes.Part.ETag,
-				PartNumber: uploadRes.Part.PartNumber,
+				ETag:           uploadRes.Part.ETag,
+				PartNumber:     uploadRes.Part.PartNumber,
+				ChecksumCRC32:  uploadRes.Part.ChecksumCRC32,
+				ChecksumCRC32C: uploadRes.Part.ChecksumCRC32C,
+				ChecksumSHA1:   uploadRes.Part.ChecksumSHA1,
+				ChecksumSHA256: uploadRes.Part.ChecksumSHA256,
 			})
 		}
 	}
@@ -235,6 +265,18 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
+
+	if withChecksum {
+		// Add hash of hashes.
+		crc := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+		for _, part := range complMultipartUpload.Parts {
+			cs, err := base64.StdEncoding.DecodeString(part.ChecksumCRC32C)
+			if err == nil {
+				crc.Write(cs)
+			}
+		}
+		opts.UserMetadata = map[string]string{"X-Amz-Checksum-Crc32c": base64.StdEncoding.EncodeToString(crc.Sum(nil))}
+	}
 
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, PutObjectOptions{})
 	if err != nil {

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -269,6 +269,9 @@ func (c *Client) putObjectCommon(ctx context.Context, bucketName, objectName str
 	}
 
 	if size < 0 {
+		if opts.DisableMultipart {
+			return UploadInfo{}, errors.New("no length provided and multipart disabled")
+		}
 		return c.putObjectMultipartStreamNoLength(ctx, bucketName, objectName, reader, opts)
 	}
 
@@ -366,7 +369,8 @@ func (c *Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketNam
 		rd := newHook(bytes.NewReader(buf[:length]), opts.Progress)
 
 		// Proceed to upload the part.
-		objPart, uerr := c.uploadPart(ctx, bucketName, objectName, uploadID, rd, partNumber, md5Base64, "", int64(length), opts.ServerSideEncryption, !opts.DisableContentSha256, customHeader)
+		p := uploadPartParams{bucketName: bucketName, objectName: objectName, uploadID: uploadID, reader: rd, partNumber: partNumber, md5Base64: md5Base64, size: int64(length), sse: opts.ServerSideEncryption, streamSha256: !opts.DisableContentSha256, customHeader: customHeader}
+		objPart, uerr := c.uploadPart(ctx, p)
 		if uerr != nil {
 			return UploadInfo{}, uerr
 		}

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -323,10 +323,10 @@ type CompletePart struct {
 	ETag       string
 
 	// Checksum values
-	ChecksumCRC32  string
-	ChecksumCRC32C string
-	ChecksumSHA1   string
-	ChecksumSHA256 string
+	ChecksumCRC32  string `xml:"ChecksumCRC32,omitempty"`
+	ChecksumCRC32C string `xml:"ChecksumCRC32C,omitempty"`
+	ChecksumSHA1   string `xml:"ChecksumSHA1,omitempty"`
+	ChecksumSHA256 string `xml:"ChecksumSHA256,omitempty"`
 }
 
 // completeMultipartUpload container for completing multipart upload.

--- a/api.go
+++ b/api.go
@@ -108,6 +108,7 @@ type Options struct {
 	BucketLookup BucketLookupType
 
 	// TrailingHeaders indicates server support of trailing headers.
+	// Only supported for v4 signatures.
 	TrailingHeaders bool
 
 	// Custom hash routines. Leave nil to use standard.
@@ -254,7 +255,7 @@ func privateNew(endpoint string, opts *Options) (*Client, error) {
 		clnt.sha256Hasher = newSHA256Hasher
 	}
 
-	clnt.trailingHeaderSupport = opts.TrailingHeaders
+	clnt.trailingHeaderSupport = opts.TrailingHeaders && !clnt.overrideSignerType.IsV4()
 
 	// Sets bucket lookup style, whether server accepts DNS or Path lookup. Default is Auto - determined
 	// by the SDK. When Auto is specified, DNS lookup is used for Amazon/Google cloud endpoints and Path for all other endpoints.

--- a/api.go
+++ b/api.go
@@ -255,7 +255,7 @@ func privateNew(endpoint string, opts *Options) (*Client, error) {
 		clnt.sha256Hasher = newSHA256Hasher
 	}
 
-	clnt.trailingHeaderSupport = opts.TrailingHeaders && !clnt.overrideSignerType.IsV4()
+	clnt.trailingHeaderSupport = opts.TrailingHeaders && clnt.overrideSignerType.IsV4()
 
 	// Sets bucket lookup style, whether server accepts DNS or Path lookup. Default is Auto - determined
 	// by the SDK. When Auto is specified, DNS lookup is used for Amazon/Google cloud endpoints and Path for all other endpoints.

--- a/constants.go
+++ b/constants.go
@@ -46,6 +46,10 @@ const maxMultipartPutObjectSize = 1024 * 1024 * 1024 * 1024 * 5
 // we don't want to sign the request payload
 const unsignedPayload = "UNSIGNED-PAYLOAD"
 
+// unsignedPayloadTrailer value to be set to X-Amz-Content-Sha256 header when
+// we don't want to sign the request payload, but have a trailer.
+const unsignedPayloadTrailer = "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+
 // Total number of parallel workers used for multipart operation.
 const totalWorkers = 4
 

--- a/core.go
+++ b/core.go
@@ -88,8 +88,19 @@ func (c Core) ListMultipartUploads(ctx context.Context, bucket, prefix, keyMarke
 
 // PutObjectPart - Upload an object part.
 func (c Core) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data io.Reader, size int64, md5Base64, sha256Hex string, sse encrypt.ServerSide) (ObjectPart, error) {
-	streamSha256 := true
-	return c.uploadPart(ctx, bucket, object, uploadID, data, partID, md5Base64, sha256Hex, size, sse, streamSha256, nil)
+	p := uploadPartParams{
+		bucketName:   bucket,
+		objectName:   object,
+		uploadID:     uploadID,
+		reader:       data,
+		partNumber:   partID,
+		md5Base64:    md5Base64,
+		sha256Hex:    sha256Hex,
+		size:         size,
+		sse:          sse,
+		streamSha256: true,
+	}
+	return c.uploadPart(ctx, p)
 }
 
 // ListObjectParts - List uploaded parts of an incomplete upload.x

--- a/pkg/signer/request-signature-streaming-unsigned-trailer.go
+++ b/pkg/signer/request-signature-streaming-unsigned-trailer.go
@@ -1,0 +1,231 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2022 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package signer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// getUnsignedChunkLength - calculates the length of chunk metadata
+func getUnsignedChunkLength(chunkDataSize int64) int64 {
+	return int64(len(fmt.Sprintf("%x", chunkDataSize))) +
+		crlfLen +
+		chunkDataSize +
+		crlfLen
+}
+
+// getUSStreamLength - calculates the length of the overall stream (data + metadata)
+func getUSStreamLength(dataLen, chunkSize int64, trailers http.Header) int64 {
+	if dataLen <= 0 {
+		return 0
+	}
+
+	chunksCount := int64(dataLen / chunkSize)
+	remainingBytes := int64(dataLen % chunkSize)
+	streamLen := int64(0)
+	streamLen += chunksCount * getUnsignedChunkLength(chunkSize)
+	if remainingBytes > 0 {
+		streamLen += getUnsignedChunkLength(remainingBytes)
+	}
+	streamLen += getUnsignedChunkLength(0)
+	if len(trailers) > 0 {
+		for name, placeholder := range trailers {
+			if len(placeholder) > 0 {
+				streamLen += int64(len(name) + len(trailerKVSeparator) + len(placeholder[0]) + 1)
+			}
+		}
+		streamLen += crlfLen
+	}
+
+	return streamLen
+}
+
+// prepareStreamingRequest - prepares a request with appropriate
+// headers before computing the seed signature.
+func prepareUSStreamingRequest(req *http.Request, sessionToken string, dataLen int64, timestamp time.Time) {
+	req.TransferEncoding = []string{"aws-chunked"}
+	if sessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", sessionToken)
+	}
+
+	req.Header.Set("X-Amz-Date", timestamp.Format(iso8601DateFormat))
+	// Set content length with streaming signature for each chunk included.
+	req.ContentLength = getUSStreamLength(dataLen, int64(payloadChunkSize), req.Trailer)
+}
+
+// buildChunkHeader - returns the chunk header.
+// e.g string(IntHexBase(chunk-size)) + ";chunk-signature=" + signature + \r\n + chunk-data + \r\n
+func buildUSChunkHeader(chunkLen int64) []byte {
+	return []byte(strconv.FormatInt(chunkLen, 16) + ";\r\n")
+}
+
+// StreamingUSReader implements chunked upload signature as a reader on
+// top of req.Body's ReaderCloser chunk header;data;... repeat
+type StreamingUSReader struct {
+	contentLen     int64         // Content-Length from req header
+	baseReadCloser io.ReadCloser // underlying io.Reader
+	bytesRead      int64         // bytes read from underlying io.Reader
+	buf            bytes.Buffer  // holds signed chunk
+	chunkBuf       []byte        // holds raw data read from req Body
+	chunkBufLen    int           // no. of bytes read so far into chunkBuf
+	done           bool          // done reading the underlying reader to EOF
+	chunkNum       int
+	totalChunks    int
+	lastChunkSize  int
+	trailer        http.Header
+}
+
+// writeChunk - signs a chunk read from s.baseReader of chunkLen size.
+func (s *StreamingUSReader) writeChunk(chunkLen int, addCrLf bool) {
+	s.buf.WriteString(strconv.FormatInt(int64(chunkLen), 16) + "\r\n")
+
+	// Write chunk data into streaming buffer
+	s.buf.Write(s.chunkBuf[:chunkLen])
+
+	// Write the chunk trailer.
+	if addCrLf {
+		s.buf.Write([]byte("\r\n"))
+	}
+
+	// Reset chunkBufLen for next chunk read.
+	s.chunkBufLen = 0
+	s.chunkNum++
+}
+
+// addSignedTrailer - adds a trailer with the provided headers,
+// then signs a chunk and adds it to output.
+func (s *StreamingUSReader) addTrailer(h http.Header) {
+	olen := len(s.chunkBuf)
+	s.chunkBuf = s.chunkBuf[:0]
+	for k, v := range h {
+		s.chunkBuf = append(s.chunkBuf, []byte(strings.ToLower(k)+trailerKVSeparator+v[0]+"\n")...)
+	}
+
+	s.buf.Write(s.chunkBuf)
+	s.buf.WriteString("\r\n\r\n")
+
+	// Reset chunkBufLen for next chunk read.
+	s.chunkBuf = s.chunkBuf[:olen]
+	s.chunkBufLen = 0
+	s.chunkNum++
+}
+
+// StreamingUnsignedV4 - provides chunked upload
+func StreamingUnsignedV4(req *http.Request, sessionToken string, dataLen int64, reqTime time.Time) *http.Request {
+	// Set headers needed for streaming signature.
+	prepareUSStreamingRequest(req, sessionToken, dataLen, reqTime)
+
+	if req.Body == nil {
+		req.Body = ioutil.NopCloser(bytes.NewReader([]byte("")))
+	}
+
+	stReader := &StreamingUSReader{
+		baseReadCloser: req.Body,
+		chunkBuf:       make([]byte, payloadChunkSize),
+		contentLen:     dataLen,
+		chunkNum:       1,
+		totalChunks:    int((dataLen+payloadChunkSize-1)/payloadChunkSize) + 1,
+		lastChunkSize:  int(dataLen % payloadChunkSize),
+	}
+	if len(req.Trailer) > 0 {
+		stReader.trailer = req.Trailer
+		// Remove...
+		req.Trailer = nil
+	}
+
+	req.Body = stReader
+
+	return req
+}
+
+// Read - this method performs chunk upload signature providing a
+// io.Reader interface.
+func (s *StreamingUSReader) Read(buf []byte) (int, error) {
+	switch {
+	// After the last chunk is read from underlying reader, we
+	// never re-fill s.buf.
+	case s.done:
+
+	// s.buf will be (re-)filled with next chunk when has lesser
+	// bytes than asked for.
+	case s.buf.Len() < len(buf):
+		s.chunkBufLen = 0
+		for {
+			n1, err := s.baseReadCloser.Read(s.chunkBuf[s.chunkBufLen:])
+			// Usually we validate `err` first, but in this case
+			// we are validating n > 0 for the following reasons.
+			//
+			// 1. n > 0, err is one of io.EOF, nil (near end of stream)
+			// A Reader returning a non-zero number of bytes at the end
+			// of the input stream may return either err == EOF or err == nil
+			//
+			// 2. n == 0, err is io.EOF (actual end of stream)
+			//
+			// Callers should always process the n > 0 bytes returned
+			// before considering the error err.
+			if n1 > 0 {
+				s.chunkBufLen += n1
+				s.bytesRead += int64(n1)
+
+				if s.chunkBufLen == payloadChunkSize ||
+					(s.chunkNum == s.totalChunks-1 &&
+						s.chunkBufLen == s.lastChunkSize) {
+					// Sign the chunk and write it to s.buf.
+					s.writeChunk(s.chunkBufLen, true)
+					break
+				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					// No more data left in baseReader - last chunk.
+					// Done reading the last chunk from baseReader.
+					s.done = true
+
+					// bytes read from baseReader different than
+					// content length provided.
+					if s.bytesRead != s.contentLen {
+						return 0, fmt.Errorf("http: ContentLength=%d with Body length %d", s.contentLen, s.bytesRead)
+					}
+
+					// Sign the chunk and write it to s.buf.
+					s.writeChunk(0, len(s.trailer) == 0)
+					if len(s.trailer) > 0 {
+						// Trailer must be set now.
+						s.addTrailer(s.trailer)
+					}
+					break
+				}
+				return 0, err
+			}
+
+		}
+	}
+	return s.buf.Read(buf)
+}
+
+// Close - this method makes underlying io.ReadCloser's Close method available.
+func (s *StreamingUSReader) Close() error {
+	return s.baseReadCloser.Close()
+}

--- a/pkg/signer/request-signature-streaming-unsigned-trailer.go
+++ b/pkg/signer/request-signature-streaming-unsigned-trailer.go
@@ -75,12 +75,6 @@ func prepareUSStreamingRequest(req *http.Request, sessionToken string, dataLen i
 	req.ContentLength = getUSStreamLength(dataLen, int64(payloadChunkSize), req.Trailer)
 }
 
-// buildChunkHeader - returns the chunk header.
-// e.g string(IntHexBase(chunk-size)) + ";chunk-signature=" + signature + \r\n + chunk-data + \r\n
-func buildUSChunkHeader(chunkLen int64) []byte {
-	return []byte(strconv.FormatInt(chunkLen, 16) + ";\r\n")
-}
-
 // StreamingUSReader implements chunked upload signature as a reader on
 // top of req.Body's ReaderCloser chunk header;data;... repeat
 type StreamingUSReader struct {

--- a/pkg/signer/request-signature-streaming_test.go
+++ b/pkg/signer/request-signature-streaming_test.go
@@ -19,6 +19,7 @@ package signer
 
 import (
 	"bytes"
+	"encoding/hex"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -111,7 +112,8 @@ func TestSetStreamingAuthorizationTrailer(t *testing.T) {
 	req.Header.Set("x-amz-storage-class", "REDUCED_REDUNDANCY")
 	req.Host = ""
 	req.URL.Host = "s3.amazonaws.com"
-	req.Trailer = http.Header{"x-amz-checksum-crc32c": nil}
+	req.Trailer = http.Header{}
+	req.Trailer.Set("x-amz-checksum-crc32c", "wdBDMA==")
 
 	dataLen := int64(65 * 1024)
 	reqTime, _ := time.Parse(iso8601DateFormat, "20130524T000000Z")
@@ -124,6 +126,8 @@ func TestSetStreamingAuthorizationTrailer(t *testing.T) {
 	if actualAuthorization != expectedAuthorization {
 		t.Errorf("Expected \n%s but received \n%s", expectedAuthorization, actualAuthorization)
 	}
+	chunkData := []byte("x-amz-checksum-crc32c:wdBDMA==\n")
+	t.Log(hex.EncodeToString(sum256(chunkData)))
 }
 
 func TestStreamingReader(t *testing.T) {

--- a/pkg/signer/request-signature-v4.go
+++ b/pkg/signer/request-signature-v4.go
@@ -263,11 +263,11 @@ func PostPresignSignatureV4(policyBase64 string, t time.Time, secretAccessKey, l
 
 // SignV4STS - signature v4 for STS request.
 func SignV4STS(req http.Request, accessKeyID, secretAccessKey, location string) *http.Request {
-	return signV4(req, accessKeyID, secretAccessKey, "", location, ServiceTypeSTS)
+	return signV4(req, accessKeyID, secretAccessKey, "", location, ServiceTypeSTS, nil)
 }
 
 // Internal function called for different service types.
-func signV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, location, serviceType string) *http.Request {
+func signV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, location, serviceType string, trailer http.Header) *http.Request {
 	// Signature calculation is not needed for anonymous credentials.
 	if accessKeyID == "" || secretAccessKey == "" {
 		return &req
@@ -282,6 +282,15 @@ func signV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, locati
 	// Set session token if available.
 	if sessionToken != "" {
 		req.Header.Set("X-Amz-Security-Token", sessionToken)
+	}
+
+	if len(trailer) > 0 {
+		for k := range trailer {
+			req.Header.Add("X-Amz-Trailer", strings.ToLower(k))
+		}
+
+		req.TransferEncoding = []string{"aws-chunked"}
+		req.Header.Set("x-amz-decoded-content-length", strconv.FormatInt(req.ContentLength, 10))
 	}
 
 	hashedPayload := getHashedPayload(req)
@@ -321,11 +330,22 @@ func signV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, locati
 	auth := strings.Join(parts, ", ")
 	req.Header.Set("Authorization", auth)
 
+	if len(trailer) > 0 {
+		// Use custom chunked encoding.
+		req.Trailer = trailer
+		return StreamingUnsignedV4(&req, sessionToken, req.ContentLength, time.Now().UTC())
+	}
 	return &req
 }
 
 // SignV4 sign the request before Do(), in accordance with
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
 func SignV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, location string) *http.Request {
-	return signV4(req, accessKeyID, secretAccessKey, sessionToken, location, ServiceTypeS3)
+	return signV4(req, accessKeyID, secretAccessKey, sessionToken, location, ServiceTypeS3, nil)
+}
+
+// SignV4Trailer sign the request before Do(), in accordance with
+// http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+func SignV4Trailer(req http.Request, accessKeyID, secretAccessKey, sessionToken, location string, trailer http.Header) *http.Request {
+	return signV4(req, accessKeyID, secretAccessKey, sessionToken, location, ServiceTypeS3, trailer)
 }

--- a/pkg/signer/request-signature-v4.go
+++ b/pkg/signer/request-signature-v4.go
@@ -42,7 +42,6 @@ const (
 	ServiceTypeSTS = "sts"
 )
 
-//
 // Excerpts from @lsegal -
 // https:/github.com/aws/aws-sdk-js/issues/659#issuecomment-120477258.
 //
@@ -57,7 +56,6 @@ const (
 // * Accept-Encoding
 // Some S3 servers like Hitachi Content Platform do not honor this header for signature
 // calculation.
-//
 var v4IgnoredHeaders = map[string]bool{
 	"Accept-Encoding": true,
 	"Authorization":   true,
@@ -177,12 +175,13 @@ func getSignedHeaders(req http.Request, ignoredHeaders map[string]bool) string {
 // getCanonicalRequest generate a canonical request of style.
 //
 // canonicalRequest =
-//  <HTTPMethod>\n
-//  <CanonicalURI>\n
-//  <CanonicalQueryString>\n
-//  <CanonicalHeaders>\n
-//  <SignedHeaders>\n
-//  <HashedPayload>
+//
+//	<HTTPMethod>\n
+//	<CanonicalURI>\n
+//	<CanonicalQueryString>\n
+//	<CanonicalHeaders>\n
+//	<SignedHeaders>\n
+//	<HashedPayload>
 func getCanonicalRequest(req http.Request, ignoredHeaders map[string]bool, hashedPayload string) string {
 	req.URL.RawQuery = strings.ReplaceAll(req.URL.Query().Encode(), "+", "%20")
 	canonicalRequest := strings.Join([]string{

--- a/utils.go
+++ b/utils.go
@@ -627,3 +627,38 @@ func IsNetworkOrHostDown(err error, expectTimeouts bool) bool {
 	}
 	return false
 }
+
+// newHashReaderWrapper will hash all reads done through r.
+// When r returns io.EOF the done function will be called with the sum.
+func newHashReaderWrapper(r io.Reader, h hash.Hash, done func(hash []byte)) *hashReaderWrapper {
+	return &hashReaderWrapper{
+		r:    r,
+		h:    h,
+		done: done,
+	}
+}
+
+type hashReaderWrapper struct {
+	r    io.Reader
+	h    hash.Hash
+	done func(hash []byte)
+}
+
+// Read implements the io.Reader interface.
+func (h *hashReaderWrapper) Read(p []byte) (n int, err error) {
+	n, err = h.r.Read(p)
+	if n > 0 {
+		n2, err := h.h.Write(p[:n])
+		if err != nil {
+			return 0, err
+		}
+		if n2 != n {
+			return 0, io.ErrShortWrite
+		}
+	}
+	if err == io.EOF {
+		// Call back
+		h.done(h.h.Sum(nil))
+	}
+	return n, err
+}


### PR DESCRIPTION
Adds signed (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER`) and unsigned (`STREAMING-UNSIGNED-PAYLOAD-TRAILER`) trailer support.

Enabled per client and for now used for multipart uploads. Verified against AWS S3.