### PR TITLE
Allow empty contentTypeStartsWith in PostPolicy

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4216,10 +4216,6 @@ func testPresignedPostPolicy() {
 		logError(testName, function, args, startTime, "", "SetContentType did not fail for invalid conditions", err)
 		return
 	}
-	if err := policy.SetContentTypeStartsWith(""); err == nil {
-		logError(testName, function, args, startTime, "", "SetContentTypeStartsWith did not fail for invalid conditions", err)
-		return
-	}
 	if err := policy.SetContentLengthRange(1024*1024, 1024); err == nil {
 		logError(testName, function, args, startTime, "", "SetContentLengthRange did not fail for invalid conditions", err)
 		return

--- a/post-policy.go
+++ b/post-policy.go
@@ -171,10 +171,8 @@ func (p *PostPolicy) SetContentType(contentType string) error {
 
 // SetContentTypeStartsWith - Sets what content-type of the object for this policy
 // based upload can start with.
+// If "" is provided it allows all content-types.
 func (p *PostPolicy) SetContentTypeStartsWith(contentTypeStartsWith string) error {
-	if strings.TrimSpace(contentTypeStartsWith) == "" || contentTypeStartsWith == "" {
-		return errInvalidArgument("No content type specified.")
-	}
 	policyCond := policyCondition{
 		matchType: "starts-with",
 		condition: "$Content-Type",


### PR DESCRIPTION
The S3 spec allows this:

https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html#sigv4-ConditionMatching
> Matching Any Content
> To configure the POST policy to allow any content within a form field, use starts-with with an empty value ("").

With this change
```go
policy.SetContentTypeStartsWith("")
```
allows the uploader to specify any content-type they want.
