### PR TITLE
Allow status code 200 for removeBucketPolicy

### DIFF
--- a/api-bucket-policy.go
+++ b/api-bucket-policy.go
@@ -88,7 +88,7 @@ func (c *Client) removeBucketPolicy(ctx context.Context, bucketName string) erro
 		return err
 	}
 
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
 		return httpRespToErrorResponse(resp, bucketName, "")
 	}
 


### PR DESCRIPTION
I'm using Hetzner Object Storage, and they return a status code of 200 on successfully deleting bucket policy.

This pull request fixes the issue of getting an error even through the policy was successfully deleted.

The error handling was introduced here 
https://github.com/minio/minio-go/pull/1609

Kind regards


