### PR TITLE
Support External Id and Session Token

### DIFF
--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -101,6 +101,7 @@ type STSAssumeRoleOptions struct {
 	// Optional only valid if using with AWS STS
 	RoleARN         string
 	RoleSessionName string
+	ExternalId      string
 }
 
 // NewSTSAssumeRole returns a pointer to a new
@@ -160,6 +161,9 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 	}
 	if opts.Policy != "" {
 		v.Set("Policy", opts.Policy)
+	}
+	if opts.ExternalId != "" {
+		v.Set("ExternalId", opts.ExternalId)
 	}
 
 	u, err := url.Parse(endpoint)

--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -101,7 +101,7 @@ type STSAssumeRoleOptions struct {
 	// Optional only valid if using with AWS STS
 	RoleARN         string
 	RoleSessionName string
-	ExternalId      string
+	ExternalID      string
 }
 
 // NewSTSAssumeRole returns a pointer to a new
@@ -162,8 +162,8 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 	if opts.Policy != "" {
 		v.Set("Policy", opts.Policy)
 	}
-	if opts.ExternalId != "" {
-		v.Set("ExternalId", opts.ExternalId)
+	if opts.ExternalID != "" {
+		v.Set("ExternalId", opts.ExternalID)
 	}
 
 	u, err := url.Parse(endpoint)

--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -93,7 +93,8 @@ type STSAssumeRoleOptions struct {
 	AccessKey string
 	SecretKey string
 
-	Policy string // Optional to assign a policy to the assumed role
+	SessionToken string // Optional if the first request is made with temporary credentials.
+	Policy       string // Optional to assign a policy to the assumed role
 
 	Location        string // Optional commonly needed with AWS STS.
 	DurationSeconds int    // Optional defaults to 1 hour.
@@ -185,6 +186,9 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(hash.Sum(nil)))
+	if opts.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", opts.SessionToken)
+	}
 	req = signer.SignV4STS(*req, opts.AccessKey, opts.SecretKey, opts.Location)
 
 	resp, err := clnt.Do(req)


### PR DESCRIPTION
This adds support for ExternalId and Session Token for Assume Role when Temporary Credentials are already in use at the time role assumption is trying to be done.

ExternalId I believe is an AWS specific thing, it's optional, when added it sets the appropriate query string parameter.
SessionToken may or may not be AWS specific, but again it's optional, when added it sets the appropriate AWS header.