### PR TITLE
feat: add error reporting fields to InventoryJobStatus

### DIFF
--- a/api-inventory-ext.go
+++ b/api-inventory-ext.go
@@ -239,6 +239,8 @@ type InventoryJobStatus struct {
 	OutputFilesCount  uint64    `json:"outputFilesCount,omitempty"`
 	NodeHostname      string    `json:"nodeHostname,omitempty"`
 	RetryAttempts     uint64    `json:"retryAttempts,omitempty"`
+	LastFailTime      time.Time `json:"lastFailTime,omitempty"`
+	LastFailErrors    []string  `json:"lastFailErrors,omitempty"`
 }
 
 // GetBucketInventoryJobStatus retrieves the status of an inventory job for a


### PR DESCRIPTION
  Added LastFailTime and LastFailErrors fields to InventoryJobStatus struct
  to expose job execution error information through the inventory status API.