### PR TITLE
fix: canceled context should not start list before do listObjects

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -760,6 +760,7 @@ func (c *Client) ListObjects(ctx context.Context, bucketName string, opts ListOb
 	go func() {
 		defer close(objectStatCh)
 		if contextCanceled(ctx) {
+			objectStatCh <- ObjectInfo{Err: ctx.Err()}
 			return
 		}
 

--- a/api-list.go
+++ b/api-list.go
@@ -780,6 +780,7 @@ func (c *Client) ListObjects(ctx context.Context, bucketName string, opts ListOb
 		for obj := range objIter {
 			select {
 			case <-ctx.Done():
+				objectStatCh <- ObjectInfo{Err: ctx.Err()}
 				return
 			case objectStatCh <- obj:
 			}

--- a/api-list.go
+++ b/api-list.go
@@ -759,6 +759,9 @@ func (c *Client) ListObjects(ctx context.Context, bucketName string, opts ListOb
 	objectStatCh := make(chan ObjectInfo, 1)
 	go func() {
 		defer close(objectStatCh)
+		if contextCanceled(ctx) {
+			return
+		}
 		send := func(obj ObjectInfo) bool {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
fix: canceled context should not start list before do listObjects
fix #2121