### PR TITLE
GetBucketLocation: Use vhost signature in case of v2 signature

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -240,9 +240,7 @@ func (c *Client) getBucketLocationRequest(ctx context.Context, bucketName string
 	}
 
 	if signerType.IsV2() {
-		// Get Bucket Location calls should be always path style
-		isVirtualHost := false
-		req = signer.SignV2(*req, accessKeyID, secretAccessKey, isVirtualHost)
+		req = signer.SignV2(*req, accessKeyID, secretAccessKey, isVirtualStyle)
 		return req, nil
 	}
 


### PR DESCRIPTION
The existing code always picks a path style signature when 
v2 mode is selected. Reviewing the history shows little information
 why it is done that way.

A previous recent commit, 24cdd7fc940230d35edf1a4d4824c0e7b5a02828, 
though it seems correct,  broke existing deployments that use GCS 
(e.g. https://github.com/minio/mc/issues/4547)

We should not sign v2 with path style when the endpoint is vhost.

This commit is tested with  MinIO/AWS/GCS when v2 is enabled.