### PR TITLE
Drop seeding rand in tests

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -48,9 +48,6 @@ func TestGetObjectCore(t *testing.T) {
 		t.Skip("skipping functional tests for the short runs")
 	}
 
-	// Seed random based on current time.
-	rand.Seed(time.Now().Unix())
-
 	// Instantiate new minio core client object.
 	c, err := NewCore(
 		os.Getenv(serverEndpoint),
@@ -248,9 +245,6 @@ func TestGetObjectContentEncoding(t *testing.T) {
 		t.Skip("skipping functional tests for the short runs")
 	}
 
-	// Seed random based on current time.
-	rand.Seed(time.Now().Unix())
-
 	// Instantiate new minio core client object.
 	c, err := NewCore(
 		os.Getenv(serverEndpoint),
@@ -323,9 +317,6 @@ func TestGetBucketPolicy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping functional tests for short runs")
 	}
-
-	// Seed random based on current time.
-	rand.Seed(time.Now().Unix())
 
 	// Instantiate new minio client object.
 	c, err := NewCore(


### PR DESCRIPTION
Since go requirement is migrated to go1.21,
rand doesn't require seeding unless same
sequence is needed.