### PR TITLE
listen bucket: Support empty events from the server

### DIFF
--- a/api-bucket-notification.go
+++ b/api-bucket-notification.go
@@ -166,6 +166,7 @@ func (c *Client) ListenBucketNotification(ctx context.Context, bucketName, prefi
 
 		// Prepare urlValues to pass into the request on every loop
 		urlValues := make(url.Values)
+		urlValues.Set("ping", "10")
 		urlValues.Set("prefix", prefix)
 		urlValues.Set("suffix", suffix)
 		urlValues["events"] = events
@@ -224,6 +225,12 @@ func (c *Client) ListenBucketNotification(ctx context.Context, bucketName, prefi
 					closeResponse(resp)
 					continue
 				}
+
+				// Empty events pinged from the server
+				if len(notificationInfo.Records) == 0 && notificationInfo.Err == nil {
+					continue
+				}
+
 				// Send notificationInfo
 				select {
 				case notificationInfoCh <- notificationInfo:


### PR DESCRIPTION
Ask the server to send empty events in Listen Bucket API

With older MinIO versions, this would clear the whitespaces for the
scanner buffer, many whitespaces will make the scanner complains as it
needs a new line to clear some internal buffer.

With new MinIO version, ping=10 query will be considered and the server
will send empty events, instead of the whitespaces, each 10 seconds.