### PR TITLE
Use proper HTTP client for fetching credentials

### DIFF
--- a/api-presigned.go
+++ b/api-presigned.go
@@ -140,7 +140,7 @@ func (c *Client) PresignedPostPolicy(ctx context.Context, p *PostPolicy) (u *url
 	}
 
 	// Get credentials from the configured credentials provider.
-	credValues, err := c.credsProvider.Get()
+	credValues, err := c.credsProvider.GetWithContext(c.CredContext())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -600,9 +600,9 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 		return nil, errors.New(c.endpointURL.String() + " is offline.")
 	}
 
-	var retryable bool          // Indicates if request can be retried.
-	var bodySeeker io.Seeker    // Extracted seeker from io.Reader.
-	var reqRetry = c.maxRetries // Indicates how many times we can retry the request
+	var retryable bool       // Indicates if request can be retried.
+	var bodySeeker io.Seeker // Extracted seeker from io.Reader.
+	reqRetry := c.maxRetries // Indicates how many times we can retry the request
 
 	if metadata.contentBody != nil {
 		// Check if body is seekable then it is retryable.
@@ -808,7 +808,7 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 	}
 
 	// Get credentials from the configured credentials provider.
-	value, err := c.credsProvider.Get()
+	value, err := c.credsProvider.GetWithContext(c.CredContext())
 	if err != nil {
 		return nil, err
 	}
@@ -1017,4 +1017,15 @@ func (c *Client) isVirtualHostStyleRequest(url url.URL, bucketName string) bool 
 	// default to virtual only for Amazon/Google  storage. In all other cases use
 	// path style requests
 	return s3utils.IsVirtualHostSupported(url, bucketName)
+}
+
+// CredContext returns the context for fetching credentials
+func (c *Client) CredContext() *credentials.CredContext {
+	httpClient := c.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &credentials.CredContext{
+		Client: httpClient,
+	}
 }

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -212,7 +212,7 @@ func (c *Client) getBucketLocationRequest(ctx context.Context, bucketName string
 	c.setUserAgent(req)
 
 	// Get credentials from the configured credentials provider.
-	value, err := c.credsProvider.Get()
+	value, err := c.credsProvider.GetWithContext(c.CredContext())
 	if err != nil {
 		return nil, err
 	}

--- a/bucket-cache_test.go
+++ b/bucket-cache_test.go
@@ -97,7 +97,7 @@ func TestGetBucketLocationRequest(t *testing.T) {
 		c.setUserAgent(req)
 
 		// Get credentials from the configured credentials provider.
-		value, err := c.credsProvider.Get()
+		value, err := c.credsProvider.GetWithContext(c.CredContext())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -76,9 +76,6 @@ type AssumeRoleResult struct {
 type STSAssumeRole struct {
 	Expiry
 
-	// Required http Client to use when connecting to MinIO STS service.
-	Client *http.Client
-
 	// STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -115,9 +112,6 @@ func NewSTSAssumeRole(stsEndpoint string, opts STSAssumeRoleOptions) (*Credentia
 		return nil, errors.New("AssumeRole credentials access/secretkey is mandatory")
 	}
 	return New(&STSAssumeRole{
-		Client: &http.Client{
-			Transport: http.DefaultTransport,
-		},
 		STSEndpoint: stsEndpoint,
 		Options:     opts,
 	}), nil
@@ -224,8 +218,8 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
-func (m *STSAssumeRole) Retrieve() (Value, error) {
-	a, err := getAssumeRoleCredentials(m.Client, m.STSEndpoint, m.Options)
+func (m *STSAssumeRole) Retrieve(cc *CredContext) (Value, error) {
+	a, err := getAssumeRoleCredentials(cc.Client, m.STSEndpoint, m.Options)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -76,6 +76,10 @@ type AssumeRoleResult struct {
 type STSAssumeRole struct {
 	Expiry
 
+	// Optional http Client to use when connecting to MinIO STS service
+	// (overrides default client in CredContext)
+	Client *http.Client
+
 	// STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -219,7 +223,11 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
 func (m *STSAssumeRole) Retrieve(cc *CredContext) (Value, error) {
-	a, err := getAssumeRoleCredentials(cc.Client, m.STSEndpoint, m.Options)
+	client := m.Client
+	if client == nil {
+		client = cc.Client
+	}
+	a, err := getAssumeRoleCredentials(client, m.STSEndpoint, m.Options)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/chain.go
+++ b/pkg/credentials/chain.go
@@ -60,9 +60,9 @@ func NewChainCredentials(providers []Provider) *Credentials {
 //
 // If a provider is found with credentials, it will be cached and any calls
 // to IsExpired() will return the expired state of the cached provider.
-func (c *Chain) Retrieve() (Value, error) {
+func (c *Chain) Retrieve(cc *CredContext) (Value, error) {
 	for _, p := range c.Providers {
-		creds, _ := p.Retrieve()
+		creds, _ := p.Retrieve(cc)
 		// Always prioritize non-anonymous providers, if any.
 		if creds.AccessKeyID == "" && creds.SecretAccessKey == "" {
 			continue

--- a/pkg/credentials/chain_test.go
+++ b/pkg/credentials/chain_test.go
@@ -28,7 +28,7 @@ type testCredProvider struct {
 	err     error
 }
 
-func (s *testCredProvider) Retrieve() (Value, error) {
+func (s *testCredProvider) Retrieve(_ *CredContext) (Value, error) {
 	s.expired = false
 	return s.creds, s.err
 }
@@ -59,7 +59,7 @@ func TestChainGet(t *testing.T) {
 		},
 	}
 
-	creds, err := p.Retrieve()
+	creds, err := p.Retrieve(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestChainIsExpired(t *testing.T) {
 		t.Fatal("Expected expired to be true before any Retrieve")
 	}
 
-	_, err := p.Retrieve()
+	_, err := p.Retrieve(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestChainWithNoProvider(t *testing.T) {
 	if !p.IsExpired() {
 		t.Fatal("Expected to be expired with no providers")
 	}
-	_, err := p.Retrieve()
+	_, err := p.Retrieve(defaultCredContext)
 	if err != nil {
 		if err.Error() != "No valid providers found []" {
 			t.Error(err)
@@ -136,7 +136,7 @@ func TestChainProviderWithNoValidProvider(t *testing.T) {
 		t.Fatal("Expected to be expired with no providers")
 	}
 
-	_, err := p.Retrieve()
+	_, err := p.Retrieve(defaultCredContext)
 	if err != nil {
 		if err.Error() != "No valid providers found [FirstError SecondError]" {
 			t.Error(err)

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -18,6 +18,7 @@
 package credentials
 
 import (
+	"net/http"
 	"sync"
 	"time"
 )
@@ -29,6 +30,10 @@ const (
 	// How much duration to slash from the given expiration duration
 	defaultExpiryWindow = 0.8
 )
+
+// defaultCredContext is used when the credential context doesn't
+// actually matter or the default context is suitable.
+var defaultCredContext = &CredContext{Client: http.DefaultClient}
 
 // A Value is the S3 credentials value for individual credential fields.
 type Value struct {
@@ -54,11 +59,19 @@ type Value struct {
 type Provider interface {
 	// Retrieve returns nil if it successfully retrieved the value.
 	// Error is returned if the value were not obtainable, or empty.
-	Retrieve() (Value, error)
+	Retrieve(cc *CredContext) (Value, error)
 
 	// IsExpired returns if the credentials are no longer valid, and need
 	// to be retrieved.
 	IsExpired() bool
+}
+
+// CredContext is passed to the Retrieve function of a provider to provide
+// some additional context to retrieve credentials.
+type CredContext struct {
+	// Client specifies the HTTP client that should be used if an HTTP
+	// request is to be made to fetch the credentials.
+	Client *http.Client
 }
 
 // A Expiry provides shared expiration logic to be used by credentials
@@ -146,7 +159,24 @@ func New(provider Provider) *Credentials {
 //
 // If Credentials.Expire() was called the credentials Value will be force
 // expired, and the next call to Get() will cause them to be refreshed.
+//
+// Deprecated: Get() exists for historical compatibility and should not be
+// used. To get new credentials use the Credentials.GetWithContext function
+// to ensure the proper context (i.e. HTTP client) will be used.
 func (c *Credentials) Get() (Value, error) {
+	return c.GetWithContext(defaultCredContext)
+}
+
+// GetWithContext returns the credentials value, or error if the
+// credentials Value failed to be retrieved.
+//
+// Will return the cached credentials Value if it has not expired. If the
+// credentials Value has expired the Provider's Retrieve() will be called
+// to refresh the credentials.
+//
+// If Credentials.Expire() was called the credentials Value will be force
+// expired, and the next call to Get() will cause them to be refreshed.
+func (c *Credentials) GetWithContext(cc *CredContext) (Value, error) {
 	if c == nil {
 		return Value{}, nil
 	}
@@ -155,7 +185,7 @@ func (c *Credentials) Get() (Value, error) {
 	defer c.Unlock()
 
 	if c.isExpired() {
-		creds, err := c.provider.Retrieve()
+		creds, err := c.provider.Retrieve(cc)
 		if err != nil {
 			return Value{}, err
 		}

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -28,7 +28,7 @@ type credProvider struct {
 	err     error
 }
 
-func (s *credProvider) Retrieve() (Value, error) {
+func (s *credProvider) Retrieve(_ *CredContext) (Value, error) {
 	s.expired = false
 	return s.creds, s.err
 }
@@ -47,7 +47,7 @@ func TestCredentialsGet(t *testing.T) {
 		expired: true,
 	})
 
-	creds, err := c.Get()
+	creds, err := c.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestCredentialsGet(t *testing.T) {
 func TestCredentialsGetWithError(t *testing.T) {
 	c := New(&credProvider{err: errors.New("Custom error")})
 
-	_, err := c.Get()
+	_, err := c.GetWithContext(defaultCredContext)
 	if err != nil {
 		if err.Error() != "Custom error" {
 			t.Errorf("Expected \"Custom error\", got %s", err.Error())

--- a/pkg/credentials/env_aws.go
+++ b/pkg/credentials/env_aws.go
@@ -38,7 +38,7 @@ func NewEnvAWS() *Credentials {
 }
 
 // Retrieve retrieves the keys from the environment.
-func (e *EnvAWS) Retrieve() (Value, error) {
+func (e *EnvAWS) Retrieve(_ *CredContext) (Value, error) {
 	e.retrieved = false
 
 	id := os.Getenv("AWS_ACCESS_KEY_ID")

--- a/pkg/credentials/env_minio.go
+++ b/pkg/credentials/env_minio.go
@@ -39,7 +39,7 @@ func NewEnvMinio() *Credentials {
 }
 
 // Retrieve retrieves the keys from the environment.
-func (e *EnvMinio) Retrieve() (Value, error) {
+func (e *EnvMinio) Retrieve(_ *CredContext) (Value, error) {
 	e.retrieved = false
 
 	id := os.Getenv("MINIO_ROOT_USER")

--- a/pkg/credentials/env_test.go
+++ b/pkg/credentials/env_test.go
@@ -34,7 +34,7 @@ func TestEnvAWSRetrieve(t *testing.T) {
 		t.Error("Expect creds to be expired before retrieve.")
 	}
 
-	creds, err := e.Retrieve()
+	creds, err := e.Retrieve(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestEnvAWSRetrieve(t *testing.T) {
 		SignerType:      SignatureV4,
 	}
 
-	creds, err = e.Retrieve()
+	creds, err = e.Retrieve(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestEnvMinioRetrieve(t *testing.T) {
 		t.Error("Expect creds to be expired before retrieve.")
 	}
 
-	creds, err := e.Retrieve()
+	creds, err := e.Retrieve(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/credentials/file_aws_credentials.go
+++ b/pkg/credentials/file_aws_credentials.go
@@ -73,7 +73,7 @@ func NewFileAWSCredentials(filename, profile string) *Credentials {
 
 // Retrieve reads and extracts the shared credentials from the current
 // users home directory.
-func (p *FileAWSCredentials) Retrieve() (Value, error) {
+func (p *FileAWSCredentials) Retrieve(_ *CredContext) (Value, error) {
 	if p.Filename == "" {
 		p.Filename = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
 		if p.Filename == "" {

--- a/pkg/credentials/file_minio_client.go
+++ b/pkg/credentials/file_minio_client.go
@@ -58,7 +58,7 @@ func NewFileMinioClient(filename, alias string) *Credentials {
 
 // Retrieve reads and extracts the shared credentials from the current
 // users home directory.
-func (p *FileMinioClient) Retrieve() (Value, error) {
+func (p *FileMinioClient) Retrieve(_ *CredContext) (Value, error) {
 	if p.Filename == "" {
 		if value, ok := os.LookupEnv("MINIO_SHARED_CREDENTIALS_FILE"); ok {
 			p.Filename = value

--- a/pkg/credentials/file_test.go
+++ b/pkg/credentials/file_test.go
@@ -31,7 +31,7 @@ func TestFileAWS(t *testing.T) {
 	os.Clearenv()
 
 	creds := NewFileAWSCredentials("credentials.sample", "")
-	credValues, err := creds.Get()
+	credValues, err := creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestFileAWS(t *testing.T) {
 
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "credentials.sample")
 	creds = NewFileAWSCredentials("", "")
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestFileAWS(t *testing.T) {
 
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(wd, "credentials.sample"))
 	creds = NewFileAWSCredentials("", "")
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestFileAWS(t *testing.T) {
 	os.Setenv("AWS_PROFILE", "no_token")
 
 	creds = NewFileAWSCredentials("credentials.sample", "")
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestFileAWS(t *testing.T) {
 	os.Clearenv()
 
 	creds = NewFileAWSCredentials("credentials.sample", "no_token")
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestFileAWS(t *testing.T) {
 	}
 
 	creds = NewFileAWSCredentials("credentials-non-existent.sample", "no_token")
-	_, err = creds.Get()
+	_, err = creds.GetWithContext(defaultCredContext)
 	if !os.IsNotExist(err) {
 		t.Errorf("Expected open non-existent.json: no such file or directory, got %s", err)
 	}
@@ -128,7 +128,7 @@ func TestFileAWS(t *testing.T) {
 	os.Clearenv()
 
 	creds = NewFileAWSCredentials("credentials.sample", "with_process")
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestFileMinioClient(t *testing.T) {
 	os.Clearenv()
 
 	creds := NewFileMinioClient("config.json.sample", "")
-	credValues, err := creds.Get()
+	credValues, err := creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestFileMinioClient(t *testing.T) {
 	os.Setenv("MINIO_ALIAS", "play")
 
 	creds = NewFileMinioClient("config.json.sample", "")
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestFileMinioClient(t *testing.T) {
 	os.Clearenv()
 
 	creds = NewFileMinioClient("config.json.sample", "play")
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestFileMinioClient(t *testing.T) {
 	}
 
 	creds = NewFileMinioClient("non-existent.json", "play")
-	_, err = creds.Get()
+	_, err = creds.GetWithContext(defaultCredContext)
 	if !os.IsNotExist(err) {
 		t.Errorf("Expected open non-existent.json: no such file or directory, got %s", err)
 	}

--- a/pkg/credentials/static.go
+++ b/pkg/credentials/static.go
@@ -51,7 +51,7 @@ func NewStatic(id, secret, token string, signerType SignatureType) *Credentials 
 }
 
 // Retrieve returns the static credentials.
-func (s *Static) Retrieve() (Value, error) {
+func (s *Static) Retrieve(_ *CredContext) (Value, error) {
 	if s.AccessKeyID == "" || s.SecretAccessKey == "" {
 		// Anonymous is not an error
 		return Value{SignerType: SignatureAnonymous}, nil

--- a/pkg/credentials/static_test.go
+++ b/pkg/credentials/static_test.go
@@ -21,7 +21,7 @@ import "testing"
 
 func TestStaticGet(t *testing.T) {
 	creds := NewStatic("UXHW", "SECRET", "", SignatureV4)
-	credValues, err := creds.Get()
+	credValues, err := creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestStaticGet(t *testing.T) {
 	}
 
 	creds = NewStatic("", "", "", SignatureDefault)
-	credValues, err = creds.Get()
+	credValues, err = creds.GetWithContext(defaultCredContext)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/credentials/sts_client_grants.go
+++ b/pkg/credentials/sts_client_grants.go
@@ -72,9 +72,6 @@ type ClientGrantsToken struct {
 type STSClientGrants struct {
 	Expiry
 
-	// Required http Client to use when connecting to MinIO STS service.
-	Client *http.Client
-
 	// MinIO endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -97,9 +94,6 @@ func NewSTSClientGrants(stsEndpoint string, getClientGrantsTokenExpiry func() (*
 		return nil, errors.New("Client grants access token and expiry retrieval function should be defined")
 	}
 	return New(&STSClientGrants{
-		Client: &http.Client{
-			Transport: http.DefaultTransport,
-		},
 		STSEndpoint:                stsEndpoint,
 		GetClientGrantsTokenExpiry: getClientGrantsTokenExpiry,
 	}), nil
@@ -164,8 +158,8 @@ func getClientGrantsCredentials(clnt *http.Client, endpoint string,
 
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
-func (m *STSClientGrants) Retrieve() (Value, error) {
-	a, err := getClientGrantsCredentials(m.Client, m.STSEndpoint, m.GetClientGrantsTokenExpiry)
+func (m *STSClientGrants) Retrieve(cc *CredContext) (Value, error) {
+	a, err := getClientGrantsCredentials(cc.Client, m.STSEndpoint, m.GetClientGrantsTokenExpiry)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/sts_client_grants.go
+++ b/pkg/credentials/sts_client_grants.go
@@ -72,6 +72,10 @@ type ClientGrantsToken struct {
 type STSClientGrants struct {
 	Expiry
 
+	// Optional http Client to use when connecting to MinIO STS service.
+	// (overrides default client in CredContext)
+	Client *http.Client
+
 	// MinIO endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -159,7 +163,11 @@ func getClientGrantsCredentials(clnt *http.Client, endpoint string,
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
 func (m *STSClientGrants) Retrieve(cc *CredContext) (Value, error) {
-	a, err := getClientGrantsCredentials(cc.Client, m.STSEndpoint, m.GetClientGrantsTokenExpiry)
+	client := m.Client
+	if client == nil {
+		client = cc.Client
+	}
+	a, err := getClientGrantsCredentials(client, m.STSEndpoint, m.GetClientGrantsTokenExpiry)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/sts_custom_identity.go
+++ b/pkg/credentials/sts_custom_identity.go
@@ -53,8 +53,6 @@ type AssumeRoleWithCustomTokenResponse struct {
 type CustomTokenIdentity struct {
 	Expiry
 
-	Client *http.Client
-
 	// MinIO server STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -70,7 +68,7 @@ type CustomTokenIdentity struct {
 }
 
 // Retrieve - to satisfy Provider interface; fetches credentials from MinIO.
-func (c *CustomTokenIdentity) Retrieve() (value Value, err error) {
+func (c *CustomTokenIdentity) Retrieve(cc *CredContext) (value Value, err error) {
 	u, err := url.Parse(c.STSEndpoint)
 	if err != nil {
 		return value, err
@@ -92,7 +90,7 @@ func (c *CustomTokenIdentity) Retrieve() (value Value, err error) {
 		return value, err
 	}
 
-	resp, err := c.Client.Do(req)
+	resp, err := cc.Client.Do(req)
 	if err != nil {
 		return value, err
 	}
@@ -122,7 +120,6 @@ func (c *CustomTokenIdentity) Retrieve() (value Value, err error) {
 // AssumeRoleWithCustomToken STS API.
 func NewCustomTokenCredentials(stsEndpoint, token, roleArn string, optFuncs ...CustomTokenOpt) (*Credentials, error) {
 	c := CustomTokenIdentity{
-		Client:      &http.Client{Transport: http.DefaultTransport},
 		STSEndpoint: stsEndpoint,
 		Token:       token,
 		RoleArn:     roleArn,

--- a/pkg/credentials/sts_custom_identity.go
+++ b/pkg/credentials/sts_custom_identity.go
@@ -53,6 +53,10 @@ type AssumeRoleWithCustomTokenResponse struct {
 type CustomTokenIdentity struct {
 	Expiry
 
+	// Optional http Client to use when connecting to MinIO STS service.
+	// (overrides default client in CredContext)
+	Client *http.Client
+
 	// MinIO server STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -90,7 +94,12 @@ func (c *CustomTokenIdentity) Retrieve(cc *CredContext) (value Value, err error)
 		return value, err
 	}
 
-	resp, err := cc.Client.Do(req)
+	client := c.Client
+	if client == nil {
+		client = cc.Client
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return value, err
 	}

--- a/pkg/credentials/sts_ldap_identity.go
+++ b/pkg/credentials/sts_ldap_identity.go
@@ -55,9 +55,6 @@ type LDAPIdentityResult struct {
 type LDAPIdentity struct {
 	Expiry
 
-	// Required http Client to use when connecting to MinIO STS service.
-	Client *http.Client
-
 	// Exported STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -77,7 +74,6 @@ type LDAPIdentity struct {
 // Identity.
 func NewLDAPIdentity(stsEndpoint, ldapUsername, ldapPassword string, optFuncs ...LDAPIdentityOpt) (*Credentials, error) {
 	l := LDAPIdentity{
-		Client:       &http.Client{Transport: http.DefaultTransport},
 		STSEndpoint:  stsEndpoint,
 		LDAPUsername: ldapUsername,
 		LDAPPassword: ldapPassword,
@@ -113,7 +109,6 @@ func LDAPIdentityExpiryOpt(d time.Duration) LDAPIdentityOpt {
 // Deprecated: Use the `LDAPIdentityPolicyOpt` with `NewLDAPIdentity` instead.
 func NewLDAPIdentityWithSessionPolicy(stsEndpoint, ldapUsername, ldapPassword, policy string) (*Credentials, error) {
 	return New(&LDAPIdentity{
-		Client:       &http.Client{Transport: http.DefaultTransport},
 		STSEndpoint:  stsEndpoint,
 		LDAPUsername: ldapUsername,
 		LDAPPassword: ldapPassword,
@@ -123,7 +118,7 @@ func NewLDAPIdentityWithSessionPolicy(stsEndpoint, ldapUsername, ldapPassword, p
 
 // Retrieve gets the credential by calling the MinIO STS API for
 // LDAP on the configured stsEndpoint.
-func (k *LDAPIdentity) Retrieve() (value Value, err error) {
+func (k *LDAPIdentity) Retrieve(cc *CredContext) (value Value, err error) {
 	u, err := url.Parse(k.STSEndpoint)
 	if err != nil {
 		return value, err
@@ -148,7 +143,7 @@ func (k *LDAPIdentity) Retrieve() (value Value, err error) {
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := k.Client.Do(req)
+	resp, err := cc.Client.Do(req)
 	if err != nil {
 		return value, err
 	}

--- a/pkg/credentials/sts_ldap_identity.go
+++ b/pkg/credentials/sts_ldap_identity.go
@@ -55,6 +55,10 @@ type LDAPIdentityResult struct {
 type LDAPIdentity struct {
 	Expiry
 
+	// Optional http Client to use when connecting to MinIO STS service.
+	// (overrides default client in CredContext)
+	Client *http.Client
+
 	// Exported STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -143,7 +147,12 @@ func (k *LDAPIdentity) Retrieve(cc *CredContext) (value Value, err error) {
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := cc.Client.Do(req)
+	client := k.Client
+	if client == nil {
+		client = cc.Client
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return value, err
 	}

--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -69,6 +69,10 @@ type WebIdentityToken struct {
 type STSWebIdentity struct {
 	Expiry
 
+	// Optional http Client to use when connecting to MinIO STS service.
+	// (overrides default client in CredContext)
+	Client *http.Client
+
 	// Exported STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -216,7 +220,12 @@ func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSession
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
 func (m *STSWebIdentity) Retrieve(cc *CredContext) (Value, error) {
-	a, err := getWebIdentityCredentials(cc.Client, m.STSEndpoint, m.RoleARN, m.roleSessionName, m.Policy, m.GetWebIDTokenExpiry)
+	client := m.Client
+	if client == nil {
+		client = cc.Client
+	}
+
+	a, err := getWebIdentityCredentials(client, m.STSEndpoint, m.RoleARN, m.roleSessionName, m.Policy, m.GetWebIDTokenExpiry)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -69,9 +69,6 @@ type WebIdentityToken struct {
 type STSWebIdentity struct {
 	Expiry
 
-	// Required http Client to use when connecting to MinIO STS service.
-	Client *http.Client
-
 	// Exported STS endpoint to fetch STS credentials.
 	STSEndpoint string
 
@@ -104,9 +101,6 @@ func NewSTSWebIdentity(stsEndpoint string, getWebIDTokenExpiry func() (*WebIdent
 		return nil, errors.New("Web ID token and expiry retrieval function should be defined")
 	}
 	i := &STSWebIdentity{
-		Client: &http.Client{
-			Transport: http.DefaultTransport,
-		},
 		STSEndpoint:         stsEndpoint,
 		GetWebIDTokenExpiry: getWebIDTokenExpiry,
 	}
@@ -221,8 +215,8 @@ func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSession
 
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
-func (m *STSWebIdentity) Retrieve() (Value, error) {
-	a, err := getWebIdentityCredentials(m.Client, m.STSEndpoint, m.RoleARN, m.roleSessionName, m.Policy, m.GetWebIDTokenExpiry)
+func (m *STSWebIdentity) Retrieve(cc *CredContext) (Value, error) {
+	a, err := getWebIdentityCredentials(cc.Client, m.STSEndpoint, m.RoleARN, m.roleSessionName, m.Policy, m.GetWebIDTokenExpiry)
 	if err != nil {
 		return Value{}, err
 	}


### PR DESCRIPTION
This PR ensures that the HTTP client that is set on the `MinioClient` will also be used when the client needs to fetch credentials via an HTTP request.

- Instead of passing the HTTP client through all layers, I have choosen to use a `CredContext` structure that abstracts the HTTP client and may also be used to add more context (when needed).
- The `STSCertificateIdentity` method passes certificates via the `TLSClientConfig`, so in this case the HTTP transport is cloned and it sets the certificate explicitly. The original implementation did set additional `http.Transport` fields, but this has been removed.
- The `credentials.(*Credentials).Get()` function is deprecated and `Provider.GetWithCredContext()` should be used instead. It's still there to provide backward compatibility.
- When this PR is merged, then we should also update `madmin` to also pass the custom HTTP client.

Fixes #2040.