### PR TITLE
fix: explicitly use UTC for expiration field when marshaling PostPolicy

### DIFF
--- a/post-policy.go
+++ b/post-policy.go
@@ -417,7 +417,7 @@ func (p PostPolicy) String() string {
 
 // marshalJSON - Provides Marshaled JSON in bytes.
 func (p PostPolicy) marshalJSON() []byte {
-	expirationStr := `"expiration":"` + p.expiration.Format(expirationDateFormat) + `"`
+	expirationStr := `"expiration":"` + p.expiration.UTC().Format(expirationDateFormat) + `"`
 	var conditionsStr string
 	conditions := []string{}
 	for _, po := range p.conditions {


### PR DESCRIPTION
This resolves issue https://github.com/minio/minio-go/issues/2134, namely that non-UTC values of `PostPolicy.expiration` were being formatted into incorrect timestamps when marshaling to JSON.

No test cases were added for this change as no tests currently exist at all for `PostPolicy.String()` or `PostPolicy.marshalJSON()`. I think if test cases were to be added, however, it might be appropriate to turn the constant `expirationDateFormat` into a function or receiver such as `func formatExpirationDate(time.Time) string` and directly test the result of that, rather than testing `marshalJSON()` as a whole. Let me know if that'd be appreciated.