### PR TITLE
Add Full Object Checksum API

### DIFF
--- a/.github/workflows/go-windows.yml
+++ b/.github/workflows/go-windows.yml
@@ -38,6 +38,7 @@ jobs:
           ENABLE_HTTPS: 1
           MINIO_KMS_MASTER_KEY: my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574
           MINIO_CI_CD: true
+          MINT_NO_FULL_OBJECT: true
         run: |
           New-Item -ItemType Directory -Path "$env:temp/certs-dir"
           Copy-Item -Path testcerts\* -Destination "$env:temp/certs-dir"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,6 +39,7 @@ jobs:
           MINIO_KMS_MASTER_KEY: my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574
           SSL_CERT_FILE: /tmp/certs-dir/public.crt
           MINIO_CI_CD: true
+          MINT_NO_FULL_OBJECT: true
         run: |
           sudo apt update -y
           sudo apt install devscripts -y

--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -143,10 +143,11 @@ type UploadInfo struct {
 	// Verified checksum values, if any.
 	// Values are base64 (standard) encoded.
 	// For multipart objects this is a checksum of the checksum of each part.
-	ChecksumCRC32  string
-	ChecksumCRC32C string
-	ChecksumSHA1   string
-	ChecksumSHA256 string
+	ChecksumCRC32     string
+	ChecksumCRC32C    string
+	ChecksumSHA1      string
+	ChecksumSHA256    string
+	ChecksumCRC64NVME string
 }
 
 // RestoreInfo contains information of the restore operation of an archived object
@@ -215,10 +216,11 @@ type ObjectInfo struct {
 	Restore *RestoreInfo
 
 	// Checksum values
-	ChecksumCRC32  string
-	ChecksumCRC32C string
-	ChecksumSHA1   string
-	ChecksumSHA256 string
+	ChecksumCRC32     string
+	ChecksumCRC32C    string
+	ChecksumSHA1      string
+	ChecksumSHA256    string
+	ChecksumCRC64NVME string
 
 	Internal *struct {
 		K int // Data blocks

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -83,10 +83,7 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 	// HTTPS connection.
 	hashAlgos, hashSums := c.hashMaterials(opts.SendContentMd5, !opts.DisableContentSha256)
 	if len(hashSums) == 0 {
-		if opts.UserMetadata == nil {
-			opts.UserMetadata = make(map[string]string, 1)
-		}
-		opts.UserMetadata["X-Amz-Checksum-Algorithm"] = opts.AutoChecksum.String()
+		addAutoChecksumHeaders(&opts)
 	}
 
 	// Initiate a new multipart upload.
@@ -113,7 +110,6 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 
 	// Create checksums
 	// CRC32C is ~50% faster on AMD64 @ 30GB/s
-	var crcBytes []byte
 	customHeader := make(http.Header)
 	crc := opts.AutoChecksum.Hasher()
 	for partNumber <= totalPartsCount {
@@ -154,7 +150,6 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 			crc.Write(buf[:length])
 			cSum := crc.Sum(nil)
 			customHeader.Set(opts.AutoChecksum.Key(), base64.StdEncoding.EncodeToString(cSum))
-			crcBytes = append(crcBytes, cSum...)
 		}
 
 		p := uploadPartParams{bucketName: bucketName, objectName: objectName, uploadID: uploadID, reader: rd, partNumber: partNumber, md5Base64: md5Base64, sha256Hex: sha256Hex, size: int64(length), sse: opts.ServerSideEncryption, streamSha256: !opts.DisableContentSha256, customHeader: customHeader}
@@ -182,18 +177,21 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 
 	// Loop over total uploaded parts to save them in
 	// Parts array before completing the multipart request.
+	allParts := make([]ObjectPart, 0, len(partsInfo))
 	for i := 1; i < partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return UploadInfo{}, errInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
+		allParts = append(allParts, part)
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
-			ETag:           part.ETag,
-			PartNumber:     part.PartNumber,
-			ChecksumCRC32:  part.ChecksumCRC32,
-			ChecksumCRC32C: part.ChecksumCRC32C,
-			ChecksumSHA1:   part.ChecksumSHA1,
-			ChecksumSHA256: part.ChecksumSHA256,
+			ETag:              part.ETag,
+			PartNumber:        part.PartNumber,
+			ChecksumCRC32:     part.ChecksumCRC32,
+			ChecksumCRC32C:    part.ChecksumCRC32C,
+			ChecksumSHA1:      part.ChecksumSHA1,
+			ChecksumSHA256:    part.ChecksumSHA256,
+			ChecksumCRC64NVME: part.ChecksumCRC64NVME,
 		})
 	}
 
@@ -203,12 +201,8 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 		ServerSideEncryption: opts.ServerSideEncryption,
 		AutoChecksum:         opts.AutoChecksum,
 	}
-	if len(crcBytes) > 0 {
-		// Add hash of hashes.
-		crc.Reset()
-		crc.Write(crcBytes)
-		opts.UserMetadata = map[string]string{opts.AutoChecksum.Key(): base64.StdEncoding.EncodeToString(crc.Sum(nil))}
-	}
+	applyAutoChecksum(&opts, allParts)
+
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
@@ -354,10 +348,11 @@ func (c *Client) uploadPart(ctx context.Context, p uploadPartParams) (ObjectPart
 	// Once successfully uploaded, return completed part.
 	h := resp.Header
 	objPart := ObjectPart{
-		ChecksumCRC32:  h.Get("x-amz-checksum-crc32"),
-		ChecksumCRC32C: h.Get("x-amz-checksum-crc32c"),
-		ChecksumSHA1:   h.Get("x-amz-checksum-sha1"),
-		ChecksumSHA256: h.Get("x-amz-checksum-sha256"),
+		ChecksumCRC32:     h.Get(ChecksumCRC32.Key()),
+		ChecksumCRC32C:    h.Get(ChecksumCRC32C.Key()),
+		ChecksumSHA1:      h.Get(ChecksumSHA1.Key()),
+		ChecksumSHA256:    h.Get(ChecksumSHA256.Key()),
+		ChecksumCRC64NVME: h.Get(ChecksumCRC64NVME.Key()),
 	}
 	objPart.Size = p.size
 	objPart.PartNumber = p.partNumber
@@ -457,9 +452,10 @@ func (c *Client) completeMultipartUpload(ctx context.Context, bucketName, object
 		Expiration:       expTime,
 		ExpirationRuleID: ruleID,
 
-		ChecksumSHA256: completeMultipartUploadResult.ChecksumSHA256,
-		ChecksumSHA1:   completeMultipartUploadResult.ChecksumSHA1,
-		ChecksumCRC32:  completeMultipartUploadResult.ChecksumCRC32,
-		ChecksumCRC32C: completeMultipartUploadResult.ChecksumCRC32C,
+		ChecksumSHA256:    completeMultipartUploadResult.ChecksumSHA256,
+		ChecksumSHA1:      completeMultipartUploadResult.ChecksumSHA1,
+		ChecksumCRC32:     completeMultipartUploadResult.ChecksumCRC32,
+		ChecksumCRC32C:    completeMultipartUploadResult.ChecksumCRC32C,
+		ChecksumCRC64NVME: completeMultipartUploadResult.ChecksumCRC64NVME,
 	}, nil
 }

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -330,7 +330,6 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 
 	// Create checksums
 	// CRC32C is ~50% faster on AMD64 @ 30GB/s
-	var crcBytes []byte
 	customHeader := make(http.Header)
 	crc := opts.AutoChecksum.Hasher()
 	md5Hash := c.md5Hasher()
@@ -377,7 +376,6 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 			crc.Write(buf[:length])
 			cSum := crc.Sum(nil)
 			customHeader.Set(opts.AutoChecksum.KeyCapitalized(), base64.StdEncoding.EncodeToString(cSum))
-			crcBytes = append(crcBytes, cSum...)
 		}
 
 		// Update progress reader appropriately to the latest offset

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -113,10 +113,7 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 	}
 	withChecksum := c.trailingHeaderSupport
 	if withChecksum {
-		if opts.UserMetadata == nil {
-			opts.UserMetadata = make(map[string]string, 1)
-		}
-		opts.UserMetadata["X-Amz-Checksum-Algorithm"] = opts.AutoChecksum.String()
+		addAutoChecksumHeaders(&opts)
 	}
 	// Initiate a new multipart upload.
 	uploadID, err := c.newUploadID(ctx, bucketName, objectName, opts)
@@ -240,6 +237,7 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 
 	// Gather the responses as they occur and update any
 	// progress bar.
+	allParts := make([]ObjectPart, 0, totalPartsCount)
 	for u := 1; u <= totalPartsCount; u++ {
 		select {
 		case <-ctx.Done():
@@ -248,16 +246,17 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 			if uploadRes.Error != nil {
 				return UploadInfo{}, uploadRes.Error
 			}
-
+			allParts = append(allParts, uploadRes.Part)
 			// Update the totalUploadedSize.
 			totalUploadedSize += uploadRes.Size
 			complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
-				ETag:           uploadRes.Part.ETag,
-				PartNumber:     uploadRes.Part.PartNumber,
-				ChecksumCRC32:  uploadRes.Part.ChecksumCRC32,
-				ChecksumCRC32C: uploadRes.Part.ChecksumCRC32C,
-				ChecksumSHA1:   uploadRes.Part.ChecksumSHA1,
-				ChecksumSHA256: uploadRes.Part.ChecksumSHA256,
+				ETag:              uploadRes.Part.ETag,
+				PartNumber:        uploadRes.Part.PartNumber,
+				ChecksumCRC32:     uploadRes.Part.ChecksumCRC32,
+				ChecksumCRC32C:    uploadRes.Part.ChecksumCRC32C,
+				ChecksumSHA1:      uploadRes.Part.ChecksumSHA1,
+				ChecksumSHA256:    uploadRes.Part.ChecksumSHA256,
+				ChecksumCRC64NVME: uploadRes.Part.ChecksumCRC64NVME,
 			})
 		}
 	}
@@ -275,15 +274,7 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 		AutoChecksum:         opts.AutoChecksum,
 	}
 	if withChecksum {
-		// Add hash of hashes.
-		crc := opts.AutoChecksum.Hasher()
-		for _, part := range complMultipartUpload.Parts {
-			cs, err := base64.StdEncoding.DecodeString(part.Checksum(opts.AutoChecksum))
-			if err == nil {
-				crc.Write(cs)
-			}
-		}
-		opts.UserMetadata = map[string]string{opts.AutoChecksum.KeyCapitalized(): base64.StdEncoding.EncodeToString(crc.Sum(nil))}
+		applyAutoChecksum(&opts, allParts)
 	}
 
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
@@ -312,10 +303,7 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 	}
 
 	if !opts.SendContentMd5 {
-		if opts.UserMetadata == nil {
-			opts.UserMetadata = make(map[string]string, 1)
-		}
-		opts.UserMetadata["X-Amz-Checksum-Algorithm"] = opts.AutoChecksum.String()
+		addAutoChecksumHeaders(&opts)
 	}
 
 	// Calculate the optimal parts info for a given size.
@@ -420,18 +408,21 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 
 	// Loop over total uploaded parts to save them in
 	// Parts array before completing the multipart request.
+	allParts := make([]ObjectPart, 0, len(partsInfo))
 	for i := 1; i < partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return UploadInfo{}, errInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
+		allParts = append(allParts, part)
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
-			ETag:           part.ETag,
-			PartNumber:     part.PartNumber,
-			ChecksumCRC32:  part.ChecksumCRC32,
-			ChecksumCRC32C: part.ChecksumCRC32C,
-			ChecksumSHA1:   part.ChecksumSHA1,
-			ChecksumSHA256: part.ChecksumSHA256,
+			ETag:              part.ETag,
+			PartNumber:        part.PartNumber,
+			ChecksumCRC32:     part.ChecksumCRC32,
+			ChecksumCRC32C:    part.ChecksumCRC32C,
+			ChecksumSHA1:      part.ChecksumSHA1,
+			ChecksumSHA256:    part.ChecksumSHA256,
+			ChecksumCRC64NVME: part.ChecksumCRC64NVME,
 		})
 	}
 
@@ -442,12 +433,7 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 		ServerSideEncryption: opts.ServerSideEncryption,
 		AutoChecksum:         opts.AutoChecksum,
 	}
-	if len(crcBytes) > 0 {
-		// Add hash of hashes.
-		crc.Reset()
-		crc.Write(crcBytes)
-		opts.UserMetadata = map[string]string{opts.AutoChecksum.KeyCapitalized(): base64.StdEncoding.EncodeToString(crc.Sum(nil))}
-	}
+	applyAutoChecksum(&opts, allParts)
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
@@ -475,10 +461,7 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 		opts.AutoChecksum = opts.Checksum
 	}
 	if !opts.SendContentMd5 {
-		if opts.UserMetadata == nil {
-			opts.UserMetadata = make(map[string]string, 1)
-		}
-		opts.UserMetadata["X-Amz-Checksum-Algorithm"] = opts.AutoChecksum.String()
+		addAutoChecksumHeaders(&opts)
 	}
 
 	// Cancel all when an error occurs.
@@ -510,7 +493,6 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 
 	// Create checksums
 	// CRC32C is ~50% faster on AMD64 @ 30GB/s
-	var crcBytes []byte
 	crc := opts.AutoChecksum.Hasher()
 
 	// Total data read and written to server. should be equal to 'size' at the end of the call.
@@ -570,7 +552,6 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 			crc.Write(buf[:length])
 			cSum := crc.Sum(nil)
 			customHeader.Set(opts.AutoChecksum.Key(), base64.StdEncoding.EncodeToString(cSum))
-			crcBytes = append(crcBytes, cSum...)
 		}
 
 		wg.Add(1)
@@ -630,18 +611,21 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 
 	// Loop over total uploaded parts to save them in
 	// Parts array before completing the multipart request.
+	allParts := make([]ObjectPart, 0, len(partsInfo))
 	for i := 1; i < partNumber; i++ {
 		part, ok := partsInfo[i]
 		if !ok {
 			return UploadInfo{}, errInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
+		allParts = append(allParts, part)
 		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
-			ETag:           part.ETag,
-			PartNumber:     part.PartNumber,
-			ChecksumCRC32:  part.ChecksumCRC32,
-			ChecksumCRC32C: part.ChecksumCRC32C,
-			ChecksumSHA1:   part.ChecksumSHA1,
-			ChecksumSHA256: part.ChecksumSHA256,
+			ETag:              part.ETag,
+			PartNumber:        part.PartNumber,
+			ChecksumCRC32:     part.ChecksumCRC32,
+			ChecksumCRC32C:    part.ChecksumCRC32C,
+			ChecksumSHA1:      part.ChecksumSHA1,
+			ChecksumSHA256:    part.ChecksumSHA256,
+			ChecksumCRC64NVME: part.ChecksumCRC64NVME,
 		})
 	}
 
@@ -652,12 +636,8 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 		ServerSideEncryption: opts.ServerSideEncryption,
 		AutoChecksum:         opts.AutoChecksum,
 	}
-	if len(crcBytes) > 0 {
-		// Add hash of hashes.
-		crc.Reset()
-		crc.Write(crcBytes)
-		opts.UserMetadata = map[string]string{opts.AutoChecksum.KeyCapitalized(): base64.StdEncoding.EncodeToString(crc.Sum(nil))}
-	}
+	applyAutoChecksum(&opts, allParts)
+
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
 		return UploadInfo{}, err
@@ -823,9 +803,10 @@ func (c *Client) putObjectDo(ctx context.Context, bucketName, objectName string,
 		ExpirationRuleID: ruleID,
 
 		// Checksum values
-		ChecksumCRC32:  h.Get("x-amz-checksum-crc32"),
-		ChecksumCRC32C: h.Get("x-amz-checksum-crc32c"),
-		ChecksumSHA1:   h.Get("x-amz-checksum-sha1"),
-		ChecksumSHA256: h.Get("x-amz-checksum-sha256"),
+		ChecksumCRC32:     h.Get(ChecksumCRC32.Key()),
+		ChecksumCRC32C:    h.Get(ChecksumCRC32C.Key()),
+		ChecksumSHA1:      h.Get(ChecksumSHA1.Key()),
+		ChecksumSHA256:    h.Get(ChecksumSHA256.Key()),
+		ChecksumCRC64NVME: h.Get(ChecksumCRC64NVME.Key()),
 	}, nil
 }

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -18,6 +18,7 @@
 package minio
 
 import (
+	"encoding/base64"
 	"encoding/xml"
 	"errors"
 	"io"
@@ -276,10 +277,44 @@ type ObjectPart struct {
 	Size int64
 
 	// Checksum values of each part.
-	ChecksumCRC32  string
-	ChecksumCRC32C string
-	ChecksumSHA1   string
-	ChecksumSHA256 string
+	ChecksumCRC32     string
+	ChecksumCRC32C    string
+	ChecksumSHA1      string
+	ChecksumSHA256    string
+	ChecksumCRC64NVME string
+}
+
+// Checksum will return the checksum for the given type.
+// Will return the empty string if not set.
+func (c ObjectPart) Checksum(t ChecksumType) string {
+	switch {
+	case t.Is(ChecksumCRC32C):
+		return c.ChecksumCRC32C
+	case t.Is(ChecksumCRC32):
+		return c.ChecksumCRC32
+	case t.Is(ChecksumSHA1):
+		return c.ChecksumSHA1
+	case t.Is(ChecksumSHA256):
+		return c.ChecksumSHA256
+	case t.Is(ChecksumCRC64NVME):
+		return c.ChecksumCRC64NVME
+	}
+	return ""
+}
+
+func (c ObjectPart) ChecksumRaw(t ChecksumType) ([]byte, error) {
+	b64 := c.Checksum(t)
+	if b64 == "" {
+		return nil, errors.New("no checksum set")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, err
+	}
+	if len(decoded) != t.RawByteLen() {
+		return nil, errors.New("checksum length mismatch")
+	}
+	return decoded, nil
 }
 
 // ListObjectPartsResult container for ListObjectParts response.
@@ -320,10 +355,11 @@ type completeMultipartUploadResult struct {
 	ETag     string
 
 	// Checksum values, hash of hashes of parts.
-	ChecksumCRC32  string
-	ChecksumCRC32C string
-	ChecksumSHA1   string
-	ChecksumSHA256 string
+	ChecksumCRC32     string
+	ChecksumCRC32C    string
+	ChecksumSHA1      string
+	ChecksumSHA256    string
+	ChecksumCRC64NVME string
 }
 
 // CompletePart sub container lists individual part numbers and their
@@ -334,10 +370,11 @@ type CompletePart struct {
 	ETag       string
 
 	// Checksum values
-	ChecksumCRC32  string `xml:"ChecksumCRC32,omitempty"`
-	ChecksumCRC32C string `xml:"ChecksumCRC32C,omitempty"`
-	ChecksumSHA1   string `xml:"ChecksumSHA1,omitempty"`
-	ChecksumSHA256 string `xml:"ChecksumSHA256,omitempty"`
+	ChecksumCRC32     string `xml:"ChecksumCRC32,omitempty"`
+	ChecksumCRC32C    string `xml:"ChecksumCRC32C,omitempty"`
+	ChecksumSHA1      string `xml:"ChecksumSHA1,omitempty"`
+	ChecksumSHA256    string `xml:"ChecksumSHA256,omitempty"`
+	ChecksumCRC64NVME string `xml:",omitempty"`
 }
 
 // Checksum will return the checksum for the given type.
@@ -352,6 +389,8 @@ func (c CompletePart) Checksum(t ChecksumType) string {
 		return c.ChecksumSHA1
 	case t.Is(ChecksumSHA256):
 		return c.ChecksumSHA256
+	case t.Is(ChecksumCRC64NVME):
+		return c.ChecksumCRC64NVME
 	}
 	return ""
 }

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -302,6 +302,7 @@ func (c ObjectPart) Checksum(t ChecksumType) string {
 	return ""
 }
 
+// ChecksumRaw returns the decoded checksum from the part.
 func (c ObjectPart) ChecksumRaw(t ChecksumType) ([]byte, error) {
 	b64 := c.Checksum(t)
 	if b64 == "" {

--- a/checksum.go
+++ b/checksum.go
@@ -21,11 +21,15 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
+	"errors"
 	"hash"
 	"hash/crc32"
+	"hash/crc64"
 	"io"
 	"math/bits"
 	"net/http"
+	"sort"
 )
 
 // ChecksumType contains information about the checksum type.
@@ -41,9 +45,15 @@ const (
 	ChecksumCRC32
 	// ChecksumCRC32C indicates a CRC32 checksum with Castagnoli table.
 	ChecksumCRC32C
+	// ChecksumCRC64NVME indicates CRC64 with 0xad93d23594c93659 polynomial.
+	ChecksumCRC64NVME
 
 	// Keep after all valid checksums
 	checksumLast
+
+	// ChecksumFullObject is a modifier that can be used on CRC32 and CRC32C
+	// to indicate full object checksums.
+	ChecksumFullObject
 
 	// checksumMask is a mask for valid checksum types.
 	checksumMask = checksumLast - 1
@@ -51,12 +61,24 @@ const (
 	// ChecksumNone indicates no checksum.
 	ChecksumNone ChecksumType = 0
 
-	amzChecksumAlgo   = "x-amz-checksum-algorithm"
-	amzChecksumCRC32  = "x-amz-checksum-crc32"
-	amzChecksumCRC32C = "x-amz-checksum-crc32c"
-	amzChecksumSHA1   = "x-amz-checksum-sha1"
-	amzChecksumSHA256 = "x-amz-checksum-sha256"
+	// ChecksumFullObjectCRC32 indicates full object CRC32
+	ChecksumFullObjectCRC32 = ChecksumCRC32 | ChecksumFullObject
+
+	// ChecksumFullObjectCRC32C indicates full object CRC32C
+	ChecksumFullObjectCRC32C = ChecksumCRC32C | ChecksumFullObject
+
+	amzChecksumAlgo      = "x-amz-checksum-algorithm"
+	amzChecksumCRC32     = "x-amz-checksum-crc32"
+	amzChecksumCRC32C    = "x-amz-checksum-crc32c"
+	amzChecksumSHA1      = "x-amz-checksum-sha1"
+	amzChecksumSHA256    = "x-amz-checksum-sha256"
+	amzChecksumCRC64NVME = "x-amz-checksum-crc64nvme"
 )
+
+// Base returns the base type, without modifiers.
+func (c ChecksumType) Base() ChecksumType {
+	return c & checksumMask
+}
 
 // Is returns if c is all of t.
 func (c ChecksumType) Is(t ChecksumType) bool {
@@ -75,8 +97,37 @@ func (c ChecksumType) Key() string {
 		return amzChecksumSHA1
 	case ChecksumSHA256:
 		return amzChecksumSHA256
+	case ChecksumCRC64NVME:
+		return amzChecksumCRC64NVME
 	}
 	return ""
+}
+
+// CanComposite will return if the checksum type can be used for composite multipart upload on AWS.
+func (c ChecksumType) CanComposite() bool {
+	switch c & checksumMask {
+	case ChecksumSHA256, ChecksumSHA1, ChecksumCRC32, ChecksumCRC32C:
+		return true
+	}
+	return false
+}
+
+// CanMergeCRC will return if the checksum type can be used for multipart upload on AWS.
+func (c ChecksumType) CanMergeCRC() bool {
+	switch c & checksumMask {
+	case ChecksumCRC32, ChecksumCRC32C, ChecksumCRC64NVME:
+		return true
+	}
+	return false
+}
+
+// FullObjectRequested will return if the checksum type indicates full object checksum was requested.
+func (c ChecksumType) FullObjectRequested() bool {
+	switch c & (ChecksumFullObject | checksumMask) {
+	case ChecksumFullObjectCRC32C, ChecksumFullObjectCRC32, ChecksumCRC64NVME:
+		return true
+	}
+	return false
 }
 
 // KeyCapitalized returns the capitalized key as used in HTTP headers.
@@ -93,9 +144,16 @@ func (c ChecksumType) RawByteLen() int {
 		return sha1.Size
 	case ChecksumSHA256:
 		return sha256.Size
+	case ChecksumCRC64NVME:
+		return crc64.Size
 	}
 	return 0
 }
+
+const crc64NVMEPolynomial = 0xad93d23594c93659
+
+// crc64 uses reversed polynomials.
+var crc64Table = crc64.MakeTable(bits.Reverse64(crc64NVMEPolynomial))
 
 // Hasher returns a hasher corresponding to the checksum type.
 // Returns nil if no checksum.
@@ -109,13 +167,15 @@ func (c ChecksumType) Hasher() hash.Hash {
 		return sha1.New()
 	case ChecksumSHA256:
 		return sha256.New()
+	case ChecksumCRC64NVME:
+		return crc64.New(crc64Table)
 	}
 	return nil
 }
 
 // IsSet returns whether the type is valid and known.
 func (c ChecksumType) IsSet() bool {
-	return bits.OnesCount32(uint32(c)) == 1
+	return bits.OnesCount32(uint32(c&checksumMask)) == 1
 }
 
 // SetDefault will set the checksum if not already set.
@@ -123,6 +183,16 @@ func (c *ChecksumType) SetDefault(t ChecksumType) {
 	if !c.IsSet() {
 		*c = t
 	}
+}
+
+// EncodeToString the encoded hash value of the content provided in b.
+func (c ChecksumType) EncodeToString(b []byte) string {
+	if !c.IsSet() {
+		return ""
+	}
+	h := c.Hasher()
+	h.Write(b)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
 }
 
 // String returns the type as a string.
@@ -140,6 +210,8 @@ func (c ChecksumType) String() string {
 		return "SHA256"
 	case ChecksumNone:
 		return ""
+	case ChecksumCRC64NVME:
+		return "CRC64NVME"
 	}
 	return "<invalid>"
 }
@@ -220,4 +292,130 @@ func (c Checksum) Raw() []byte {
 		return nil
 	}
 	return c.r
+}
+
+// CompositeChecksum returns the composite checksum of all provided parts.
+func (c ChecksumType) CompositeChecksum(p []ObjectPart) (*Checksum, error) {
+	if !c.CanComposite() {
+		return nil, errors.New("cannot do composite checksum")
+	}
+	sort.Slice(p, func(i, j int) bool {
+		return p[i].PartNumber < p[j].PartNumber
+	})
+	c = c.Base()
+	crcBytes := make([]byte, 0, len(p)*c.RawByteLen())
+	for _, part := range p {
+		pCrc, err := part.ChecksumRaw(c)
+		if err != nil {
+			return nil, err
+		}
+		crcBytes = append(crcBytes, pCrc...)
+	}
+	h := c.Hasher()
+	h.Write(crcBytes)
+	return &Checksum{Type: c, r: h.Sum(nil)}, nil
+}
+
+// FullObjectChecksum will return the full object checksum from provided parts.
+func (c ChecksumType) FullObjectChecksum(p []ObjectPart) (*Checksum, error) {
+	if !c.CanMergeCRC() {
+		return nil, errors.New("cannot merge this checksum type")
+	}
+	c = c.Base()
+	sort.Slice(p, func(i, j int) bool {
+		return p[i].PartNumber < p[j].PartNumber
+	})
+
+	switch len(p) {
+	case 0:
+		return nil, errors.New("no parts given")
+	case 1:
+		check, err := p[0].ChecksumRaw(c)
+		if err != nil {
+			return nil, err
+		}
+		return &Checksum{
+			Type: c,
+			r:    check,
+		}, nil
+	}
+	var merged uint32
+	var merged64 uint64
+	first, err := p[0].ChecksumRaw(c)
+	if err != nil {
+		return nil, err
+	}
+	sz := p[0].Size
+	switch c {
+	case ChecksumCRC32, ChecksumCRC32C:
+		merged = binary.BigEndian.Uint32(first)
+	case ChecksumCRC64NVME:
+		merged64 = binary.BigEndian.Uint64(first)
+	}
+
+	poly32 := uint32(crc32.IEEE)
+	if c.Is(ChecksumCRC32C) {
+		poly32 = crc32.Castagnoli
+	}
+	for _, part := range p[1:] {
+		if part.Size == 0 {
+			continue
+		}
+		sz += part.Size
+		pCrc, err := part.ChecksumRaw(c)
+		if err != nil {
+			return nil, err
+		}
+		switch c {
+		case ChecksumCRC32, ChecksumCRC32C:
+			merged = crc32Combine(poly32, merged, binary.BigEndian.Uint32(pCrc), part.Size)
+		case ChecksumCRC64NVME:
+			merged64 = crc64Combine(bits.Reverse64(crc64NVMEPolynomial), merged64, binary.BigEndian.Uint64(pCrc), part.Size)
+		}
+	}
+	var tmp [8]byte
+	switch c {
+	case ChecksumCRC32, ChecksumCRC32C:
+		binary.BigEndian.PutUint32(tmp[:], merged)
+		return &Checksum{
+			Type: c,
+			r:    tmp[:4],
+		}, nil
+	case ChecksumCRC64NVME:
+		binary.BigEndian.PutUint64(tmp[:], merged64)
+		return &Checksum{
+			Type: c,
+			r:    tmp[:8],
+		}, nil
+	default:
+		return nil, errors.New("unknown checksum type")
+	}
+}
+
+func addAutoChecksumHeaders(opts *PutObjectOptions) {
+	if opts.UserMetadata == nil {
+		opts.UserMetadata = make(map[string]string, 1)
+	}
+	opts.UserMetadata["X-Amz-Checksum-Algorithm"] = opts.AutoChecksum.String()
+	if opts.AutoChecksum.FullObjectRequested() {
+		opts.UserMetadata["X-Amz-Checksum-Type"] = "FULL_OBJECT"
+	}
+}
+
+func applyAutoChecksum(opts *PutObjectOptions, allParts []ObjectPart) {
+	if !opts.AutoChecksum.IsSet() {
+		return
+	}
+	if opts.AutoChecksum.CanComposite() && !opts.AutoChecksum.Is(ChecksumFullObject) {
+		// Add composite hash of hashes.
+		crc, err := opts.AutoChecksum.CompositeChecksum(allParts)
+		if err == nil {
+			opts.UserMetadata = map[string]string{opts.AutoChecksum.Key(): crc.Encoded()}
+		}
+	} else if opts.AutoChecksum.CanMergeCRC() {
+		crc, err := opts.AutoChecksum.FullObjectChecksum(allParts)
+		if err == nil {
+			opts.UserMetadata = map[string]string{opts.AutoChecksum.KeyCapitalized(): crc.Encoded(), "X-Amz-Checksum-Type": "FULL_OBJECT"}
+		}
+	}
 }

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -2407,10 +2407,6 @@ func testPutMultipartObjectWithChecksums(trailing bool) {
 
 		args["section"] = "prep"
 		bufSize := dataFileMap["datafile-129-MB"]
-		if false && test.cs.Is(minio.ChecksumFullObjectCRC32) {
-			c.TraceOn(os.Stdout)
-			defer c.TraceOff()
-		}
 		// Save the data
 		objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
 		args["objectName"] = objectName

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -2542,8 +2542,10 @@ func testPutMultipartObjectWithChecksums(trailing bool) {
 		case minio.ChecksumSHA256:
 			cmpChecksum(st.ChecksumSHA256, want)
 		case minio.ChecksumCRC64NVME:
-			// AWS does not send this.
-			cmpChecksum(st.ChecksumCRC64NVME, "")
+			// AWS doesn't return part checksum, but may in the future.
+			if st.ChecksumCRC64NVME != "" {
+				cmpChecksum(st.ChecksumCRC64NVME, want)
+			}
 		}
 
 		delete(args, "metadata")

--- a/utils.go
+++ b/utils.go
@@ -378,10 +378,11 @@ func ToObjectInfo(bucketName, objectName string, h http.Header) (ObjectInfo, err
 		Restore:      restore,
 
 		// Checksum values
-		ChecksumCRC32:  h.Get("x-amz-checksum-crc32"),
-		ChecksumCRC32C: h.Get("x-amz-checksum-crc32c"),
-		ChecksumSHA1:   h.Get("x-amz-checksum-sha1"),
-		ChecksumSHA256: h.Get("x-amz-checksum-sha256"),
+		ChecksumCRC32:     h.Get(ChecksumCRC32.Key()),
+		ChecksumCRC32C:    h.Get(ChecksumCRC32C.Key()),
+		ChecksumSHA1:      h.Get(ChecksumSHA1.Key()),
+		ChecksumSHA256:    h.Get(ChecksumSHA256.Key()),
+		ChecksumCRC64NVME: h.Get(ChecksumCRC64NVME.Key()),
 	}, nil
 }
 
@@ -697,4 +698,147 @@ func (h *hashReaderWrapper) Read(p []byte) (n int, err error) {
 		h.done(h.h.Sum(nil))
 	}
 	return n, err
+}
+
+// Followis is ported from C to Go in 2016 by Justin Ruggles, with minimal alteration.
+// Used uint for unsigned long. Used uint32 for input arguments in order to match
+// the Go hash/crc32 package. zlib CRC32 combine (https://github.com/madler/zlib)
+// Modified for hash/crc64 by Klaus Post, 2024.
+func gf2MatrixTimes(mat []uint64, vec uint64) uint64 {
+	var sum uint64
+
+	for vec != 0 {
+		if vec&1 != 0 {
+			sum ^= mat[0]
+		}
+		vec >>= 1
+		mat = mat[1:]
+	}
+	return sum
+}
+
+func gf2MatrixSquare(square, mat []uint64) {
+	if len(square) != len(mat) {
+		panic("square matrix size mismatch")
+	}
+	for n := range mat {
+		square[n] = gf2MatrixTimes(mat, mat[n])
+	}
+}
+
+// crc32Combine returns the combined CRC-32 hash value of the two passed CRC-32
+// hash values crc1 and crc2. poly represents the generator polynomial
+// and len2 specifies the byte length that the crc2 hash covers.
+func crc32Combine(poly uint32, crc1, crc2 uint32, len2 int64) uint32 {
+	// degenerate case (also disallow negative lengths)
+	if len2 <= 0 {
+		return crc1
+	}
+
+	even := make([]uint64, 32) // even-power-of-two zeros operator
+	odd := make([]uint64, 32)  // odd-power-of-two zeros operator
+
+	// put operator for one zero bit in odd
+	odd[0] = uint64(poly) // CRC-32 polynomial
+	row := uint64(1)
+	for n := 1; n < 32; n++ {
+		odd[n] = row
+		row <<= 1
+	}
+
+	// put operator for two zero bits in even
+	gf2MatrixSquare(even, odd)
+
+	// put operator for four zero bits in odd
+	gf2MatrixSquare(odd, even)
+
+	// apply len2 zeros to crc1 (first square will put the operator for one
+	// zero byte, eight zero bits, in even)
+	crc1n := uint64(crc1)
+	for {
+		// apply zeros operator for this bit of len2
+		gf2MatrixSquare(even, odd)
+		if len2&1 != 0 {
+			crc1n = gf2MatrixTimes(even, crc1n)
+		}
+		len2 >>= 1
+
+		// if no more bits set, then done
+		if len2 == 0 {
+			break
+		}
+
+		// another iteration of the loop with odd and even swapped
+		gf2MatrixSquare(odd, even)
+		if len2&1 != 0 {
+			crc1n = gf2MatrixTimes(odd, crc1n)
+		}
+		len2 >>= 1
+
+		// if no more bits set, then done
+		if len2 == 0 {
+			break
+		}
+	}
+
+	// return combined crc
+	crc1n ^= uint64(crc2)
+	return uint32(crc1n)
+}
+
+func crc64Combine(poly uint64, crc1, crc2 uint64, len2 int64) uint64 {
+	// degenerate case (also disallow negative lengths)
+	if len2 <= 0 {
+		return crc1
+	}
+
+	even := make([]uint64, 64) // even-power-of-two zeros operator
+	odd := make([]uint64, 64)  // odd-power-of-two zeros operator
+
+	// put operator for one zero bit in odd
+	odd[0] = poly // CRC-64 polynomial
+	row := uint64(1)
+	for n := 1; n < 64; n++ {
+		odd[n] = row
+		row <<= 1
+	}
+
+	// put operator for two zero bits in even
+	gf2MatrixSquare(even, odd)
+
+	// put operator for four zero bits in odd
+	gf2MatrixSquare(odd, even)
+
+	// apply len2 zeros to crc1 (first square will put the operator for one
+	// zero byte, eight zero bits, in even)
+	crc1n := crc1
+	for {
+		// apply zeros operator for this bit of len2
+		gf2MatrixSquare(even, odd)
+		if len2&1 != 0 {
+			crc1n = gf2MatrixTimes(even, crc1n)
+		}
+		len2 >>= 1
+
+		// if no more bits set, then done
+		if len2 == 0 {
+			break
+		}
+
+		// another iteration of the loop with odd and even swapped
+		gf2MatrixSquare(odd, even)
+		if len2&1 != 0 {
+			crc1n = gf2MatrixTimes(odd, crc1n)
+		}
+		len2 >>= 1
+
+		// if no more bits set, then done
+		if len2 == 0 {
+			break
+		}
+	}
+
+	// return combined crc
+	crc1n ^= crc2
+	return crc1n
 }

--- a/utils.go
+++ b/utils.go
@@ -700,7 +700,7 @@ func (h *hashReaderWrapper) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-// Followis is ported from C to Go in 2016 by Justin Ruggles, with minimal alteration.
+// Following is ported from C to Go in 2016 by Justin Ruggles, with minimal alteration.
 // Used uint for unsigned long. Used uint32 for input arguments in order to match
 // the Go hash/crc32 package. zlib CRC32 combine (https://github.com/madler/zlib)
 // Modified for hash/crc64 by Klaus Post, 2024.

--- a/utils_test.go
+++ b/utils_test.go
@@ -446,7 +446,7 @@ func TestFullObjectChecksum64(t *testing.T) {
 			want := sum(b)
 			var parts []ObjectPart
 			for len(b) > 0 {
-				sz := len(b) / 2
+				sz := rng.Intn(len(b) / 2)
 				if len(b)-sz < 1024 {
 					sz = len(b)
 				}

--- a/utils_test.go
+++ b/utils_test.go
@@ -465,7 +465,7 @@ func TestFullObjectChecksum64(t *testing.T) {
 				t.Fatal(err)
 			}
 			if gotCRC.Encoded() != want {
-				t.Errorf("Checksum CRC64NVME does not match the expected CRC got:%s want:%s", gotCRC.Encoded(), want)
+				t.Errorf("Checksum %v does not match the expected CRC got:%s want:%s", cs.String(), gotCRC.Encoded(), want)
 			}
 		})
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -20,6 +20,7 @@ package minio
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"testing"
 	"time"
@@ -427,5 +428,45 @@ func TestIsCustomQueryValue(t *testing.T) {
 		if actual != testCase.expectedValue {
 			t.Errorf("Test %d: Expected to pass, but failed", i+1)
 		}
+	}
+}
+
+func TestFullObjectChecksum64(t *testing.T) {
+	tests := []ChecksumType{
+		ChecksumCRC32,
+		ChecksumCRC32C,
+		ChecksumCRC64NVME,
+	}
+	for _, cs := range tests {
+		t.Run(cs.String(), func(t *testing.T) {
+			b := make([]byte, 1024000)
+			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+			rng.Read(b)
+			sum := cs.EncodeToString
+			want := sum(b)
+			var parts []ObjectPart
+			for len(b) > 0 {
+				sz := len(b) / 2
+				if len(b)-sz < 1024 {
+					sz = len(b)
+				}
+				switch cs {
+				case ChecksumCRC32:
+					parts = append(parts, ObjectPart{PartNumber: len(parts) + 1, ChecksumCRC32: cs.EncodeToString(b[:sz]), Size: int64(sz)})
+				case ChecksumCRC32C:
+					parts = append(parts, ObjectPart{PartNumber: len(parts) + 1, ChecksumCRC32C: cs.EncodeToString(b[:sz]), Size: int64(sz)})
+				case ChecksumCRC64NVME:
+					parts = append(parts, ObjectPart{PartNumber: len(parts) + 1, ChecksumCRC64NVME: cs.EncodeToString(b[:sz]), Size: int64(sz)})
+				}
+				b = b[sz:]
+			}
+			gotCRC, err := cs.FullObjectChecksum(parts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotCRC.Encoded() != want {
+				t.Errorf("Checksum CRC64NVME does not match the expected CRC got:%s want:%s", gotCRC.Encoded(), want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add support for full object checksums as described here:

https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html

To enable, use `ChecksumCRC64NVME`, `ChecksumFullObjectCRC32` or `ChecksumFullObjectCRC32C` as checksum type when uploading.

Mint tests updated, but can be disabled with `MINT_NO_FULL_OBJECT=anything` env var.

PR will fail against community MinIO without above env var.

Validated against AWS S3.