### PR TITLE
Fix missing CompleteMultipartUpload SSE-C

### DIFF
--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -637,7 +637,9 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
 
-	opts = PutObjectOptions{}
+	opts = PutObjectOptions{
+		ServerSideEncryption: opts.ServerSideEncryption,
+	}
 	if len(crcBytes) > 0 {
 		// Add hash of hashes.
 		crc.Reset()

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -464,7 +464,9 @@ func (c *Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketNam
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
 
-	opts = PutObjectOptions{}
+	opts = PutObjectOptions{
+		ServerSideEncryption: opts.ServerSideEncryption,
+	}
 	if len(crcBytes) > 0 {
 		// Add hash of hashes.
 		crc.Reset()


### PR DESCRIPTION
`putObjectMultipartStreamNoLength` and `putObjectMultipartStreamParallel` were missing SSE-C headers.

Before:
```
c: <DEBUG> POST /trace.json?uploadId=u3RE7kyHylOIHLKTCJOl2xMU6Lz4dJEotSRRQ.t2oqBP9chVWpSLnKVjhvogCEnq1Uzl8DTVyEeBn.d1KWoVFwCeyvfOYAawyP11.szXNYA9nZ8TC7qOHg4tNYVwrMrv HTTP/1.1
Host: xxxx-us-east-1.s3.dualstack.us-east-1.amazonaws.com
User-Agent: MinIO (windows; amd64) minio-go/v7.0.73 mc/DEVELOPMENT.GOGET
Content-Length: 224
Accept-Encoding: zstd,gzip
Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20240702/us-east-1/s3/aws4_request, SignedHeaders=content-type;host;x-amz-checksum-crc32c;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
Content-Type: application/octet-stream
X-Amz-Checksum-Crc32c: FTkqvw==
X-Amz-Content-Sha256: c6463f4718f1420115e5937d0df8b5f1b12360bf19067c7c693f74b5629a21d2
X-Amz-Date: 20240702T163623Z

mc: <DEBUG> HTTP/1.1 400 Bad Request
Connection: close
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Tue, 02 Jul 2024 16:36:17 GMT
Server: AmazonS3
X-Amz-Id-2: XxNuG0/LrCJhn6zp8qSQTx1hbBSao5zbJF2LuXCjV84hnyMa0WhvyOGbwfYH2xsL0KMPk+PmTUc=
X-Amz-Request-Id: 8BDWVH8SS555TY65
```

After:

```
c: <DEBUG> POST /trace.json?uploadId=RcaVx.E7ikFputT7vEDDUSZnfke2GRyOFxjVX1j_VvC_rwGS.DRYCg7hylsb7TXuuPgOSnb58PX05D6hG6pby5RJM2Jf8h7ghYtFS19MsV2i2A.RjNsxsrvesKZV6Or3 HTTP/1.1
Host: xxxx-us-east-1.s3.dualstack.us-east-1.amazonaws.com
User-Agent: MinIO (windows; amd64) minio-go/v7.0.73 mc/DEVELOPMENT.GOGET
Content-Length: 224
Accept-Encoding: zstd,gzip
Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20240702/us-east-1/s3/aws4_request, SignedHeaders=content-type;host;x-amz-checksum-crc32c;x-amz-content-sha256;x-amz-date;x-amz-server-side-encryption-customer-algorithm;x-amz-server-side-encryption-customer-key;x-amz-server-side-encryption-customer-key-md5, Signature=**REDACTED**
Content-Type: application/octet-stream
X-Amz-Checksum-Crc32c: FTkqvw==
X-Amz-Content-Sha256: d875307b7d216bbd02e040f30224e256fa16ba3f436f463ad9ea7abc04ef4ceb
X-Amz-Date: 20240702T163752Z
X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256
X-Amz-Server-Side-Encryption-Customer-Key: wC6y20rByatPS9xS1RLsoNvRZAHvssYI1ruYS2iv5cY=
X-Amz-Server-Side-Encryption-Customer-Key-Md5: fXxP96p2ajAxFivAA0G66w==

mc: <DEBUG> HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Tue, 02 Jul 2024 16:37:48 GMT
Server: AmazonS3
X-Amz-Id-2: xqscCqpoBVPcJT2GpKLMDj6mFntOLrgUeBA3ambHCPnlSzClakQwhZ7VAsjW+K//z6RhCyuuxGE=
X-Amz-Request-Id: XMBFVMVCPMZ4H0WG
X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256
X-Amz-Server-Side-Encryption-Customer-Key-Md5: fXxP96p2ajAxFivAA0G66w==
```