### PR TITLE
Update remove bucket replication reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The full API Reference is available here.
 
 * [setbucketencryption.go](https://github.com/minio/minio-go/blob/master/examples/s3/setbucketencryption.go)
 * [getbucketencryption.go](https://github.com/minio/minio-go/blob/master/examples/s3/getbucketencryption.go)
-* [deletebucketencryption.go](https://github.com/minio/minio-go/blob/master/examples/s3/deletebucketencryption.go)
+* [removebucketencryption.go](https://github.com/minio/minio-go/blob/master/examples/s3/removebucketencryption.go)
 
 ### Full Examples : Bucket replication Operations
 


### PR DESCRIPTION
# PR Summary
Commit 5f85da59959d7f5e77c4ebd49b8684b7cbaedd64 renamed `deletebucketencryption.go` to be `removebucketencryption.go`. This PR adjusts sources to changes.