### PR TITLE
Allow , character in object tags

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -69,7 +69,7 @@ const (
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
 // borrowed from this article and also testing various ASCII characters following regex
 // is supported by AWS S3 for both tags and values.
-var validTagKeyValue = regexp.MustCompile(`^[a-zA-Z0-9-+\-._:/@ ]+$`)
+var validTagKeyValue = regexp.MustCompile(`^[a-zA-Z0-9-+\-.,_:/@ ]+$`)
 
 func checkKey(key string) error {
 	if len(key) == 0 {

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -43,6 +43,11 @@ func TestParseTags(t *testing.T) {
 			fmt.Sprintf("%0128d=%0256d", 1, 1),
 			false,
 		},
+		// Valid tags support ,
+		{
+			"11/23/2022, 1:07:45 PM",
+			false,
+		},
 		// Failure cases - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
 		{
 			"key1=value1&key1=value2",


### PR DESCRIPTION
Based on the possibly updated tag restrictions described here - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions

> If you enable instance tags in instance metadata, instance tag keys can only use letters (a-z, A-Z), numbers (0-9), and the following characters: + - = . , _ : @. Instance tag keys can't contain spaces or /, and can't comprise only . (one period), .. (two periods), or _index. For more information, see [Work with instance tags in instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).