### PR TITLE
Use default STS endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -1026,6 +1026,7 @@ func (c *Client) CredContext() *credentials.CredContext {
 		httpClient = http.DefaultClient
 	}
 	return &credentials.CredContext{
-		Client: httpClient,
+		Client:   httpClient,
+		Endpoint: c.endpointURL.String(),
 	}
 }

--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -109,9 +109,6 @@ type STSAssumeRoleOptions struct {
 // NewSTSAssumeRole returns a pointer to a new
 // Credentials object wrapping the STSAssumeRole.
 func NewSTSAssumeRole(stsEndpoint string, opts STSAssumeRoleOptions) (*Credentials, error) {
-	if stsEndpoint == "" {
-		return nil, errors.New("STS endpoint cannot be empty")
-	}
 	if opts.AccessKey == "" || opts.SecretKey == "" {
 		return nil, errors.New("AssumeRole credentials access/secretkey is mandatory")
 	}
@@ -220,12 +217,30 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 	return a, nil
 }
 
-func (m *STSAssumeRole) retrieve(cc *CredContext) (Value, error) {
+// RetrieveWithCredContext retrieves credentials from the MinIO service.
+// Error will be returned if the request fails, optional cred context.
+func (m *STSAssumeRole) RetrieveWithCredContext(cc *CredContext) (Value, error) {
+	if cc == nil {
+		cc = defaultCredContext
+	}
+
 	client := m.Client
 	if client == nil {
 		client = cc.Client
 	}
-	a, err := getAssumeRoleCredentials(client, m.STSEndpoint, m.Options)
+	if client == nil {
+		client = defaultCredContext.Client
+	}
+
+	stsEndpoint := m.STSEndpoint
+	if stsEndpoint == "" {
+		stsEndpoint = cc.Endpoint
+	}
+	if stsEndpoint == "" {
+		return Value{}, errors.New("STS endpoint unknown")
+	}
+
+	a, err := getAssumeRoleCredentials(client, stsEndpoint, m.Options)
 	if err != nil {
 		return Value{}, err
 	}
@@ -242,14 +257,8 @@ func (m *STSAssumeRole) retrieve(cc *CredContext) (Value, error) {
 	}, nil
 }
 
-// RetrieveWithCredContext retrieves credentials from the MinIO service.
-// Error will be returned if the request fails, optional cred context.
-func (m *STSAssumeRole) RetrieveWithCredContext(cc *CredContext) (Value, error) {
-	return m.retrieve(cc)
-}
-
 // Retrieve retrieves credentials from the MinIO service.
 // Error will be returned if the request fails.
 func (m *STSAssumeRole) Retrieve() (Value, error) {
-	return m.retrieve(defaultCredContext)
+	return m.RetrieveWithCredContext(nil)
 }

--- a/pkg/credentials/chain.go
+++ b/pkg/credentials/chain.go
@@ -80,7 +80,7 @@ func (c *Chain) RetrieveWithCredContext(cc *CredContext) (Value, error) {
 // to IsExpired() will return the expired state of the cached provider.
 func (c *Chain) Retrieve() (Value, error) {
 	for _, p := range c.Providers {
-		creds, _ := p.RetrieveWithCredContext(defaultCredContext)
+		creds, _ := p.Retrieve()
 		// Always prioritize non-anonymous providers, if any.
 		if creds.AccessKeyID == "" && creds.SecretAccessKey == "" {
 			continue

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -64,6 +64,10 @@ type Provider interface {
 
 	// Retrieve returns nil if it successfully retrieved the value.
 	// Error is returned if the value were not obtainable, or empty.
+	//
+	// Deprecated: Retrieve() exists for historical compatibility and should not
+	// be used. To get new credentials use the RetrieveWithCredContext function
+	// to ensure the proper context (i.e. HTTP client) will be used.
 	Retrieve() (Value, error)
 
 	// IsExpired returns if the credentials are no longer valid, and need
@@ -77,6 +81,10 @@ type CredContext struct {
 	// Client specifies the HTTP client that should be used if an HTTP
 	// request is to be made to fetch the credentials.
 	Client *http.Client
+
+	// Endpoint specifies the MinIO endpoint that will be used if no
+	// explicit endpoint is provided.
+	Endpoint string
 }
 
 // A Expiry provides shared expiration logic to be used by credentials
@@ -169,7 +177,7 @@ func New(provider Provider) *Credentials {
 // used. To get new credentials use the Credentials.GetWithContext function
 // to ensure the proper context (i.e. HTTP client) will be used.
 func (c *Credentials) Get() (Value, error) {
-	return c.GetWithContext(defaultCredContext)
+	return c.GetWithContext(nil)
 }
 
 // GetWithContext returns the credentials value, or error if the
@@ -184,6 +192,9 @@ func (c *Credentials) Get() (Value, error) {
 func (c *Credentials) GetWithContext(cc *CredContext) (Value, error) {
 	if c == nil {
 		return Value{}, nil
+	}
+	if cc == nil {
+		cc = defaultCredContext
 	}
 
 	c.Lock()

--- a/pkg/credentials/env_aws.go
+++ b/pkg/credentials/env_aws.go
@@ -69,7 +69,7 @@ func (e *EnvAWS) Retrieve() (Value, error) {
 	return e.retrieve()
 }
 
-// RetrieveWithContext is like Retrieve (no-op input of Cred Context)
+// RetrieveWithCredContext is like Retrieve (no-op input of Cred Context)
 func (e *EnvAWS) RetrieveWithCredContext(_ *CredContext) (Value, error) {
 	return e.retrieve()
 }

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -95,7 +95,12 @@ func NewIAM(endpoint string) *Credentials {
 	})
 }
 
-func (m *IAM) retrieve(cc *CredContext) (Value, error) {
+// RetrieveWithCredContext is like Retrieve with Cred Context
+func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
+	if cc == nil {
+		cc = defaultCredContext
+	}
+
 	token := os.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN")
 	if token == "" {
 		token = m.Container.AuthorizationToken
@@ -143,8 +148,15 @@ func (m *IAM) retrieve(cc *CredContext) (Value, error) {
 	if client == nil {
 		client = cc.Client
 	}
+	if client == nil {
+		client = defaultCredContext.Client
+	}
 
 	endpoint := m.Endpoint
+	if endpoint == "" {
+		endpoint = cc.Endpoint
+	}
+
 	switch {
 	case identityFile != "":
 		if len(endpoint) == 0 {
@@ -228,12 +240,7 @@ func (m *IAM) retrieve(cc *CredContext) (Value, error) {
 // Error will be returned if the request fails, or unable to extract
 // the desired
 func (m *IAM) Retrieve() (Value, error) {
-	return m.retrieve(defaultCredContext)
-}
-
-// RetrieveWithCredContext is like Retrieve with Cred Context
-func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
-	return m.retrieve(cc)
+	return m.RetrieveWithCredContext(nil)
 }
 
 // A ec2RoleCredRespBody provides the shape for unmarshaling credential


### PR DESCRIPTION
The `CredentialContext` allows to pass the MinIO endpoint to the credential provider. This PR will use the MinIO endpoint as the default STS endpoint if no STS endpoint is specified.

I didn't want to break the API, but when we move to MinIO v8, then the `endpoint` parameter should be removed from functions like `credentials.NewSTSWebIdentity()` and it should be passed as an option.