### PR TITLE
fix: Send correct host header when an endpoint is IPv4

### DIFF
--- a/api.go
+++ b/api.go
@@ -919,7 +919,7 @@ func (c *Client) makeTargetURL(bucketName, objectName, bucketLocation string, is
 	if h, p, err := net.SplitHostPort(host); err == nil {
 		if scheme == "http" && p == "80" || scheme == "https" && p == "443" {
 			host = h
-			if ip := net.ParseIP(h); ip != nil && ip.To16() != nil {
+			if ip := net.ParseIP(h); ip != nil && ip.To4() == nil {
 				host = "[" + h + "]"
 			}
 		}


### PR DESCRIPTION
Currently, when the specified endpoint is an IP v4 address and the port is 80/443, 
minio-go sends a Host header with a bracket, which is wrong.

An ipV4 can be converted to ip6 in golang library, therefore using ip.To4() shoud 
return nil if the passed IP is v6.