### PR TITLE
Fix getBucketPolicy to match pattern for prefix used in setBucketPolicy 

### DIFF
--- a/pkg/policy/bucket-policy.go
+++ b/pkg/policy/bucket-policy.go
@@ -523,7 +523,7 @@ func getBucketPolicy(statement Statement, prefix string) (commonFound, readOnly,
 				}
 			} else if stringLikeValue, ok := statement.Conditions["StringLike"]; ok {
 				if s3PrefixValues, ok := stringLikeValue["s3:prefix"]; ok {
-					if s3PrefixValues.Contains(prefix+"*") {
+					if s3PrefixValues.Contains(prefix + "*") {
 						readOnly = true
 					}
 				}

--- a/pkg/policy/bucket-policy.go
+++ b/pkg/policy/bucket-policy.go
@@ -521,6 +521,12 @@ func getBucketPolicy(statement Statement, prefix string) (commonFound, readOnly,
 						readOnly = true
 					}
 				}
+			} else if stringLikeValue, ok := statement.Conditions["StringLike"]; ok {
+				if s3PrefixValues, ok := stringLikeValue["s3:prefix"]; ok {
+					if s3PrefixValues.Contains(prefix+"*") {
+						readOnly = true
+					}
+				}
 			}
 		} else if prefix == "" && statement.Conditions == nil {
 			readOnly = true


### PR DESCRIPTION
setBucketPolicy was changed in https://github.com/minio/minio-go/pull/2124 to use StringLike with a wildcard for prefix. getBucketPolicy now updated to correctly return the name for the readonly bucket anonymous policy created using the new policy format.

fixes https://github.com/miniohq/aistor-console/issues/4789