### PR TITLE
feat: volcengine TOS also support virtualhost.

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -65,9 +65,8 @@ func IsValidIP(ip string) bool {
 	return net.ParseIP(ip) != nil
 }
 
-// IsVirtualHostSupported - verifies if bucketName can be part of
-// virtual host. Currently only Amazon S3 and Google Cloud Storage
-// would support this.
+// IsVirtualHostSupported - verifies if bucketName can be part of virtual host.
+// Currently supported storages: Amazon S3, Google Cloud Storage, Aliyun OSS, VolcEngine TOS.
 func IsVirtualHostSupported(endpointURL url.URL, bucketName string) bool {
 	if endpointURL == sentinelURL {
 		return false
@@ -78,7 +77,8 @@ func IsVirtualHostSupported(endpointURL url.URL, bucketName string) bool {
 		return false
 	}
 	// Return true for all other cases
-	return IsAmazonEndpoint(endpointURL) || IsGoogleEndpoint(endpointURL) || IsAliyunOSSEndpoint(endpointURL)
+	return IsAmazonEndpoint(endpointURL) || IsGoogleEndpoint(endpointURL) || IsAliyunOSSEndpoint(endpointURL) ||
+		IsVolcEngineTOSEndpoint(endpointURL)
 }
 
 // Refer for region styles - https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
@@ -170,6 +170,11 @@ func GetRegionFromURL(endpointURL url.URL) string {
 // IsAliyunOSSEndpoint - Match if it is exactly Aliyun OSS endpoint.
 func IsAliyunOSSEndpoint(endpointURL url.URL) bool {
 	return strings.HasSuffix(endpointURL.Host, "aliyuncs.com")
+}
+
+// IsVolcEngineTOSEndpoint - Match if it is exactly VolcEngine TOS endpoint
+func IsVolcEngineTOSEndpoint(endpointURL url.URL) bool {
+	return strings.HasSuffix(endpointURL.Host, ".ivolces.com") || strings.HasSuffix(endpointURL.Host, ".volces.com")
 }
 
 // IsAmazonEndpoint - Match if it is exactly Amazon S3 endpoint.


### PR DESCRIPTION
Hi, I am using [volcengine TOS](https://www.volcengine.com/docs/6349/147050) (a s3 compatible Object storage from bytedance), mc and [argo workflows](https://github.com/argoproj/argo-workflows) recently,  and find out volcengine TOS only support VirtualHost because path-style is being [deprecated](https://aws.amazon.com/cn/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) by aws s3 in the future. 

It will be convenient if mc will detect it by default, and It will also make argo workflows S3ArtifactRepository available based on volcengine TOS. :)