### PR TITLE
fix: support more type to umnarshaJSON

### DIFF
--- a/pkg/set/stringset.go
+++ b/pkg/set/stringset.go
@@ -153,18 +153,18 @@ func (set StringSet) MarshalJSON() ([]byte, error) {
 // If 'data' contains JSON string, the set contains the string as one element.
 // If 'data' contains Other JSON types, JSON parse error is returned.
 func (set *StringSet) UnmarshalJSON(data []byte) error {
-	sl := []string{}
+	sl := []interface{}{}
 	var err error
 	if err = json.Unmarshal(data, &sl); err == nil {
 		*set = make(StringSet)
 		for _, s := range sl {
-			set.Add(s)
+			set.Add(fmt.Sprintf("%v", s))
 		}
 	} else {
-		var s string
+		var s interface{}
 		if err = json.Unmarshal(data, &s); err == nil {
 			*set = make(StringSet)
-			set.Add(s)
+			set.Add(fmt.Sprintf("%v", s))
 		}
 	}
 


### PR DESCRIPTION
support more type to umnarshaJSON
fix: https://github.com/minio/mc/issues/3786
or 
```log
ReadString: expects " or n, but found [, error found in #1 byte of ...|[true]|..., bigger context ...|[true]|...
```
`[true]` will unmarsha here.