### PR TITLE
Fix duplicate API call on `obj.Stat()`

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -318,7 +318,7 @@ func (o *Object) doGetRequest(request getRequest) (getResponse, error) {
 	response := <-o.resCh
 
 	// Return any error to the top level.
-	if response.Error != nil {
+	if response.Error != nil && response.Error != io.EOF {
 		return response, response.Error
 	}
 
@@ -340,7 +340,7 @@ func (o *Object) doGetRequest(request getRequest) (getResponse, error) {
 	// Data are ready on the wire, no need to reinitiate connection in lower level
 	o.seekData = false
 
-	return response, nil
+	return response, response.Error
 }
 
 // setOffset - handles the setting of offsets for


### PR DESCRIPTION
Should fix #2027 

Created to convey the idea. ~Not tested~, nor wrote tests

Tested locally using `replace github.com/minio/minio-go/v7 v7.0.82 => github.com/OrkhanAlikhanov/minio-go/v7 patch-1`. Works as expected