### PR TITLE
retry: make max retries configurable

### DIFF
--- a/api.go
+++ b/api.go
@@ -283,7 +283,10 @@ func privateNew(endpoint string, opts *Options) (*Client, error) {
 	// healthcheck is not initialized
 	clnt.healthStatus = unknown
 
-	clnt.maxRetries = opts.MaxRetries
+	clnt.maxRetries = MaxRetry
+	if opts.MaxRetries > 0 {
+		clnt.maxRetries = opts.MaxRetries
+	}
 
 	// Return.
 	return clnt, nil
@@ -597,13 +600,9 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 		return nil, errors.New(c.endpointURL.String() + " is offline.")
 	}
 
-	var retryable bool       // Indicates if request can be retried.
-	var bodySeeker io.Seeker // Extracted seeker from io.Reader.
-
-	reqRetry := MaxRetry // Indicates how many times we can retry the request
-	if c.maxRetries > 0 {
-		reqRetry = c.maxRetries
-	}
+	var retryable bool          // Indicates if request can be retried.
+	var bodySeeker io.Seeker    // Extracted seeker from io.Reader.
+	var reqRetry = c.maxRetries // Indicates how many times we can retry the request
 
 	if metadata.contentBody != nil {
 		// Check if body is seekable then it is retryable.

--- a/api.go
+++ b/api.go
@@ -99,6 +99,7 @@ type Client struct {
 	healthStatus int32
 
 	trailingHeaderSupport bool
+	maxRetries            int
 }
 
 // Options for New method
@@ -123,6 +124,10 @@ type Options struct {
 	// Custom hash routines. Leave nil to use standard.
 	CustomMD5    func() md5simd.Hasher
 	CustomSHA256 func() md5simd.Hasher
+
+	// Number of times a request is retried. Defaults to 10 retries if this option is not configured.
+	// Set to 1 to disable retries.
+	MaxRetries int
 }
 
 // Global constants.
@@ -277,6 +282,8 @@ func privateNew(endpoint string, opts *Options) (*Client, error) {
 
 	// healthcheck is not initialized
 	clnt.healthStatus = unknown
+
+	clnt.maxRetries = opts.MaxRetries
 
 	// Return.
 	return clnt, nil
@@ -592,7 +599,11 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 
 	var retryable bool       // Indicates if request can be retried.
 	var bodySeeker io.Seeker // Extracted seeker from io.Reader.
-	reqRetry := MaxRetry     // Indicates how many times we can retry the request
+
+	reqRetry := MaxRetry // Indicates how many times we can retry the request
+	if c.maxRetries > 0 {
+		reqRetry = c.maxRetries
+	}
 
 	if metadata.contentBody != nil {
 		// Check if body is seekable then it is retryable.


### PR DESCRIPTION
Adds an option to configure the max retries. This would come in handy for users that want to control retries at a higher level.
