### PR TITLE
Only retry multi-part upload as single-part upload on GCS endpoints

### DIFF
--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -52,7 +52,7 @@ func (c *Client) putObjectMultipartStream(ctx context.Context, bucketName, objec
 	} else {
 		info, err = c.putObjectMultipartStreamOptionalChecksum(ctx, bucketName, objectName, reader, size, opts)
 	}
-	if err != nil {
+	if err != nil && s3utils.IsGoogleEndpoint(*c.endpointURL) {
 		errResp := ToErrorResponse(err)
 		// Verify if multipart functionality is not available, if not
 		// fall back to single PutObject operation.


### PR DESCRIPTION
Because of GCS compatibility, the multi-part upload retries a multi-part upload as a single `PutObject` when it receives an access denied. This introduces a strange error message, because when a multi-part upload isn't allowed (i.e. due to policy), then it retries the operation as a single-part operation.

Single part uploads are limited to 5GiB, so if uploading a file larger than 5GiB is uploaded, but not allowed, this will return the following error message: `Your proposed upload size ‘...’ exceeds the maximum allowed object size ‘5368709120’ for single PUT operation.`. For AWS S3 and MinIO, there is just a single action for upload operations (`s3:PutObject`), so it doesn't make sense to retry the upload. This saves a roundtrip and an error message that could be misleading.