### PR TITLE
Detect S3 region from OVH Cloud endpoints

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -113,6 +113,9 @@ var elbAmazonCnRegex = regexp.MustCompile(`elb(.*?).amazonaws.com.cn$`)
 // amazonS3HostPrivateLink - regular expression used to determine if an arg is s3 host in AWS PrivateLink interface endpoints style
 var amazonS3HostPrivateLink = regexp.MustCompile(`^(?:bucket|accesspoint).vpce-.*?.s3.(.*?).vpce.amazonaws.com$`)
 
+// ovhS3Host - regular expression used to determine if an arg is an OVH CLOUD s3 host in . style.
+var ovhS3Host = regexp.MustCompile(`^s3\.([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(?:\.(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]))?\.cloud\.ovh\.(?:net|us)$`)
+
 // GetRegionFromURL - returns a region from url host.
 func GetRegionFromURL(endpointURL url.URL) string {
 	if endpointURL == sentinelURL {
@@ -161,6 +164,11 @@ func GetRegionFromURL(endpointURL url.URL) string {
 		return parts[1]
 	}
 	parts = amazonS3HostPrivateLink.FindStringSubmatch(endpointURL.Host)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+
+	parts = ovhS3Host.FindStringSubmatch(endpointURL.Host)
 	if len(parts) > 1 {
 		return parts[1]
 	}

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -127,6 +127,24 @@ func TestGetRegionFromURL(t *testing.T) {
 			},
 			expectedRegion: "us-west-1",
 		},
+		{
+			u: url.URL{
+				Host: "s3.sbg.perf.cloud.ovh.net",
+			},
+			expectedRegion: "sbg",
+		},
+		{
+			u: url.URL{
+				Host: "s3.us-west-1.io.cloud.ovh.us",
+			},
+			expectedRegion: "us-west-1",
+		},
+		{
+			u: url.URL{
+				Host: "s3.sbg.cloud.ovh.net",
+			},
+			expectedRegion: "sbg",
+		},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
as discussed in #1782, a generic solution is not acceptable.

here is the regex that match all [OVH CLOUD S3](https://www.ovhcloud.com/en/public-cloud/object-storage/) endpoints.

Working at ovh in the public storage team, I can assure the endpoints matches `s3.region(.sub)?.cloud.ovh.(net|us)`. Futur endpoints will follow the same pattern.