### PR TITLE
listen bucket: Support empty events from the server

### DIFF
--- a/api-bucket-notification.go
+++ b/api-bucket-notification.go
@@ -166,6 +166,7 @@ func (c *Client) ListenBucketNotification(ctx context.Context, bucketName, prefi
 
 		// Prepare urlValues to pass into the request on every loop
 		urlValues := make(url.Values)
+		urlValues.Set("ping", "true")
 		urlValues.Set("prefix", prefix)
 		urlValues.Set("suffix", suffix)
 		urlValues["events"] = events
@@ -224,6 +225,12 @@ func (c *Client) ListenBucketNotification(ctx context.Context, bucketName, prefi
 					closeResponse(resp)
 					continue
 				}
+
+				// Empty events pinged from the server
+				if len(notificationInfo.Records) == 0 && notificationInfo.Err == nil {
+					continue
+				}
+
 				// Send notificationInfo
 				select {
 				case notificationInfoCh <- notificationInfo:


### PR DESCRIPTION
Ask the server to send empty events to clear the buffer 
scanner which can be filled with whitespaces but without
 new lines when the bucket is idle and without any events