### PR TITLE
fix: parse the mime metadata when do get/head object

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -30,6 +30,7 @@ import (
 	"hash"
 	"io"
 	"math/rand"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -210,6 +211,7 @@ func extractObjMetadata(header http.Header) http.Header {
 		"X-Amz-Server-Side-Encryption",
 		"X-Amz-Tagging-Count",
 		"X-Amz-Meta-",
+		"X-Minio-Meta-",
 		// Add new headers to be preserved.
 		// if you add new headers here, please extend
 		// PutObjectOptions{} to preserve them
@@ -223,6 +225,16 @@ func extractObjMetadata(header http.Header) http.Header {
 				continue
 			}
 			found = true
+			if len(v) == 1 && (prefix == "X-Amz-Meta-" || prefix == "X-Minio-Meta-") {
+				i := strings.Index(v[0], "=?")
+				if i == -1 {
+					break
+				}
+				decoder := mime.WordDecoder{}
+				if decoded, err := decoder.DecodeHeader(v[0]); err == nil {
+					v = []string{decoded}
+				}
+			}
 			break
 		}
 		if found {

--- a/utils.go
+++ b/utils.go
@@ -225,14 +225,18 @@ func extractObjMetadata(header http.Header) http.Header {
 				continue
 			}
 			found = true
-			if len(v) == 1 && (prefix == "X-Amz-Meta-" || prefix == "X-Minio-Meta-") {
-				i := strings.Index(v[0], "=?")
-				if i == -1 {
-					break
-				}
-				decoder := mime.WordDecoder{}
-				if decoded, err := decoder.DecodeHeader(v[0]); err == nil {
-					v = []string{decoded}
+			if prefix == "X-Amz-Meta-" || prefix == "X-Minio-Meta-" {
+				for index, val := range v {
+					if strings.HasPrefix(val, "=?") {
+						i := strings.Index(val, "=?")
+						if i == -1 {
+							break
+						}
+						decoder := mime.WordDecoder{}
+						if decoded, err := decoder.DecodeHeader(val); err == nil {
+							v[index] = decoded
+						}
+					}
 				}
 			}
 			break

--- a/utils.go
+++ b/utils.go
@@ -227,7 +227,7 @@ func extractObjMetadata(header http.Header) http.Header {
 			found = true
 			if prefix == "X-Amz-Meta-" || prefix == "X-Minio-Meta-" {
 				for index, val := range v {
-					if strings.Contains(val, "=?") {
+					if strings.HasPrefix(val, "=?") {
 						decoder := mime.WordDecoder{}
 						if decoded, err := decoder.DecodeHeader(val); err == nil {
 							v[index] = decoded

--- a/utils.go
+++ b/utils.go
@@ -227,11 +227,7 @@ func extractObjMetadata(header http.Header) http.Header {
 			found = true
 			if prefix == "X-Amz-Meta-" || prefix == "X-Minio-Meta-" {
 				for index, val := range v {
-					if strings.HasPrefix(val, "=?") {
-						i := strings.Index(val, "=?")
-						if i == -1 {
-							break
-						}
+					if strings.Contains(val, "=?") {
 						decoder := mime.WordDecoder{}
 						if decoded, err := decoder.DecodeHeader(val); err == nil {
 							v[index] = decoded

--- a/utils_test.go
+++ b/utils_test.go
@@ -523,6 +523,15 @@ func TestExtractObjMetadata(t *testing.T) {
 				"X-Minio-Meta-Test": []string{strings.Repeat("öha, das", 100)},
 			},
 		},
+		{
+			name: "Test with valid header with multi-BEncoding characters",
+			header: http.Header{
+				"X-Minio-Meta-Test": []string{mime.BEncoding.Encode("UTF-8", strings.Repeat("öha, das", 100)), mime.BEncoding.Encode("UTF-8", strings.Repeat("öha, das123", 100))},
+			},
+			want: http.Header{
+				"X-Minio-Meta-Test": []string{strings.Repeat("öha, das", 100), strings.Repeat("öha, das123", 100)},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fix: parse the mime metadata when do get/head object
will work with https://github.com/minio/minio/pull/21282