### PR TITLE
fix: allow any content using starts-with with an empty value

### DIFF
--- a/functional_tests.go
+++ b/functional_tests.go
@@ -4204,10 +4204,6 @@ func testPresignedPostPolicy() {
 		logError(testName, function, args, startTime, "", "SetKey did not fail for invalid conditions", err)
 		return
 	}
-	if err := policy.SetKeyStartsWith(""); err == nil {
-		logError(testName, function, args, startTime, "", "SetKeyStartsWith did not fail for invalid conditions", err)
-		return
-	}
 	if err := policy.SetExpires(time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)); err == nil {
 		logError(testName, function, args, startTime, "", "SetExpires did not fail for invalid conditions", err)
 		return

--- a/post-policy.go
+++ b/post-policy.go
@@ -97,10 +97,8 @@ func (p *PostPolicy) SetKey(key string) error {
 
 // SetKeyStartsWith - Sets an object name that an policy based upload
 // can start with.
+// Can use an empty value ("") to allow any key.
 func (p *PostPolicy) SetKeyStartsWith(keyStartsWith string) error {
-	if strings.TrimSpace(keyStartsWith) == "" || keyStartsWith == "" {
-		return errInvalidArgument("Object prefix is empty.")
-	}
 	policyCond := policyCondition{
 		matchType: "starts-with",
 		condition: "$key",
@@ -171,7 +169,7 @@ func (p *PostPolicy) SetContentType(contentType string) error {
 
 // SetContentTypeStartsWith - Sets what content-type of the object for this policy
 // based upload can start with.
-// If "" is provided it allows all content-types.
+// Can use an empty value ("") to allow any content-type.
 func (p *PostPolicy) SetContentTypeStartsWith(contentTypeStartsWith string) error {
 	policyCond := policyCondition{
 		matchType: "starts-with",
@@ -283,9 +281,13 @@ func (p *PostPolicy) SetUserData(key string, value string) error {
 }
 
 // addNewPolicy - internal helper to validate adding new policies.
+// Can use starts-with with an empty value ("") to allow any content within a form field.
 func (p *PostPolicy) addNewPolicy(policyCond policyCondition) error {
-	if policyCond.matchType == "" || policyCond.condition == "" || policyCond.value == "" {
+	if policyCond.matchType == "" || policyCond.condition == "" {
 		return errInvalidArgument("Policy fields are empty.")
+	}
+	if policyCond.matchType != "starts-with" && policyCond.value == "" {
+		return errInvalidArgument("Policy value is empty.")
 	}
 	p.conditions = append(p.conditions, policyCond)
 	return nil


### PR DESCRIPTION
Thanks for the PR @skirsten 

```text
commit 4acfae712723fae025df6b841f9cc0e80c8ca464
Author: Simon Kirsten <1972314+skirsten@users.noreply.github.com>
Date:   Fri Oct 21 22:38:04 2022 +0200

    Allow empty contentTypeStartsWith in PostPolicy (#1710)
```

- But it's still not allowed to add an empty value in `addNewPolicy`, so i supported it when using `starts-with`.
- And by the way, this PR will allow empty `keyStartsWith` in `PostPolicy`.