### PR TITLE
Add anonymous chunked encoding with trailing headers

### DIFF
--- a/api.go
+++ b/api.go
@@ -909,6 +909,11 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 
 	// For anonymous requests just return.
 	if signerType.IsAnonymous() {
+		if len(metadata.trailer) > 0 {
+			req.Header.Set("X-Amz-Content-Sha256", unsignedPayloadTrailer)
+			return signer.UnsignedTrailer(*req, metadata.trailer), nil
+		}
+
 		return req, nil
 	}
 

--- a/pkg/signer/request-signature-v4.go
+++ b/pkg/signer/request-signature-v4.go
@@ -358,7 +358,7 @@ func UnsignedTrailer(req http.Request, trailer http.Header) *http.Request {
 
 	// Use custom chunked encoding.
 	req.Trailer = trailer
-	return StreamingUnsignedV4(&req, "", req.ContentLength, time.Now().UTC())
+	return StreamingUnsignedV4(&req, "", req.ContentLength, t)
 }
 
 // SignV4 sign the request before Do(), in accordance with

--- a/pkg/signer/request-signature-v4.go
+++ b/pkg/signer/request-signature-v4.go
@@ -338,6 +338,29 @@ func signV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, locati
 	return &req
 }
 
+// UnsignedTrailer will do chunked encoding with a custom trailer.
+func UnsignedTrailer(req http.Request, trailer http.Header) *http.Request {
+	if len(trailer) == 0 {
+		return &req
+	}
+	// Initial time.
+	t := time.Now().UTC()
+
+	// Set x-amz-date.
+	req.Header.Set("X-Amz-Date", t.Format(iso8601DateFormat))
+
+	for k := range trailer {
+		req.Header.Add("X-Amz-Trailer", strings.ToLower(k))
+	}
+
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("x-amz-decoded-content-length", strconv.FormatInt(req.ContentLength, 10))
+
+	// Use custom chunked encoding.
+	req.Trailer = trailer
+	return StreamingUnsignedV4(&req, "", req.ContentLength, time.Now().UTC())
+}
+
 // SignV4 sign the request before Do(), in accordance with
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
 func SignV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, location string) *http.Request {


### PR DESCRIPTION
Trailing headers would be ignored on anonymous uploads.

Send these as unsigned aws chunked uploads.

Requires https://github.com/minio/minio/pull/21095