### PR TITLE
Added `x-minio-replication-actual-object-size` to allowed headers

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -517,6 +517,7 @@ var supportedReplicationEncryptionHeaders = map[string]bool{
 	"x-minio-replication-server-side-encryption-seal-algorithm": true,
 	"x-minio-replication-server-side-encryption-iv":             true,
 	"x-minio-replication-encrypted-multipart":                   true,
+	"x-minio-replication-object-size":                           true,
 	// Add more supported headers here.
 	// Must be lower case.
 }

--- a/utils.go
+++ b/utils.go
@@ -517,7 +517,7 @@ var supportedReplicationEncryptionHeaders = map[string]bool{
 	"x-minio-replication-server-side-encryption-seal-algorithm": true,
 	"x-minio-replication-server-side-encryption-iv":             true,
 	"x-minio-replication-encrypted-multipart":                   true,
-	"x-minio-replication-object-size":                           true,
+	"x-minio-replication-actual-object-size":                    true,
 	// Add more supported headers here.
 	// Must be lower case.
 }


### PR DESCRIPTION
Need to send actual object size while replicating a multipart object as parts would be replicated as is with their encrypted content and content length. Later at target while creating xl.meta for the completed object, we need the actual object size be set as `X-Minio-Internal-actual-size`