### PR TITLE
Add nill check for processBucketLocationResponse

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -145,6 +145,8 @@ func processBucketLocationResponse(resp *http.Response, bucketName string) (buck
 			}
 			return "", err
 		}
+	} else {
+		return "", errInvalidArgument("Response is empty.")
 	}
 
 	// Extract location.


### PR DESCRIPTION
resp not checking for nil and can be deferenced at `resp.Body`

https://github.com/minio/minio-go/blob/79b60997cb772a6fdc715453e27a03b94984e9ca/bucket-cache.go#L121

We check it for nil, so I decided that this func can accept nil resp