### PR TITLE
fix: RetainUntilDate in the correct format

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -109,7 +109,7 @@ func (opts CopyDestOptions) Marshal(header http.Header) {
 
 	if opts.Mode != RetentionMode("") && !opts.RetainUntilDate.IsZero() {
 		header.Set(amzLockMode, opts.Mode.String())
-		header.Set(amzLockRetainUntil, opts.RetainUntilDate.Format(time.RFC3339))
+		header.Set(amzLockRetainUntil, opts.RetainUntilDate.Format(iso8601TimeFormat))
 	}
 
 	if opts.Encryption != nil {

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -158,7 +158,7 @@ func (opts PutObjectOptions) Header() (header http.Header) {
 	}
 
 	if !opts.RetainUntilDate.IsZero() {
-		header.Set("X-Amz-Object-Lock-Retain-Until-Date", opts.RetainUntilDate.Format(time.RFC3339))
+		header.Set(amzLockRetainUntil, opts.RetainUntilDate.Format(iso8601TimeFormat))
 	}
 
 	if opts.LegalHold != "" {

--- a/constants.go
+++ b/constants.go
@@ -57,6 +57,7 @@ const totalWorkers = 4
 const (
 	signV4Algorithm   = "AWS4-HMAC-SHA256"
 	iso8601DateFormat = "20060102T150405Z"
+	iso8601TimeFormat = "2006-01-02T15:04:05.000Z"
 )
 
 const (


### PR DESCRIPTION
`RetainUntilDate` uses the `time.RFC3339` format instead of the ISO 8601 format.

This problem generates the error `The retain until date must be provided in ISO 8601 format`.