### PR TITLE
fix: non md5 etags

### DIFF
--- a/api-get-object-file.go
+++ b/api-get-object-file.go
@@ -69,7 +69,8 @@ func (c *Client) FGetObject(ctx context.Context, bucketName, objectName, filePat
 	}
 
 	// Write to a temporary file "fileName.part.minio" before saving.
-	filePartPath := filePath + objectStat.ETag + ".part.minio"
+	filePartPath := filePath + sum256Hex([]byte(objectStat.ETag)) + ".part.minio"
+
 
 	// If exists, open in append mode. If not create it as a part file.
 	filePart, err := os.OpenFile(filePartPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)


### PR DESCRIPTION
minio and S3 are consistent about ETAGs being MD5 strings or slight variants of that. However GCS can produce [ETAGs of any format](https://cloud.google.com/storage/docs/hashes-etags#etags) when the file was multi-part uploaded to GCS. We therefore have encountered ETAGs that look like the following:

- `CNzP/6ips4UDEAE`
- `CMKV/Jacs4UDEAE= `

Due to the slash, these ETAGs get interpreted as a directory delimiter on unix systems when the ETAG is templated into the temporary download file path on `FGetObject`, leading to a `no such file or directory` error.

The updated code SHA256 hashes the ETAG value that goes into the temporary download file path, to ensure the path is always accessible. 