### PR TITLE
Add refresh token to WebIdentity OpenID response

### DIFF
--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -58,9 +58,10 @@ type WebIdentityResult struct {
 
 // WebIdentityToken - web identity token with expiry.
 type WebIdentityToken struct {
-	Token       string
-	AccessToken string
-	Expiry      int
+	Token        string
+	AccessToken  string
+	RefreshToken string
+	Expiry       int
 }
 
 // A STSWebIdentity retrieves credentials from MinIO service, and keeps track if


### PR DESCRIPTION
OpenID can return the refresh token along with the token ID and the access token. Adding this latter to use it in refresh a user claims