### PR TITLE
expiration date format must not use 999Z use 000Z

### DIFF
--- a/post-policy.go
+++ b/post-policy.go
@@ -25,7 +25,7 @@ import (
 )
 
 // expirationDateFormat date format for expiration key in json policy.
-const expirationDateFormat = "2006-01-02T15:04:05.999Z"
+const expirationDateFormat = "2006-01-02T15:04:05.000Z"
 
 // policyCondition explanation:
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html


### PR DESCRIPTION
999Z means padded zeroes are ignored however
000Z maintains the padded zeroes upto 3 elements