### PR TITLE
Revert "Add missing aws-chunked transfer encoding (#1803)"

### DIFF
--- a/.github/workflows/go-windows.yml
+++ b/.github/workflows/go-windows.yml
@@ -33,12 +33,10 @@ jobs:
         env:
           MINT_MODE: core
           SERVER_ENDPOINT: localhost:9000
-          ACCESS_KEY: minio
-          SECRET_KEY: minio123
+          ACCESS_KEY: minioadmin
+          SECRET_KEY: minioadmin
           ENABLE_HTTPS: 1
           MINIO_KMS_MASTER_KEY: my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574
-          MINIO_ACCESS_KEY: minio
-          MINIO_SECRET_KEY: minio123
           MINIO_CI_CD: true
         run: |
           New-Item -ItemType Directory -Path "$env:temp/certs-dir"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,11 +33,9 @@ jobs:
         env:
           MINT_MODE: full
           SERVER_ENDPOINT: localhost:9000
-          ACCESS_KEY: minio
-          SECRET_KEY: minio123
+          ACCESS_KEY: minioadmin
+          SECRET_KEY: minioadmin
           ENABLE_HTTPS: 1
-          MINIO_ACCESS_KEY: minio
-          MINIO_SECRET_KEY: minio123
           MINIO_KMS_MASTER_KEY: my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574
           SSL_CERT_FILE: /tmp/certs-dir/public.crt
           MINIO_CI_CD: true

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ vet:
 	${GOPATH}/bin/staticcheck -tests=false -checks="all,-ST1000,-ST1003,-ST1016,-ST1020,-ST1021,-ST1022,-ST1023,-ST1005"
 
 test:
-	@GO111MODULE=on SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minio SECRET_KEY=minio123 ENABLE_HTTPS=1 MINT_MODE=full go test -race -v ./...
+	@GO111MODULE=on SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 MINT_MODE=full go test -race -v ./...
 
 examples:
 	@echo "Building s3 examples"
@@ -30,7 +30,7 @@ examples:
 
 functional-test:
 	@GO111MODULE=on go build -race functional_tests.go
-	@SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minio SECRET_KEY=minio123 ENABLE_HTTPS=1 MINT_MODE=full ./functional_tests
+	@SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 MINT_MODE=full ./functional_tests
 
 clean:
 	@echo "Cleaning up all the generated files"

--- a/pkg/signer/request-signature-streaming.go
+++ b/pkg/signer/request-signature-streaming.go
@@ -130,8 +130,8 @@ func prepareStreamingRequest(req *http.Request, sessionToken string, dataLen int
 		for k := range req.Trailer {
 			req.Header.Add("X-Amz-Trailer", strings.ToLower(k))
 		}
+		req.TransferEncoding = []string{"aws-chunked"}
 	}
-	req.TransferEncoding = []string{"aws-chunked"}
 
 	if sessionToken != "" {
 		req.Header.Set("X-Amz-Security-Token", sessionToken)


### PR DESCRIPTION
This reverts commit 8175bf7bdaa7f8d5bff612af0a2f5dad78998064.