### PR TITLE
Rety iterators

### DIFF
--- a/api-bucket-notification.go
+++ b/api-bucket-notification.go
@@ -157,13 +157,6 @@ func (c *Client) ListenBucketNotification(ctx context.Context, bucketName, prefi
 			return
 		}
 
-		// Continuously run and listen on bucket notification.
-		// Create a done channel to control 'ListObjects' go routine.
-		retryDoneCh := make(chan struct{}, 1)
-
-		// Indicate to our routine to exit cleanly upon return.
-		defer close(retryDoneCh)
-
 		// Prepare urlValues to pass into the request on every loop
 		urlValues := make(url.Values)
 		urlValues.Set("ping", "10")
@@ -172,7 +165,7 @@ func (c *Client) ListenBucketNotification(ctx context.Context, bucketName, prefi
 		urlValues["events"] = events
 
 		// Wait on the jitter retry loop.
-		for range c.newRetryTimerContinous(time.Second, time.Second*30, MaxJitter, retryDoneCh) {
+		for range c.newRetryTimerContinous(time.Second, time.Second*30, MaxJitter) {
 			// Execute GET on bucket to list objects.
 			resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{
 				bucketName:       bucketName,

--- a/api.go
+++ b/api.go
@@ -660,13 +660,7 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 		metadata.trailer.Set(metadata.addCrc.Key(), base64.StdEncoding.EncodeToString(crc.Sum(nil)))
 	}
 
-	// Create cancel context to control 'newRetryTimer' go routine.
-	retryCtx, cancel := context.WithCancel(ctx)
-
-	// Indicate to our routine to exit cleanly upon return.
-	defer cancel()
-
-	for range c.newRetryTimer(retryCtx, reqRetry, DefaultRetryUnit, DefaultRetryCap, MaxJitter) {
+	for range c.newRetryTimer(ctx, reqRetry, DefaultRetryUnit, DefaultRetryCap, MaxJitter) {
 		// Retry executes the following function body if request has an
 		// error until maxRetries have been exhausted, retry attempts are
 		// performed after waiting for a given period of time in a
@@ -779,7 +773,7 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 	}
 
 	// Return an error when retry is canceled or deadlined
-	if e := retryCtx.Err(); e != nil {
+	if e := ctx.Err(); e != nil {
 		return nil, e
 	}
 

--- a/retry.go
+++ b/retry.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"iter"
+	"math"
 	"net/http"
 	"net/url"
 	"time"
@@ -45,9 +47,7 @@ var DefaultRetryCap = time.Second
 
 // newRetryTimer creates a timer with exponentially increasing
 // delays until the maximum retry attempts are reached.
-func (c *Client) newRetryTimer(ctx context.Context, maxRetry int, baseSleep, maxSleep time.Duration, jitter float64) <-chan int {
-	attemptCh := make(chan int)
-
+func (c *Client) newRetryTimer(ctx context.Context, maxRetry int, baseSleep, maxSleep time.Duration, jitter float64) iter.Seq[int] {
 	// computes the exponential backoff duration according to
 	// https://www.awsarchitectureblog.com/2015/03/backoff.html
 	exponentialBackoffWait := func(attempt int) time.Duration {
@@ -64,18 +64,22 @@ func (c *Client) newRetryTimer(ctx context.Context, maxRetry int, baseSleep, max
 		if sleep > maxSleep {
 			sleep = maxSleep
 		}
-		if jitter != NoJitter {
+		if math.Abs(jitter-NoJitter) > 1e-9 {
 			sleep -= time.Duration(c.random.Float64() * float64(sleep) * jitter)
 		}
 		return sleep
 	}
 
-	go func() {
-		defer close(attemptCh)
-		for i := 0; i < maxRetry; i++ {
-			select {
-			case attemptCh <- i + 1:
-			case <-ctx.Done():
+	return func(yield func(int) bool) {
+		// if context is already canceled, skip yield
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		for i := range maxRetry {
+			if !yield(i) {
 				return
 			}
 
@@ -85,8 +89,7 @@ func (c *Client) newRetryTimer(ctx context.Context, maxRetry int, baseSleep, max
 				return
 			}
 		}
-	}()
-	return attemptCh
+	}
 }
 
 // List of AWS S3 error codes which are retryable.

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,138 @@
+package minio
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestRetryTimer(t *testing.T) {
+	t.Run("withLimit", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{random: rand.New(rand.NewSource(42))}
+		ctx := context.Background()
+		var count int
+		for range c.newRetryTimer(ctx, 3, time.Millisecond, 10*time.Millisecond, 0.0) {
+			count++
+		}
+		if count != 3 {
+			t.Errorf("expected exactly 3 yields")
+		}
+	})
+
+	t.Run("checkDelay", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{random: rand.New(rand.NewSource(42))}
+		ctx := context.Background()
+		prev := time.Now()
+		baseSleep := time.Millisecond
+		maxSleep := 10 * time.Millisecond
+		for i := range c.newRetryTimer(ctx, 6, baseSleep, maxSleep, 0.0) {
+			if i == 0 {
+				// there is no sleep for the first execution
+				if time.Since(prev) >= time.Millisecond {
+					t.Errorf("expected to not sleep for the first instance of the loop")
+				}
+				prev = time.Now()
+				continue
+			}
+			expect := baseSleep * time.Duration(1<<uint(i-1))
+			expect = min(expect, maxSleep)
+			if d := time.Since(prev); d < expect || d > 2*maxSleep {
+				t.Errorf("expected to sleep for at least %s", expect.String())
+			}
+			prev = time.Now()
+		}
+	})
+
+	t.Run("withBreak", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{random: rand.New(rand.NewSource(42))}
+		ctx := context.Background()
+		var count int
+		for range c.newRetryTimer(ctx, 10, time.Millisecond, 10*time.Millisecond, 0.5) {
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		if count != 3 {
+			t.Errorf("expected exactly 3 yields")
+		}
+	})
+
+	t.Run("withCancelledContext", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{random: rand.New(rand.NewSource(42))}
+		ctx := context.Background()
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+		var count int
+		for range c.newRetryTimer(ctx, 10, time.Millisecond, 10*time.Millisecond, 0.5) {
+			count++
+		}
+		if count != 0 {
+			t.Errorf("expected no yields")
+		}
+	})
+	t.Run("whileCancelledContext", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{random: rand.New(rand.NewSource(42))}
+		ctx := context.Background()
+		ctx, cancel := context.WithCancel(ctx)
+		var count int
+		for range c.newRetryTimer(ctx, 10, time.Millisecond, 10*time.Millisecond, 0.5) {
+			count++
+			cancel()
+		}
+		cancel()
+		if count != 1 {
+			t.Errorf("expected only one yield")
+		}
+	})
+}
+
+func TestRetryContinuous(t *testing.T) {
+	t.Run("checkDelay", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{random: rand.New(rand.NewSource(42))}
+		prev := time.Now()
+		baseSleep := time.Millisecond
+		maxSleep := 10 * time.Millisecond
+		for i := range c.newRetryTimerContinous(time.Millisecond, 10*time.Millisecond, 0.0) {
+			if i == 0 {
+				// there is no sleep for the first execution
+				if time.Since(prev) >= time.Millisecond {
+					t.Errorf("expected to not sleep for the first instance of the loop")
+				}
+				prev = time.Now()
+				continue
+			}
+			expect := baseSleep * time.Duration(1<<uint(i-1))
+			expect = min(expect, maxSleep)
+			if d := time.Since(prev); d < expect || d > 2*maxSleep {
+				t.Errorf("expected to sleep for at least %s", expect.String())
+			}
+			prev = time.Now()
+			if i >= 10 {
+				break
+			}
+		}
+	})
+
+	t.Run("withBreak", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{random: rand.New(rand.NewSource(42))}
+		var count int
+		for range c.newRetryTimerContinous(time.Millisecond, 10*time.Millisecond, 0.5) {
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		if count != 3 {
+			t.Errorf("expected exactly 3 yields")
+		}
+	})
+}


### PR DESCRIPTION
With the transition to go 1.23 the internal retry goroutine+channel can be replaced with an iter.Seq[int]. This reduces the memory allocation of a new goroutine and the extra overhead for waiting on the receipt/done channels. 