### PR TITLE
feat: add SetContentDisposition method for postPolicy Upload

### DIFF
--- a/post-policy.go
+++ b/post-policy.go
@@ -209,6 +209,23 @@ func (p *PostPolicy) SetContentTypeStartsWith(contentTypeStartsWith string) erro
 	return nil
 }
 
+// SetContentDisposition - Sets content-disposition of the object for this policy
+func (p *PostPolicy) SetContentDisposition(contentDisposition string) error {
+	if strings.TrimSpace(contentDisposition) == "" || contentDisposition == "" {
+		return errInvalidArgument("No content disposition specified.")
+	}
+	policyCond := policyCondition{
+		matchType: "eq",
+		condition: "$Content-Disposition",
+		value:     contentDisposition,
+	}
+	if err := p.addNewPolicy(policyCond); err != nil {
+		return err
+	}
+	p.formData["Content-Disposition"] = contentDisposition
+	return nil
+}
+
 // SetContentLengthRange - Set new min and max content length
 // condition for all incoming uploads.
 func (p *PostPolicy) SetContentLengthRange(min, max int64) error {


### PR DESCRIPTION
I want to add a method to support add the 'Content-Disposition' condition when generate post policy .
The S3 document is as the image:
![image](https://github.com/minio/minio-go/assets/32149068/076bafd9-59ca-48f1-8c98-039de6b61e70)
