### PR TITLE
allow users to extend DNS style buckets

### DIFF
--- a/api.go
+++ b/api.go
@@ -92,6 +92,9 @@ type Client struct {
 	// default to Auto.
 	lookup BucketLookupType
 
+	// lookupFn is a custom function to return URL lookup type supported by the server.
+	lookupFn func(u url.URL, bucketName string) BucketLookupType
+
 	// Factory for MD5 hash functions.
 	md5Hasher    func() md5simd.Hasher
 	sha256Hasher func() md5simd.Hasher
@@ -116,6 +119,25 @@ type Options struct {
 	// have a custom endpoints with many regions you can use this
 	// function to perform region lookups appropriately.
 	CustomRegionViaURL func(u url.URL) string
+
+	// Provide a custom function that returns BucketLookupType based
+	// on the input URL, this is just like s3utils.IsVirtualHostSupported()
+	// function but allows users to provide their own implementation.
+	// Once this is set it overrides all settings for opts.BucketLookup
+	// if this function returns BucketLookupAuto then default detection
+	// via s3utils.IsVirtualHostSupported() is used, otherwise the
+	// function is expected to return appropriate value as expected for
+	// the URL the user wishes to honor.
+	//
+	// BucketName is passed additionally for the caller to ensure
+	// handle situations where `bucketNames` have multiple `.` separators
+	// in such case HTTPs certs will not work properly for *.<domain>
+	// wildcards, so you need to specifically handle these situations
+	// and not return bucket as part of DNS since those requests may fail.
+	//
+	// For better understanding look at s3utils.IsVirtualHostSupported()
+	// implementation.
+	BucketLookupViaURL func(u url.URL, bucketName string) BucketLookupType
 
 	// TrailingHeaders indicates server support of trailing headers.
 	// Only supported for v4 signatures.
@@ -279,6 +301,7 @@ func privateNew(endpoint string, opts *Options) (*Client, error) {
 	// Sets bucket lookup style, whether server accepts DNS or Path lookup. Default is Auto - determined
 	// by the SDK. When Auto is specified, DNS lookup is used for Amazon/Google cloud endpoints and Path for all other endpoints.
 	clnt.lookup = opts.BucketLookup
+	clnt.lookupFn = opts.BucketLookupViaURL
 
 	// healthcheck is not initialized
 	clnt.healthStatus = unknown
@@ -1003,6 +1026,18 @@ func (c *Client) makeTargetURL(bucketName, objectName, bucketLocation string, is
 
 // returns true if virtual hosted style requests are to be used.
 func (c *Client) isVirtualHostStyleRequest(url url.URL, bucketName string) bool {
+	if c.lookupFn != nil {
+		lookup := c.lookupFn(url, bucketName)
+		switch lookup {
+		case BucketLookupDNS:
+			return true
+		case BucketLookupPath:
+			return false
+		}
+		// if its auto then we fallback to default detection.
+		return s3utils.IsVirtualHostSupported(url, bucketName)
+	}
+
 	if bucketName == "" {
 		return false
 	}
@@ -1010,11 +1045,12 @@ func (c *Client) isVirtualHostStyleRequest(url url.URL, bucketName string) bool 
 	if c.lookup == BucketLookupDNS {
 		return true
 	}
+
 	if c.lookup == BucketLookupPath {
 		return false
 	}
 
-	// default to virtual only for Amazon/Google  storage. In all other cases use
+	// default to virtual only for Amazon/Google storage. In all other cases use
 	// path style requests
 	return s3utils.IsVirtualHostSupported(url, bucketName)
 }


### PR DESCRIPTION
this is to allow for custom extensions, since
we keep getting new requests to add new URLs
as default for bucket DNS style requests. This
is not scalable for this SDK, allowing a caller
specific function allows callers can write their
own function and provide us when they wish to use
path style or bucket DNS style.