### PR TITLE
fix: DurationSeconds is a QueryValues not a Form data (#2128)

### DIFF
--- a/pkg/credentials/sts_tls_identity.go
+++ b/pkg/credentials/sts_tls_identity.go
@@ -125,6 +125,7 @@ func (i *STSCertificateIdentity) RetrieveWithCredContext(cc *CredContext) (Value
 	queryValues := url.Values{}
 	queryValues.Set("Action", "AssumeRoleWithCertificate")
 	queryValues.Set("Version", STSVersion)
+	queryValues.Set("DurationSeconds", strconv.FormatUint(uint64(livetime.Seconds()), 10))
 	if i.TokenRevokeType != "" {
 		queryValues.Set("TokenRevokeType", i.TokenRevokeType)
 	}
@@ -134,10 +135,6 @@ func (i *STSCertificateIdentity) RetrieveWithCredContext(cc *CredContext) (Value
 	if err != nil {
 		return Value{}, err
 	}
-	if req.Form == nil {
-		req.Form = url.Values{}
-	}
-	req.Form.Add("DurationSeconds", strconv.FormatUint(uint64(livetime.Seconds()), 10))
 
 	client := i.Client
 	if client == nil {


### PR DESCRIPTION
DurationSeconds need to be set as queryValues, setting it as Form data is ignored by Minio, Fix #2128 

Search for **DurationSeconds** in https://github.com/minio/minio/blob/master/docs/sts/tls.md.