### PR TITLE
Add `credentials.WithPolicy` method to narrow down policy

### DIFF
--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -112,6 +113,21 @@ func NewSTSWebIdentity(stsEndpoint string, getWebIDTokenExpiry func() (*WebIdent
 		o(i)
 	}
 	return New(i), nil
+}
+
+// NewKubernetesIdentity returns a pointer to a new
+// Credentials object using the Kubernetes service account
+func NewKubernetesIdentity(stsEndpoint string, opts ...func(*STSWebIdentity)) (*Credentials, error) {
+	return NewSTSWebIdentity(stsEndpoint, func() (*WebIdentityToken, error) {
+		token, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+		if err != nil {
+			return nil, err
+		}
+
+		return &WebIdentityToken{
+			Token: string(token),
+		}, nil
+	}, opts...)
 }
 
 // WithPolicy option will enforce that the returned credentials


### PR DESCRIPTION
The `NewSTSWebIdentity` allows fetching credentials that are narrowed down to the specified policy. This is useful when a client requires less rights then it actually has. The returned credentials will have the intersection of the requested policy and the assigned policies.

The `credentials.NewSTSWebIdentity` function is updated to use the options pattern (backward compatible). By adding the `credentials.WithPolicy(...)` method the credentials can be scoped.

To allow using the default Kubernetes service account that is assigned to the pod, the `credentials.NewKubernetesIdentity`  function is added.