### PR TITLE
Detect S3 region from non amazon endpoint

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -113,6 +113,12 @@ var elbAmazonCnRegex = regexp.MustCompile(`elb(.*?).amazonaws.com.cn$`)
 // amazonS3HostPrivateLink - regular expression used to determine if an arg is s3 host in AWS PrivateLink interface endpoints style
 var amazonS3HostPrivateLink = regexp.MustCompile(`^(?:bucket|accesspoint).vpce-.*?.s3.(.*?).vpce.amazonaws.com$`)
 
+// Regular expression used to determine if the arg is related to amazon
+var amazonHostRegex = regexp.MustCompile(`\.amazonaws\.com(?:\.cn)?$`)
+
+// genericS3HostDot - regular expression used to determine if an arg is s3 host in . style.
+var genericS3HostDot = regexp.MustCompile(`^s3\.([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(?:\.(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])){2,}$`)
+
 // GetRegionFromURL - returns a region from url host.
 func GetRegionFromURL(endpointURL url.URL) string {
 	if endpointURL == sentinelURL {
@@ -163,6 +169,13 @@ func GetRegionFromURL(endpointURL url.URL) string {
 	parts = amazonS3HostPrivateLink.FindStringSubmatch(endpointURL.Host)
 	if len(parts) > 1 {
 		return parts[1]
+	}
+
+	if !amazonHostRegex.MatchString(endpointURL.Host) {
+		parts = genericS3HostDot.FindStringSubmatch(endpointURL.Host)
+		if len(parts) > 1 {
+			return parts[1]
+		}
 	}
 	return ""
 }

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -127,6 +127,36 @@ func TestGetRegionFromURL(t *testing.T) {
 			},
 			expectedRegion: "us-west-1",
 		},
+		{
+			u: url.URL{
+				Host: "s3.sbg.io.cloud.ovh.net",
+			},
+			expectedRegion: "sbg",
+		},
+		{
+			u: url.URL{
+				Host: "s3.nl-ams.scw.cloud",
+			},
+			expectedRegion: "nl-ams",
+		},
+		{
+			u: url.URL{
+				Host: "s3.us-central-1.wasabisys.com",
+			},
+			expectedRegion: "us-central-1",
+		},
+		{
+			u: url.URL{
+				Host: "s3.wasabisys.com",
+			},
+			expectedRegion: "",
+		},
+		{
+			u: url.URL{
+				Host: "something.s3.foo.bar",
+			},
+			expectedRegion: "",
+		},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
when using S3 endpoints from providers other than amazon the region is not extracted from the endpoint and the first request returns `HTTP 400` with `AuthorizationHeaderMalformed` and the client gather the region from the XML and then retry the request with the correct region.

It would be nice to extract the region from the endpoint instead of having to set it in `minio.Options` as it's redundant when the region is already in the endpoint.