### PR TITLE
fix replication validation for Role ARN

### DIFF
--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -406,6 +406,9 @@ func (c *Config) EditRule(opts Options) error {
 			return fmt.Errorf("priority must be unique. Replication configuration already has a rule with this priority")
 		}
 		if rule.Destination.Bucket != newRule.Destination.Bucket && rule.ID == newRule.ID {
+			if c.Role == newRule.Destination.Bucket {
+				continue
+			}
 			return fmt.Errorf("invalid destination bucket for this rule")
 		}
 	}

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -180,7 +180,7 @@ func TestEditReplicationRule(t *testing.T) {
 				StorageClass: "STANDARD",
 				DestBucket:   "arn:minio:replication:eu-west-1:c5acb6ac-9918-4dc6-8534-6244ed1a611a:destbucket",
 			},
-			expectedErr: "invalid destination bucket for this rule",
+			expectedErr: "",
 		},
 		{ // test case :2 mismatched rule id
 			cfg: Config{


### PR DESCRIPTION

updating replication rule with deprecated Role ARN fails with "invalid destination bucket for this rule" 

repro: 
```
{
 "Rules": [
  {
   "ID": "cptjg0rkru7aqane8md0",
   "Status": "Enabled",
   "Priority": 0,
   "DeleteMarkerReplication": {
    "Status": "Enabled"
   },
   "DeleteReplication": {
    "Status": "Enabled"
   },
   "Destination": {
    "Bucket": "arn:aws:s3:::bucket"
   },
   "Filter": {
    "And": {},
    "Tag": {}
   },
   "SourceSelectionCriteria": {
    "ReplicaModifications": {
     "Status": "Enabled"
    }
   },
   "ExistingObjectReplication": {
    "Status": "Disabled"
   }
  }
 ],
 "Role": "arn:minio:replication::090575fd-f689-4cfa-8a5a-5712c55825b2:bucket"
}
```
```
mc replicate update sitea/bucket --id cptjg0rkru7aqane8md0 --remote-bucket http://"${remote_access_key}:${remote_secret_key}"@localhost:9000/bucket
mc: <ERROR> unable to modify replication rule: invalid destination bucket for this rule.
```