### PR TITLE
feat(#1755): GetObject supports overriding response header values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 validator
 golangci-lint
 functional_tests
+.idea

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strconv"
 	"sync"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
@@ -654,19 +652,11 @@ func (c *Client) getObject(ctx context.Context, bucketName, objectName string, o
 		return nil, ObjectInfo{}, nil, err
 	}
 
-	urlValues := make(url.Values)
-	if opts.VersionID != "" {
-		urlValues.Set("versionId", opts.VersionID)
-	}
-	if opts.PartNumber > 0 {
-		urlValues.Set("partNumber", strconv.Itoa(opts.PartNumber))
-	}
-
 	// Execute GET on objectName.
 	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{
 		bucketName:       bucketName,
 		objectName:       objectName,
-		queryValues:      urlValues,
+		queryValues:      opts.toQueryValues(),
 		customHeader:     opts.Header(),
 		contentSHA256Hex: emptySHA256Hex,
 	})

--- a/api-get-options.go
+++ b/api-get-options.go
@@ -20,6 +20,8 @@ package minio
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/encrypt"
@@ -36,6 +38,7 @@ type AdvancedGetOptions struct {
 // during GET requests.
 type GetObjectOptions struct {
 	headers              map[string]string
+	reqParams            url.Values
 	ServerSideEncryption encrypt.ServerSide
 	VersionID            string
 	PartNumber           int
@@ -81,6 +84,34 @@ func (o *GetObjectOptions) Set(key, value string) {
 		o.headers = make(map[string]string)
 	}
 	o.headers[http.CanonicalHeaderKey(key)] = value
+}
+
+// SetReqParam - set request query string parameter
+// supported key: see supportedQueryValues.
+// If an unsupported key is passed in, it will be ignored and nothing will be done.
+func (o *GetObjectOptions) SetReqParam(key, value string) {
+	if !isStandardQueryValue(key) {
+		// do nothing
+		return
+	}
+	if o.reqParams == nil {
+		o.reqParams = make(url.Values)
+	}
+	o.reqParams.Set(key, value)
+}
+
+// AddReqParam - add request query string parameter
+// supported key: see supportedQueryValues.
+// If an unsupported key is passed in, it will be ignored and nothing will be done.
+func (o *GetObjectOptions) AddReqParam(key, value string) {
+	if !isStandardQueryValue(key) {
+		// do nothing
+		return
+	}
+	if o.reqParams == nil {
+		o.reqParams = make(url.Values)
+	}
+	o.reqParams.Add(key, value)
 }
 
 // SetMatchETag - set match etag.
@@ -148,4 +179,25 @@ func (o *GetObjectOptions) SetRange(start, end int64) error {
 				start, end))
 	}
 	return nil
+}
+
+// toQueryValues - Convert the versionId, partNumber, and reqParams in Options to query string parameters.
+func (o *GetObjectOptions) toQueryValues() url.Values {
+	urlValues := make(url.Values)
+	if o.VersionID != "" {
+		urlValues.Set("versionId", o.VersionID)
+	}
+	if o.PartNumber > 0 {
+		urlValues.Set("partNumber", strconv.Itoa(o.PartNumber))
+	}
+
+	if o.reqParams != nil {
+		for key, values := range o.reqParams {
+			for _, value := range values {
+				urlValues.Add(key, value)
+			}
+		}
+	}
+
+	return urlValues
 }

--- a/examples/s3/getobject-override-respheaders.go
+++ b/examples/s3/getobject-override-respheaders.go
@@ -21,7 +21,13 @@
 package s3
 
 import (
+	"context"
+	"io"
+	"log"
 	"os"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 func main() {

--- a/examples/s3/getobject-override-respheaders.go
+++ b/examples/s3/getobject-override-respheaders.go
@@ -1,0 +1,75 @@
+//go:build example
+// +build example
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3
+
+import (
+	"os"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname, my-objectname and
+	// my-testfile are dummy values, please replace them with original values.
+
+	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
+	// This boolean value is the last argument for New().
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", &minio.Options{
+		Creds:  credentials.NewStaticV4("YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", ""),
+		Secure: true,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// response-cache-control=ResponseCacheControl
+	// response-content-disposition=ResponseContentDisposition
+	// response-content-encoding=ResponseContentEncoding
+	// response-content-language=ResponseContentLanguage
+	// response-content-type=ResponseContentType
+	// response-expires=ResponseExpires
+	opt := minio.GetObjectOptions{}
+	opt.SetReqParam("response-content-disposition", `attachment; filename="testing.txt"`)
+	opt.SetReqParam("response-cache-control", "No-cache")
+	opt.SetReqParam("response-content-encoding", "x-gzip")
+	opt.SetReqParam("response-expires", "Mon, 02 Jan 2006 15:04:05 GMT")
+	reader, err := s3Client.GetObject(context.Background(), "my-bucketname", "my-objectname", opt)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer reader.Close()
+
+	localFile, err := os.Create("my-testfile")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer localFile.Close()
+
+	stat, err := reader.Stat()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if _, err := io.CopyN(localFile, reader, stat.Size); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/examples/s3/go.mod
+++ b/examples/s3/go.mod
@@ -20,4 +20,4 @@ require (
 	gopkg.in/ini.v1 v1.66.6 // indirect
 )
 
-replace github.com/minio/minio-go/v7 v7.0.10 => ../..
+replace github.com/minio/minio-go/v7 v7.0.32 => github.com/reedchan7/minio-go-sdk/v7 v7.0.48-0.20230116044606-89d027d0d418

--- a/examples/s3/go.mod
+++ b/examples/s3/go.mod
@@ -20,4 +20,4 @@ require (
 	gopkg.in/ini.v1 v1.66.6 // indirect
 )
 
-replace github.com/minio/minio-go/v7 v7.0.32 => github.com/reedchan7/minio-go-sdk/v7 v7.0.48-0.20230116044606-89d027d0d418
+replace github.com/minio/minio-go/v7 v7.0.32 => ../..

--- a/examples/s3/go.sum
+++ b/examples/s3/go.sum
@@ -50,6 +50,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/reedchan7/minio-go-sdk/v7 v7.0.48-0.20230116044606-89d027d0d418 h1:GwSqibsxYk62jRck8mt/HThq2LicP3A8pVtoWJ/WCeI=
+github.com/reedchan7/minio-go-sdk/v7 v7.0.48-0.20230116044606-89d027d0d418/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/utils.go
+++ b/utils.go
@@ -523,7 +523,7 @@ var supportedQueryValues = map[string]bool{
 	"response-expires":             true,
 }
 
-// isStandardQueryValue will return true when the passed in query string parameter is supported rather than customised.
+// isStandardQueryValue will return true when the passed in query string parameter is supported rather than customized.
 func isStandardQueryValue(qsKey string) bool {
 	return supportedQueryValues[qsKey]
 }

--- a/utils.go
+++ b/utils.go
@@ -511,6 +511,23 @@ func isAmzHeader(headerKey string) bool {
 	return strings.HasPrefix(key, "x-amz-meta-") || strings.HasPrefix(key, "x-amz-grant-") || key == "x-amz-acl" || isSSEHeader(headerKey) || strings.HasPrefix(key, "x-amz-checksum-")
 }
 
+// supportedQueryValues is a list of query strings that can be passed in when using GetObject.
+var supportedQueryValues = map[string]bool{
+	"partNumber":                   true,
+	"versionId":                    true,
+	"response-cache-control":       true,
+	"response-content-disposition": true,
+	"response-content-encoding":    true,
+	"response-content-language":    true,
+	"response-content-type":        true,
+	"response-expires":             true,
+}
+
+// isStandardQueryValue will return true when the passed in query string parameter is supported rather than customised.
+func isStandardQueryValue(qsKey string) bool {
+	return supportedQueryValues[qsKey]
+}
+
 var (
 	md5Pool    = sync.Pool{New: func() interface{} { return md5.New() }}
 	sha256Pool = sync.Pool{New: func() interface{} { return sha256.New() }}


### PR DESCRIPTION
This allows you to pass in the response headers that you need to override when calling the GetObject method.