### PR TITLE
fix: get ETag from resp.Body rather than resp.Header

### DIFF
--- a/api-copy-object.go
+++ b/api-copy-object.go
@@ -68,7 +68,7 @@ func (c *Client) CopyObject(ctx context.Context, dst CopyDestOptions, src CopySr
 		Bucket:           dst.Bucket,
 		Key:              dst.Object,
 		LastModified:     cpObjRes.LastModified,
-		ETag:             trimEtag(resp.Header.Get("ETag")),
+		ETag:             trimEtag(cpObjRes.ETag),
 		VersionID:        resp.Header.Get(amzVersionID),
 		Expiration:       expTime,
 		ExpirationRuleID: ruleID,


### PR DESCRIPTION
When I use the CopyObject function with AWS S3, I find the ETag in the response is always an empty string. 
According to AWS's latest API Reference[^1], the variable ETag is in the CopyObjectResult part, not in the header part. 
<img width="1353" alt="AWS" src="https://github.com/user-attachments/assets/595be8f0-1f7e-4e2c-9217-a7f74d976fea">

Therefore, we should modify the source code to get the ETag from cpObjRes rather than resp.Header.Get("ETag").
I did so and got the correct ETag value, which is not an empty string.

I hope you can take this into consideration. If you have any questions, please feel free to ask.

**Reference:**
[^1]:https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html