### PR TITLE
Fixed #1994 - incorrect MPU threshold

### DIFF
--- a/api-put-object.go
+++ b/api-put-object.go
@@ -333,7 +333,7 @@ func (c *Client) putObjectCommon(ctx context.Context, bucketName, objectName str
 		return c.putObjectMultipartStreamNoLength(ctx, bucketName, objectName, reader, opts)
 	}
 
-	if size < int64(partSize) || opts.DisableMultipart {
+	if size <= int64(partSize) || opts.DisableMultipart {
 		return c.putObject(ctx, bucketName, objectName, reader, size, opts)
 	}
 


### PR DESCRIPTION
Per #1994, executing PutObject with exactly `partSize` will execute an unnecessary MPU. You only need it if you're _above_ partSize.

With fix:

```
/tmp/minio-examples/examples/s3 $ dd if=/dev/random of=my-testfile bs=1M count=16
16+0 records in
16+0 records out
16777216 bytes (17 MB, 16 MiB) copied, 0.0712859 s, 235 MB/s

$ /tmp/minio-examples/examples/s3  ./putobject | tee put2.txt 
<snip>
2024/08/28 10:51:13 Uploaded my-objectname  of size:  16777216 Successfully in  367.233449ms

/tmp/minio-examples/examples/s3 $ grep -A 1 START-HT put2.txt
---------START-HTTP---------
GET /testbucket/?location= HTTP/1.1
--
---------START-HTTP---------
PUT /testbucket/my-objectname HTTP/1.1
```

Verify with 16MiB+1

```
/tmp/minio-examples/examples/s3 $ dd if=/dev/random of=my-testfile bs=1 count=16777217
16777217+0 records in
16777217+0 records out
16777217 bytes (17 MB, 16 MiB) copied, 24.9064 s, 674 kB/s


/tmp/minio-examples/examples/s3 $ ls -l my-testfile 
-rw-rw-r-- 1 jcwik jcwik 16777217 Aug 28 09:27 my-testfile


/tmp/minio-examples/examples/s3 $ ./putobject | tee put3.txt 
<snip>
2024/08/28 11:14:41 Uploaded my-objectname  of size:  16777217 Successfully in  364.248976ms


/tmp/minio-examples/examples/s3 $ grep -A 1 START-HT put3.txt
---------START-HTTP---------
GET /testbucket/?location= HTTP/1.1
--
---------START-HTTP---------
POST /testbucket/my-objectname?uploads= HTTP/1.1
--
---------START-HTTP---------
PUT /testbucket/my-objectname?partNumber=2&uploadId=ZGE0YzdiNmQtNzNhYS00MzlhLTgyMzEtZThhMjA2MGM3ZThkLjFkNzljNjEwLTAyMWItNDQwMy04YzdhLWM1MjU3ODNlMzgyOXgxNzI0ODYxNjgwNjkzMjY5OTc0 HTTP/1.1
--
---------START-HTTP---------
PUT /testbucket/my-objectname?partNumber=1&uploadId=ZGE0YzdiNmQtNzNhYS00MzlhLTgyMzEtZThhMjA2MGM3ZThkLjFkNzljNjEwLTAyMWItNDQwMy04YzdhLWM1MjU3ODNlMzgyOXgxNzI0ODYxNjgwNjkzMjY5OTc0 HTTP/1.1
--
---------START-HTTP---------
POST /testbucket/my-objectname?uploadId=ZGE0YzdiNmQtNzNhYS00MzlhLTgyMzEtZThhMjA2MGM3ZThkLjFkNzljNjEwLTAyMWItNDQwMy04YzdhLWM1MjU3ODNlMzgyOXgxNzI0ODYxNjgwNjkzMjY5OTc0 HTTP/1.1
```
