### PR TITLE
Support V10 generated config

### DIFF
--- a/pkg/credentials/file_minio_client.go
+++ b/pkg/credentials/file_minio_client.go
@@ -113,6 +113,7 @@ type hostConfig struct {
 type config struct {
 	Version string                `json:"version"`
 	Hosts   map[string]hostConfig `json:"hosts"`
+	Aliases map[string]hostConfig `json:"aliases"`
 }
 
 // loadAliass loads from the file pointed to by shared credentials filename for alias.
@@ -129,5 +130,10 @@ func loadAlias(filename, alias string) (hostConfig, error) {
 	if err = json.Unmarshal(configBytes, cfg); err != nil {
 		return hostConfig{}, err
 	}
+
+	if cfg.Version == "10" {
+		return cfg.Aliases[alias], nil
+	}
+
 	return cfg.Hosts[alias], nil
 }


### PR DESCRIPTION
It's currently not possible to use `credentials.NewFileMinioClient` with a V10 generated config because it expects `hosts` instead of `aliases`. This commit uses `aliases` if the version is 10.