### PR TITLE
Add CRC32 checksums as trailer

### DIFF
--- a/core.go
+++ b/core.go
@@ -87,7 +87,10 @@ func (c Core) ListMultipartUploads(ctx context.Context, bucket, prefix, keyMarke
 }
 
 // PutObjectPart - Upload an object part.
-func (c Core) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data io.Reader, size int64, md5Base64, sha256Hex string, sse encrypt.ServerSide) (ObjectPart, error) {
+func (c Core) PutObjectPart(ctx context.Context, bucket, object, uploadID string,
+	partID int, data io.Reader, size int64, md5Base64, sha256Hex string,
+	sse encrypt.ServerSide, customHeader, trailer http.Header,
+) (ObjectPart, error) {
 	p := uploadPartParams{
 		bucketName:   bucket,
 		objectName:   object,
@@ -99,6 +102,8 @@ func (c Core) PutObjectPart(ctx context.Context, bucket, object, uploadID string
 		size:         size,
 		sse:          sse,
 		streamSha256: true,
+		customHeader: customHeader,
+		trailer:      trailer,
 	}
 	return c.uploadPart(ctx, p)
 }
@@ -109,11 +114,11 @@ func (c Core) ListObjectParts(ctx context.Context, bucket, object, uploadID stri
 }
 
 // CompleteMultipartUpload - Concatenate uploaded parts and commit to an object.
-func (c Core) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, parts []CompletePart, opts PutObjectOptions) (string, error) {
+func (c Core) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, parts []CompletePart, opts PutObjectOptions) (UploadInfo, error) {
 	res, err := c.completeMultipartUpload(ctx, bucket, object, uploadID, completeMultipartUpload{
 		Parts: parts,
 	}, opts)
-	return res.ETag, err
+	return res, err
 }
 
 // AbortMultipartUpload - Abort an incomplete upload.

--- a/core_test.go
+++ b/core_test.go
@@ -875,7 +875,7 @@ func TestCoreMultipartUpload(t *testing.T) {
 			partID++
 			data := bytes.NewReader(partBuf[:n])
 			dataLen := int64(len(partBuf[:n]))
-			objectPart, err := core.PutObjectPart(context.Background(), bucketName, objectName, uploadID, partID, data, dataLen, "", "", encrypt.NewSSE())
+			objectPart, err := core.PutObjectPart(context.Background(), bucketName, objectName, uploadID, partID, data, dataLen, "", "", encrypt.NewSSE(), nil, nil)
 			if err != nil {
 				t.Fatal("Error:", err, bucketName, objectName)
 			}

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -2053,7 +2053,7 @@ func testPutObjectWithChecksums() {
 	}
 
 	// Enable tracing, write to stderr.
-	//c.TraceOn(os.Stderr)
+	// c.TraceOn(os.Stderr)
 
 	// Set user agent.
 	c.SetAppInfo("MinIO-go-FunctionalTest", "0.1.0")
@@ -8414,14 +8414,14 @@ func testSSECMultipartEncryptedToSSECCopyObjectPart() {
 
 	var completeParts []minio.CompletePart
 
-	part, err := c.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, bytes.NewReader(buf[:5*1024*1024]), 5*1024*1024, "", "", srcencryption)
+	part, err := c.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, bytes.NewReader(buf[:5*1024*1024]), 5*1024*1024, "", "", srcencryption, nil, nil)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PutObjectPart call failed", err)
 		return
 	}
 	completeParts = append(completeParts, minio.CompletePart{PartNumber: part.PartNumber, ETag: part.ETag})
 
-	part, err = c.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 2, bytes.NewReader(buf[5*1024*1024:]), 1024*1024, "", "", srcencryption)
+	part, err = c.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 2, bytes.NewReader(buf[5*1024*1024:]), 1024*1024, "", "", srcencryption, nil, nil)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "PutObjectPart call failed", err)
 		return


### PR DESCRIPTION
This change is made for the multipart parallel (non-seekable) stream
upload.
