### PR TITLE
PutObject() to return a wrapped error for io.Reader errors

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -242,7 +242,7 @@ func (c *Client) PutObject(ctx context.Context, bucketName, objectName string, r
 		return UploadInfo{}, err
 	}
 
-	return c.putObjectCommon(ctx, bucketName, objectName, reader, objectSize, opts)
+	return c.putObjectCommon(ctx, bucketName, objectName, &wrapReader{reader}, objectSize, opts)
 }
 
 func (c *Client) putObjectCommon(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64, opts PutObjectOptions) (info UploadInfo, err error) {

--- a/utils.go
+++ b/utils.go
@@ -666,3 +666,20 @@ func (h *hashReaderWrapper) Read(p []byte) (n int, err error) {
 	}
 	return n, err
 }
+
+// wrapReader embeds io.Reader but returns an error
+// with 'read error' prefix. This is needed because
+// net/http Do() request does not have a way to indicate
+// a way to indicate this is an error from reading the
+// request body.
+type wrapReader struct {
+	io.Reader
+}
+
+func (wr wrapReader) Read(p []byte) (n int, e error) {
+	n, e = wr.Reader.Read(p)
+	if e != nil && e != io.EOF { // do not wrap io.EOF for callers not using errors.Is() yet
+		e = fmt.Errorf("read: %w", e)
+	}
+	return
+}


### PR DESCRIPTION
PutObject() does not differentiate between internal errors 
or errors coming from io.Reader argument, which makes t
roubleshooting harder.

Add a prefix for the returned error during reading io.Reader
 argument.

Example:
Before this commit:

```
mc: <ERROR> Failed to copy `http://192.168.1.113:9000/testbucket/testobject.2`. Put "http://localhost:9001/testbucket/testobject.2": Resource requested is unreadable, please reduce your request rate
```

After this commit:
```
mc: <ERROR> Failed to copy `http://192.168.1.113:9000/testbucket/testobject.2`. Put "http://localhost:9001/testbucket/testobject.2": read: Resource requested is unreadable, please reduce your request rate
```