### PR TITLE
Add function for getting creds of remote client

### DIFF
--- a/api.go
+++ b/api.go
@@ -1071,9 +1071,5 @@ func (c *Client) GetCreds() (credentials.Value, error) {
 	if c.credsProvider == nil {
 		return credentials.Value{}, errors.New("no credentials provider")
 	}
-	value, err := c.credsProvider.GetWithContext(c.CredContext())
-	if err != nil {
-		return credentials.Value{}, err
-	}
-	return value, nil
+	return c.credsProvider.GetWithContext(c.CredContext())
 }

--- a/api.go
+++ b/api.go
@@ -1066,7 +1066,6 @@ func (c *Client) CredContext() *credentials.CredContext {
 	}
 }
 
-
 // GetCreds returns the access creds for the client
 func (c *Client) GetCreds() (*credentials.Value, error) {
 	if c.credsProvider == nil {
@@ -1078,4 +1077,3 @@ func (c *Client) GetCreds() (*credentials.Value, error) {
 	}
 	return &value, nil
 }
-

--- a/api.go
+++ b/api.go
@@ -1065,3 +1065,17 @@ func (c *Client) CredContext() *credentials.CredContext {
 		Endpoint: c.endpointURL.String(),
 	}
 }
+
+
+// GetCreds returns the access creds for the client
+func (c *Client) GetCreds() (*credentials.Value, error) {
+	if c.credsProvider == nil {
+		return nil, errors.New("no credentials provider")
+	}
+	value, err := c.credsProvider.GetWithContext(c.CredContext())
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+

--- a/api.go
+++ b/api.go
@@ -1067,13 +1067,13 @@ func (c *Client) CredContext() *credentials.CredContext {
 }
 
 // GetCreds returns the access creds for the client
-func (c *Client) GetCreds() (*credentials.Value, error) {
+func (c *Client) GetCreds() (credentials.Value, error) {
 	if c.credsProvider == nil {
-		return nil, errors.New("no credentials provider")
+		return credentials.Value{}, errors.New("no credentials provider")
 	}
 	value, err := c.credsProvider.GetWithContext(c.CredContext())
 	if err != nil {
-		return nil, err
+		return credentials.Value{}, err
 	}
-	return &value, nil
+	return value, nil
 }


### PR DESCRIPTION
This is needed while checking PutObject/DeleteObject permissions on bucket replicated remote targets to create admin client and invoke API.