### PR TITLE
Add Checksums to versioned list results

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -419,19 +419,25 @@ func (c *Client) listObjectVersions(ctx context.Context, bucketName string, opts
 			}
 			for _, version := range vers {
 				info := ObjectInfo{
-					ETag:           trimEtag(version.ETag),
-					Key:            version.Key,
-					LastModified:   version.LastModified.Truncate(time.Millisecond),
-					Size:           version.Size,
-					Owner:          version.Owner,
-					StorageClass:   version.StorageClass,
-					IsLatest:       version.IsLatest,
-					VersionID:      version.VersionID,
-					IsDeleteMarker: version.isDeleteMarker,
-					UserTags:       version.UserTags,
-					UserMetadata:   version.UserMetadata,
-					Internal:       version.Internal,
-					NumVersions:    numVersions,
+					ETag:              trimEtag(version.ETag),
+					Key:               version.Key,
+					LastModified:      version.LastModified.Truncate(time.Millisecond),
+					Size:              version.Size,
+					Owner:             version.Owner,
+					StorageClass:      version.StorageClass,
+					IsLatest:          version.IsLatest,
+					VersionID:         version.VersionID,
+					IsDeleteMarker:    version.isDeleteMarker,
+					UserTags:          version.UserTags,
+					UserMetadata:      version.UserMetadata,
+					Internal:          version.Internal,
+					NumVersions:       numVersions,
+					ChecksumMode:      version.ChecksumType,
+					ChecksumCRC32:     version.ChecksumCRC32,
+					ChecksumCRC32C:    version.ChecksumCRC32C,
+					ChecksumSHA1:      version.ChecksumSHA1,
+					ChecksumSHA256:    version.ChecksumSHA256,
+					ChecksumCRC64NVME: version.ChecksumCRC64NVME,
 				}
 				if !yield(info) {
 					return false

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -107,6 +107,14 @@ type Version struct {
 		M int // Parity blocks
 	} `xml:"Internal"`
 
+	// Checksum values. Only returned by AiStor servers.
+	ChecksumCRC32     string `xml:",omitempty"`
+	ChecksumCRC32C    string `xml:",omitempty"`
+	ChecksumSHA1      string `xml:",omitempty"`
+	ChecksumSHA256    string `xml:",omitempty"`
+	ChecksumCRC64NVME string `xml:",omitempty"`
+	ChecksumType      string `xml:",omitempty"`
+
 	isDeleteMarker bool
 }
 


### PR DESCRIPTION
With metadata option, allow server to return version checksums as well.

To be used by data integrity checker tool.