### PR TITLE
Add missing JSON tags for NoncurrentVersionExpiration struct

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -54,8 +54,8 @@ func (n AbortIncompleteMultipartUpload) MarshalXML(e *xml.Encoder, start xml.Sta
 // specific period in the object's lifetime.
 type NoncurrentVersionExpiration struct {
 	XMLName                 xml.Name       `xml:"NoncurrentVersionExpiration" json:"-"`
-	NoncurrentDays          ExpirationDays `xml:"NoncurrentDays,omitempty"`
-	NewerNoncurrentVersions int            `xml:"NewerNoncurrentVersions,omitempty"`
+	NoncurrentDays          ExpirationDays `xml:"NoncurrentDays,omitempty" json:"NoncurrentDays,omitempty"`
+	NewerNoncurrentVersions int            `xml:"NewerNoncurrentVersions,omitempty" json:"NewerNoncurrentVersions,omitempty"`
 }
 
 // MarshalXML if n is non-empty, i.e has a non-zero NoncurrentDays or NewerNoncurrentVersions.


### PR DESCRIPTION
The omission of the missing JSON tags on the NoncurrentVersionExpiration struct was causing the default value of NoncurrentDays to be shown even when it was not being entered.

Steps to reproduce:
1- Build `mc` with the latest version of `minio-go`. Then verify that `NoncurrentDays` is shown as `0` even when it is not entered.
```
$ cat test1.json
{
  "Rules": [
   {
    "ID": "chhjo4um3rd3sheeultg",
    "NoncurrentVersionExpiration": {
     "NewerNoncurrentVersions": 1
    },
    "Status": "Enabled"
   }
  ]
 }
$ ./mc ilm  import play/test < ~/test1.json
Lifecycle configuration imported successfully to `play/test`.
$ ./mc ilm  export play/test 
{
 "Rules": [
  {
   "ID": "chhjo4um3rd3sheeultg",
   "NoncurrentVersionExpiration": {
    "NoncurrentDays": 0,
    "NewerNoncurrentVersions": 1
   },
   "Status": "Enabled"
  }
 ]
}
```
2- Build `mc` with this branch of `minio-go`. Then verify that `NoncurrentDays` is not shown when it is not entered.
```
$ cat test1.json
{
  "Rules": [
   {
    "ID": "chhjo4um3rd3sheeultg",
    "NoncurrentVersionExpiration": {
     "NewerNoncurrentVersions": 1
    },
    "Status": "Enabled"
   }
  ]
 }
$ ./mc ilm  import play/test < ~/test1.json
Lifecycle configuration imported successfully to `play/test`.
$ ./mc ilm  export play/test 
{
 "Rules": [
  {
   "ID": "chhjo4um3rd3sheeultg",
   "NoncurrentVersionExpiration": {
    "NewerNoncurrentVersions": 1
   },
   "Status": "Enabled"
  }
 ]
}
```