### PR TITLE
fix: allow port in endpoint for aws private link validation

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -218,7 +218,7 @@ func IsAmazonPrivateLinkEndpoint(endpointURL url.URL) bool {
 	if endpointURL == sentinelURL {
 		return false
 	}
-	return amazonS3HostPrivateLink.MatchString(endpointURL.Host)
+	return amazonS3HostPrivateLink.MatchString(endpointURL.Hostname())
 }
 
 // IsGoogleEndpoint - Match if it is exactly Google cloud storage endpoint.

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -488,3 +488,48 @@ func TestIsValidBucketNameStrict(t *testing.T) {
 
 	}
 }
+
+func TestIsAmazonPrivateLinkEndpoint(t *testing.T) {
+	testCases := []struct {
+		url string
+		// Expected result.
+		result bool
+	}{
+		{"https://192.168.1.1", false},
+		{"192.168.1.1", false},
+		{"http://storage.googleapis.com", false},
+		{"https://storage.googleapis.com", false},
+		{"storage.googleapis.com", false},
+		{"s3.amazonaws.com", false},
+		{"https://amazons3.amazonaws.com", false},
+		{"-192.168.1.1", false},
+		{"260.192.1.1", false},
+		{"https://s3-.amazonaws.com", false},
+		{"https://s3..amazonaws.com", false},
+		{"https://s3.dualstack.us-west-1.amazonaws.com.cn", false},
+		{"https://s3..us-west-1.amazonaws.com.cn", false},
+		{"https://s3.amazonaws.com", false},
+		{"https://s3-external-1.amazonaws.com", false},
+		{"https://s3.cn-north-1.amazonaws.com.cn", false},
+		{"https://s3-us-west-1.amazonaws.com", false},
+		{"https://s3.us-west-1.amazonaws.com", false},
+		{"https://s3.dualstack.us-west-1.amazonaws.com", false},
+		// valid inputs.
+		{"https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com", true},
+		{"https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com", true},
+		{"https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com:443", true},
+		{"https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com:443", true},
+	}
+
+	for i, testCase := range testCases {
+		u, err := url.Parse(testCase.url)
+		if err != nil {
+			t.Errorf("Test %d: Expected to pass, but failed with: <ERROR> %s", i+1, err)
+		}
+		result := IsAmazonPrivateLinkEndpoint(*u)
+		if testCase.result != result {
+			t.Errorf("Test %d: Expected IsAmazonPrivateLinkEndpoint to be '%v' for input \"%s\", but found it to be '%v' instead", i+1, testCase.result, testCase.url, result)
+		}
+	}
+
+}


### PR DESCRIPTION
Creating a new client for an endpoint url in the form `hostname:port` makes `IsAmazonPrivateLinkEndpoint` return `false`  since the regex used to verify if that url is a valid aws private link does not match when it contains a port.

I propose to perform the validation on `Hostname()` instead of `Host` to always validate agains the actual `hostname`.

I've added some tests to prove that it works