### PR TITLE
removed NodeHostname from InventoryJobStatus

### DIFF
--- a/api-inventory-ext.go
+++ b/api-inventory-ext.go
@@ -292,7 +292,6 @@ type InventoryJobStatus struct {
 	NumErrors         uint64    `json:"numErrors,omitempty"`
 	NumLockLosses     uint64    `json:"numLockLosses,omitempty"`
 	ManifestPath      string    `json:"manifestPath,omitempty"`
-	NodeHostname      string    `json:"nodeHostname,omitempty"`
 	RetryAttempts     uint64    `json:"retryAttempts,omitempty"`
 	LastFailTime      time.Time `json:"lastFailTime,omitempty"`
 	LastFailErrors    []string  `json:"lastFailErrors,omitempty"`

--- a/docs/API.md
+++ b/docs/API.md
@@ -3019,7 +3019,6 @@ The `InventoryJobStatus` struct contains comprehensive job information:
 | `NumErrors`          | uint64          | Total errors encountered                                             |
 | `NumLockLosses`      | uint64          | Number of distributed lock losses                                    |
 | `ManifestPath`       | string          | Full path to manifest.json file                                      |
-| `NodeHostname`       | string          | Hostname of node running the job                                     |
 | `RetryAttempts`      | uint64          | Number of retry attempts                                             |
 | `LastFailTime`       | time.Time       | When last failure occurred (only present on errors)                  |
 | `LastFailErrors`     | []string        | Up to 5 most recent error messages (only present on errors)          |


### PR DESCRIPTION
As requested by @donatello,

This PR removes the NodeHostname field from the InventoryJobStatus struct and its associated documentation. The change eliminates the ability to track which node is running an inventory job.

Key changes:

Removed NodeHostname field from InventoryJobStatus struct definition
Removed NodeHostname documentation from API documentation table