### PR TITLE
Fix fanout response unmarshalable error type

### DIFF
--- a/api-put-object-fan-out.go
+++ b/api-put-object-fan-out.go
@@ -62,7 +62,7 @@ type PutObjectFanOutResponse struct {
 	ETag         string     `json:"etag,omitempty"`
 	VersionID    string     `json:"versionId,omitempty"`
 	LastModified *time.Time `json:"lastModified,omitempty"`
-	Error        error      `json:"error,omitempty"`
+	Error        string     `json:"error,omitempty"`
 }
 
 // PutObjectFanOut - is a variant of PutObject instead of writing a single object from a single


### PR DESCRIPTION
Type `error` cannot be JSON unmarshaled, so it should not be used in responses.

Change the type to a  string.

Not backwards compatible.