### PR TITLE
add `=` character to tag validation regex

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -69,7 +69,7 @@ const (
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
 // borrowed from this article and also testing various ASCII characters following regex
 // is supported by AWS S3 for both tags and values.
-var validTagKeyValue = regexp.MustCompile(`^[a-zA-Z0-9-+\-._:/@ ]+$`)
+var validTagKeyValue = regexp.MustCompile(`^[a-zA-Z0-9-+\-._:/@ =]+$`)
 
 func checkKey(key string) error {
 	if len(key) == 0 {

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -44,6 +44,11 @@ func TestParseTags(t *testing.T) {
 			2,
 		},
 		{
+			"key=value=",
+			false,
+			1,
+		},
+		{
 			fmt.Sprintf("%0128d=%0256d", 1, 1),
 			false,
 			1,


### PR DESCRIPTION
The [tags restrictions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions) mentioned for the `validTagKeyValue` regex includes the `=` character which is not present in the regex.

This PR aims at reducing this drift between AWS and Minio restrictions on this API.
I've added a simple test case in the unit test for this package, let me know if this enough or if further testing is needed.