### PR TITLE
Presign return invalid url

### DIFF
--- a/api-presigned.go
+++ b/api-presigned.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
@@ -41,13 +42,13 @@ func (c *Client) presignURL(ctx context.Context, method string, bucketName strin
 	if err = isValidExpiry(expires); err != nil {
 		return nil, err
 	}
-
+	validObjectName := strings.TrimPrefix(objectName, "/")
 	// Convert expires into seconds.
 	expireSeconds := int64(expires / time.Second)
 	reqMetadata := requestMetadata{
 		presignURL:         true,
 		bucketName:         bucketName,
-		objectName:         objectName,
+		objectName:         validObjectName,
 		expires:            expireSeconds,
 		queryValues:        reqParams,
 		extraPresignHeader: extraHeaders,


### PR DESCRIPTION
Hello.

Expectation:
/some-bucket/subdirectory-path1/subdirectory-path2/test.jpg

Reality:
 /some-bucket//subdirectory-path1/subdirectory-path2/test.jpg

`
d, err := client.PreSign(context.Background(), "some-bucket", "/subdirectory-path1/subdirectory-path2/test.jpg")
fmt.Println(d.Path) // returning /some-bucket//subdirectory-path1/subdirectory-path2/test.jpg
`

this fix trim objectName path, to correct urlPath 