### PR TITLE
Keep all x-minio- headers as-is

### DIFF
--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -119,7 +119,7 @@ func (opts CopyDestOptions) Marshal(header http.Header) {
 	if opts.ReplaceMetadata {
 		header.Set("x-amz-metadata-directive", replaceDirective)
 		for k, v := range filterCustomMeta(opts.UserMetadata) {
-			if isAmzHeader(k) || isStandardHeader(k) || isStorageClassHeader(k) || isValidReplicationEncryptionHeader(k) {
+			if isAmzHeader(k) || isStandardHeader(k) || isStorageClassHeader(k) || isMinioHeader(k) {
 				header.Set(k, v)
 			} else {
 				header.Set("x-amz-meta-"+k, v)

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -212,7 +212,7 @@ func (opts PutObjectOptions) Header() (header http.Header) {
 	}
 
 	for k, v := range opts.UserMetadata {
-		if isAmzHeader(k) || isStandardHeader(k) || isStorageClassHeader(k) || isValidReplicationEncryptionHeader(k) {
+		if isAmzHeader(k) || isStandardHeader(k) || isStorageClassHeader(k) || isMinioHeader(k) {
 			header.Set(k, v)
 		} else {
 			header.Set("x-amz-meta-"+k, v)
@@ -230,7 +230,7 @@ func (opts PutObjectOptions) Header() (header http.Header) {
 // validate() checks if the UserMetadata map has standard headers or and raises an error if so.
 func (opts PutObjectOptions) validate() (err error) {
 	for k, v := range opts.UserMetadata {
-		if !httpguts.ValidHeaderFieldName(k) || isStandardHeader(k) || isSSEHeader(k) || isStorageClassHeader(k) || isValidReplicationEncryptionHeader(k) {
+		if !httpguts.ValidHeaderFieldName(k) || isStandardHeader(k) || isSSEHeader(k) || isStorageClassHeader(k) || isMinioHeader(k) {
 			return errInvalidArgument(k + " unsupported user defined metadata name")
 		}
 		if !httpguts.ValidHeaderFieldValue(v) {

--- a/utils.go
+++ b/utils.go
@@ -510,19 +510,9 @@ func isAmzHeader(headerKey string) bool {
 	return strings.HasPrefix(key, "x-amz-meta-") || strings.HasPrefix(key, "x-amz-grant-") || key == "x-amz-acl" || isSSEHeader(headerKey) || strings.HasPrefix(key, "x-amz-checksum-")
 }
 
-var supportedReplicationEncryptionHeaders = map[string]bool{
-	"x-minio-replication-server-side-encryption-sealed-key":     true,
-	"x-minio-replication-server-side-encryption-seal-algorithm": true,
-	"x-minio-replication-server-side-encryption-iv":             true,
-	"x-minio-replication-encrypted-multipart":                   true,
-	"x-minio-replication-actual-object-size":                    true,
-	// Add more supported headers here.
-	// Must be lower case.
-}
-
-// isValidReplicationEncryptionHeader returns true if header is one of valid replication encryption headers
-func isValidReplicationEncryptionHeader(headerKey string) bool {
-	return supportedReplicationEncryptionHeaders[strings.ToLower(headerKey)]
+// isMinioHeader returns true if header is x-minio- header.
+func isMinioHeader(headerKey string) bool {
+	return strings.HasPrefix(strings.ToLower(headerKey), "x-minio-")
 }
 
 // supportedQueryValues is a list of query strings that can be passed in when using GetObject.


### PR DESCRIPTION
Having a whitelist for minio headers is pointless. Remove so we don't have to keep these in sync.