### PR TITLE
Update vulncheck Go version to 1.22.x

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.21.8 ]
+        go-version: [ 1.22.x ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3


### PR DESCRIPTION
There is no point in pinning the minor version as we don't release binaries or similar.