### PR TITLE
Add support of error responses in 200 OK body

### DIFF
--- a/200OKwithError_test.go
+++ b/200OKwithError_test.go
@@ -1,0 +1,209 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2017-2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func Test200MultipartUploadWithSpaces(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>`))
+		w.(http.Flusher).Flush()
+		for i := 0; i < 10; i++ {
+			time.Sleep(time.Second)
+			w.Write([]byte(" "))
+			w.(http.Flusher).Flush()
+		}
+
+		w.Write([]byte(`<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>http://random/bucket/object</Location><Bucket>bucket</Bucket><Key>object</Key><ETag>&#34;2b3ffa539769372e2df9553358fe26b2-2&#34;</ETag></CompleteMultipartUploadResult>`))
+	}))
+
+	srv, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Instantiate new minio client object.
+	core, err := NewCore(
+		srv.Host,
+		&Options{
+			Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
+			Secure: srv.Scheme == "https",
+		})
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	parts := []CompletePart{
+		{PartNumber: 1, ETag: "b386a859d8a22ff986c0b1252be34658"},
+		{PartNumber: 2, ETag: "78c577a580bbbba92845789cda1fa932"},
+	}
+
+	foundUploadInfo, err := core.CompleteMultipartUpload(context.Background(),
+		"bucket",
+		"object",
+		"jY1M2U5NWMtZGY2OC00ZjYyLTljZGYtYmZlOWEzODM3MDMwLjlmZWY5OGNlLWQ1Y2EtNDgwMC04N2Y4LWZkNTNkMDM4ZDdiMXgxNzQ4NjA0NzI0NzE4NjU3MTY3",
+		parts,
+		PutObjectOptions{},
+	)
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	expectedUploadInfo := UploadInfo{
+		Bucket:   "bucket",
+		Key:      "object",
+		ETag:     "2b3ffa539769372e2df9553358fe26b2-2",
+		Location: "http://random/bucket/object",
+	}
+
+	if foundUploadInfo != expectedUploadInfo {
+		t.Fatalf("Unexpected upload info, expected: `%v`, found: `%v`", expectedUploadInfo, foundUploadInfo)
+	}
+}
+
+func Test200MultipartUploadWithError(t *testing.T) {
+	const maxRetries = 3
+	var retries = maxRetries
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		retries--
+		w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>`))
+		w.(http.Flusher).Flush()
+		for i := 0; i < 5; i++ {
+			time.Sleep(time.Second)
+			w.Write([]byte(" "))
+			w.(http.Flusher).Flush()
+		}
+
+		w.Write([]byte(`<Error><Code>SlowDownWrite</Code><Message>Resource requested is unwritable, please reduce your request rate</Message><Key>object</Key><BucketName>bucket</BucketName><Resource>/bucket/object</Resource><RequestId>18413E84F6C30613</RequestId><HostId>49371f38c0d7ec74eae2befc695360a3dfece04732914e58a4281759cd2eba4f</HostId></Error>`))
+	}))
+
+	srv, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Instantiate new minio client object.
+	core, err := NewCore(
+		srv.Host,
+		&Options{
+			Creds:      credentials.NewStaticV4("foo", "foo12345", ""),
+			Secure:     srv.Scheme == "https",
+			Region:     "us-east-1",
+			MaxRetries: retries,
+		})
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	parts := []CompletePart{
+		{PartNumber: 1, ETag: "b386a859d8a22ff986c0b1252be34658"},
+		{PartNumber: 2, ETag: "78c577a580bbbba92845789cda1fa932"},
+	}
+
+	_, err = core.CompleteMultipartUpload(context.Background(),
+		"bucket",
+		"object",
+		"jY1M2U5NWMtZGY2OC00ZjYyLTljZGYtYmZlOWEzODM3MDMwLjlmZWY5OGNlLWQ1Y2EtNDgwMC04N2Y4LWZkNTNkMDM4ZDdiMXgxNzQ4NjA0NzI0NzE4NjU3MTY3",
+		parts,
+		PutObjectOptions{},
+	)
+	if err == nil {
+		t.Fatal("CompleteMultipartUpload() returned <nil>, which is unexpected")
+	}
+
+	expectedErrorMsg := "Resource requested is unwritable, please reduce your request rate"
+	if err.Error() != expectedErrorMsg {
+		t.Fatalf("Unexpected returned error, expected: `%v`, found: `%v`", expectedErrorMsg, err.Error())
+	}
+
+	if retries != 0 {
+		t.Fatalf("CompleteMultipart request was not retried enough times, expected: %d, found: %d", maxRetries, retries)
+	}
+}
+
+func Test200DeleteObjectsWithError(t *testing.T) {
+	const maxRetries = 3
+	var retries = maxRetries
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		retries--
+		w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>`))
+		w.(http.Flusher).Flush()
+		for i := 0; i < 5; i++ {
+			time.Sleep(time.Second)
+			w.Write([]byte(" "))
+			w.(http.Flusher).Flush()
+		}
+
+		w.Write([]byte(`<Error><Code>SlowDownWrite</Code><Message>Resource requested is unwritable, please reduce your request rate</Message><Key>object</Key><BucketName>bucket</BucketName><Resource>/bucket/object</Resource><RequestId>18413E84F6C30613</RequestId><HostId>49371f38c0d7ec74eae2befc695360a3dfece04732914e58a4281759cd2eba4f</HostId></Error>`))
+	}))
+
+	srv, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Instantiate new minio client object.
+	core, err := NewCore(
+		srv.Host,
+		&Options{
+			Creds:      credentials.NewStaticV4("foo", "foo12345", ""),
+			Secure:     srv.Scheme == "https",
+			Region:     "us-east-1",
+			MaxRetries: retries,
+		})
+	if err != nil {
+		t.Fatal("Error:", err)
+	}
+
+	core.TraceOn(os.Stderr)
+
+	objs := make(chan ObjectInfo, 1000)
+	for i := range 1000 {
+		objs <- ObjectInfo{Key: fmt.Sprintf("obj-%d", i)}
+	}
+	close(objs)
+
+	delErrCh := core.RemoveObjects(context.Background(), "bucket", objs, RemoveObjectsOptions{})
+	delErr := <-delErrCh
+	err = delErr.Err
+	if err == nil {
+		t.Fatal("RemoveObjects() returned <nil>, which is unexpected")
+	}
+
+	expectedErrorMsg := "Resource requested is unwritable, please reduce your request rate"
+	if err.Error() != expectedErrorMsg {
+		t.Fatalf("Unexpected returned error, expected: `%v`, found: `%v`", expectedErrorMsg, err.Error())
+	}
+
+	if retries != 0 {
+		t.Fatalf("RemoveObjects() request was not retried enough times, expected: %d, found: %d", maxRetries, retries)
+	}
+}

--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -392,13 +392,14 @@ func (c *Client) completeMultipartUpload(ctx context.Context, bucketName, object
 	// Instantiate all the complete multipart buffer.
 	completeMultipartUploadBuffer := bytes.NewReader(completeMultipartUploadBytes)
 	reqMetadata := requestMetadata{
-		bucketName:       bucketName,
-		objectName:       objectName,
-		queryValues:      urlValues,
-		contentBody:      completeMultipartUploadBuffer,
-		contentLength:    int64(len(completeMultipartUploadBytes)),
-		contentSHA256Hex: sum256Hex(completeMultipartUploadBytes),
-		customHeader:     headers,
+		bucketName:           bucketName,
+		objectName:           objectName,
+		queryValues:          urlValues,
+		contentBody:          completeMultipartUploadBuffer,
+		contentLength:        int64(len(completeMultipartUploadBytes)),
+		contentSHA256Hex:     sum256Hex(completeMultipartUploadBytes),
+		customHeader:         headers,
+		expect200OKWithError: true,
 	}
 
 	// Execute POST to complete multipart upload for an objectName.

--- a/api-remove.go
+++ b/api-remove.go
@@ -442,13 +442,14 @@ func (c *Client) removeObjects(ctx context.Context, bucketName string, objectsCh
 		removeBytes := generateRemoveMultiObjectsRequest(batch)
 		// Execute POST on bucket to remove objects.
 		resp, err := c.executeMethod(ctx, http.MethodPost, requestMetadata{
-			bucketName:       bucketName,
-			queryValues:      urlValues,
-			contentBody:      bytes.NewReader(removeBytes),
-			contentLength:    int64(len(removeBytes)),
-			contentMD5Base64: sumMD5Base64(removeBytes),
-			contentSHA256Hex: sum256Hex(removeBytes),
-			customHeader:     headers,
+			bucketName:           bucketName,
+			queryValues:          urlValues,
+			contentBody:          bytes.NewReader(removeBytes),
+			contentLength:        int64(len(removeBytes)),
+			contentMD5Base64:     sumMD5Base64(removeBytes),
+			contentSHA256Hex:     sum256Hex(removeBytes),
+			customHeader:         headers,
+			expect200OKWithError: true,
 		})
 		if resp != nil {
 			if resp.StatusCode != http.StatusOK {

--- a/api.go
+++ b/api.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -45,6 +46,8 @@ import (
 	"github.com/minio/minio-go/v7/pkg/signer"
 	"github.com/minio/minio-go/v7/pkg/singleflight"
 	"golang.org/x/net/publicsuffix"
+
+	internalutils "github.com/minio/minio-go/v7/pkg/utils"
 )
 
 // Client implements Amazon S3 compatible methods.
@@ -512,6 +515,8 @@ type requestMetadata struct {
 	streamSha256     bool
 	addCrc           *ChecksumType
 	trailer          http.Header // (http.Request).Trailer. Requires v4 signature.
+
+	expect200OKWithError bool
 }
 
 // dumpHTTP - dump HTTP request and response.
@@ -615,6 +620,28 @@ func (c *Client) do(req *http.Request) (resp *http.Response, err error) {
 	return resp, nil
 }
 
+// Peek resp.Body looking for S3 XMl error response:
+//   - Return the error XML bytes if an error is found
+//   - Make sure to always restablish the whole http response stream before returning
+func tryParseErrRespFromBody(resp *http.Response) ([]byte, error) {
+	peeker := internalutils.NewPeekReadCloser(resp.Body, 1024*1024)
+	defer func() {
+		peeker.ReplayFromStart()
+		resp.Body = peeker
+	}()
+
+	errResp := ErrorResponse{}
+	errBytes, err := xmlDecodeAndBody(peeker, &errResp)
+	if err != nil {
+		var unmarshalErr xml.UnmarshalError
+		if errors.As(err, &unmarshalErr) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return errBytes, nil
+}
+
 // List of success status.
 var successStatus = []int{
 	http.StatusOK,
@@ -702,16 +729,30 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 			return nil, err
 		}
 
-		// For any known successful http status, return quickly.
+		var success bool
+		var errBodyBytes []byte
+
 		for _, httpStatus := range successStatus {
 			if httpStatus == res.StatusCode {
-				return res, nil
+				success = true
+				break
 			}
 		}
 
-		// Read the body to be saved later.
-		errBodyBytes, err := io.ReadAll(res.Body)
-		// res.Body should be closed
+		if success {
+			if !metadata.expect200OKWithError {
+				return res, nil
+			}
+			errBodyBytes, err = tryParseErrRespFromBody(res)
+			if err == nil && len(errBodyBytes) == 0 {
+				// No S3 XML error is found
+				return res, nil
+			}
+		} else {
+			errBodyBytes, err = io.ReadAll(res.Body)
+		}
+
+		// By now, res.Body should be closed
 		closeResponse(res)
 		if err != nil {
 			return nil, err
@@ -723,6 +764,7 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 
 		// For errors verify if its retryable otherwise fail quickly.
 		errResponse := ToErrorResponse(httpRespToErrorResponse(res, metadata.bucketName, metadata.objectName))
+		err = errResponse
 
 		// Save the body back again.
 		errBodySeeker.Seek(0, 0) // Seek back to starting point.

--- a/api.go
+++ b/api.go
@@ -624,7 +624,7 @@ func (c *Client) do(req *http.Request) (resp *http.Response, err error) {
 //   - Return the error XML bytes if an error is found
 //   - Make sure to always restablish the whole http response stream before returning
 func tryParseErrRespFromBody(resp *http.Response) ([]byte, error) {
-	peeker := internalutils.NewPeekReadCloser(resp.Body, 1024*1024)
+	peeker := internalutils.NewPeekReadCloser(resp.Body, 5*humanize.MiByte)
 	defer func() {
 		peeker.ReplayFromStart()
 		resp.Body = peeker

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -1073,7 +1073,7 @@ func testPutObjectWithVersioning() {
 	var results []minio.ObjectInfo
 	for info := range objectsInfo {
 		if info.Err != nil {
-			logError(testName, function, args, startTime, "", "Unexpected error during listing objects", err)
+			logError(testName, function, args, startTime, "", "Unexpected error during listing objects", info.Err)
 			return
 		}
 		results = append(results, info)

--- a/pkg/utils/peek-reader-closer.go
+++ b/pkg/utils/peek-reader-closer.go
@@ -1,0 +1,73 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2025 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+// PeekReadCloser offers a way to peek a ReadCloser stream and then
+// return the exact stream of the underlying ReadCloser
+type PeekReadCloser struct {
+	io.ReadCloser
+
+	recordMode   bool
+	recordMaxBuf int
+	recordBuf    *bytes.Buffer
+}
+
+// ReplayFromStart ensures next Read() will restart to stream the
+// underlying ReadCloser stream from the beginning
+func (prc *PeekReadCloser) ReplayFromStart() {
+	prc.recordMode = false
+}
+
+func (prc *PeekReadCloser) Read(p []byte) (int, error) {
+	if prc.recordMode {
+		if prc.recordBuf.Len() > prc.recordMaxBuf {
+			return 0, errors.New("maximum peek buffer exceeded")
+		}
+		n, err := prc.ReadCloser.Read(p)
+		prc.recordBuf.Write(p[:n])
+		return n, err
+	}
+	// Replay mode
+	if prc.recordBuf.Len() > 0 {
+		pn, _ := prc.recordBuf.Read(p)
+		return pn, nil
+	}
+	return prc.ReadCloser.Read(p)
+}
+
+// Close releases the record buffer memory and close the underlying ReadCloser
+func (prc *PeekReadCloser) Close() error {
+	prc.recordBuf.Reset()
+	return prc.ReadCloser.Close()
+}
+
+// NewPeekReadCloser returns a new peek reader
+func NewPeekReadCloser(rc io.ReadCloser, maxBufSize int) *PeekReadCloser {
+	return &PeekReadCloser{
+		ReadCloser:   rc,
+		recordMode:   true, // recording mode by default
+		recordBuf:    bytes.NewBuffer(make([]byte, 0, 1024)),
+		recordMaxBuf: maxBufSize,
+	}
+}

--- a/pkg/utils/peek-reader-closer_test.go
+++ b/pkg/utils/peek-reader-closer_test.go
@@ -1,0 +1,64 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2025 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"bytes"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPeekReadCloser(t *testing.T) {
+
+	body := make([]byte, 1024*1024)
+	rand.Read(body)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(body)
+	}))
+	defer ts.Close()
+
+	for _, pLen := range []int{1, 4, 1024, 32 * 1024} {
+		res, err := http.Get(ts.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prc := NewPeekReadCloser(res.Body, 1024)
+
+		p := make([]byte, pLen)
+		n, err := prc.Read(p)
+		if err != nil {
+			t.Fatalf("Read() returned an error while len(p) = %d, error: %v", pLen, err)
+		}
+		if n != pLen {
+			t.Fatalf("unexpected read bytes length, expected: `%d`, found: `%d`", pLen, n)
+		}
+
+		prc.ReplayFromStart()
+		all, err := ioutil.ReadAll(prc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(all, body) {
+			t.Fatal("unexpected content after replay")
+		}
+	}
+}

--- a/retry.go
+++ b/retry.go
@@ -104,6 +104,8 @@ var retryableS3Codes = map[string]struct{}{
 	"ExpiredToken":          {},
 	"ExpiredTokenException": {},
 	"SlowDown":              {},
+	"SlowDownWrite":         {},
+	"SlowDownRead":          {},
 	// Add more AWS S3 codes here.
 }
 


### PR DESCRIPTION
An S3 server can respond with 200 OK with an S3 Error response, for long standing calls, 
such as S3 listing when a prefix contains a lot of entries.

This commit will support this use case. This can only be enabled with specific calls, 
that returns XML as a success response, so this will not be confused with GetObject
returning a valid document that contains an S3 error response.

Supported calls: CompleteMultipartUpload and DeleteMultiObjects.
