### PR TITLE
PutObject to allow upload with a given size less than io.Reader content

### DIFF
--- a/api.go
+++ b/api.go
@@ -813,7 +813,11 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 	if metadata.contentLength == 0 {
 		req.Body = nil
 	} else {
-		req.Body = io.NopCloser(metadata.contentBody)
+		body := metadata.contentBody
+		if metadata.contentLength > 0 {
+			body = io.LimitReader(body, metadata.contentLength)
+		}
+		req.Body = io.NopCloser(body)
 	}
 
 	// Set incoming content-length.


### PR DESCRIPTION
This commit will allow upload of io.Reader content when size is specified 
and it is less than what io.Reader can provide.

e.g.

```
 // Upload an object.
 _, err = c.PutObject(context.Background(), "bucket", "object", 
                bytes.NewBuffer([]byte("abcd")), 3, minio.PutObjectOptions{})
```