### PR TITLE
Feature: enable faster server-server copies by enabling ComposeObject with --part-size and --parallel

### DIFF
--- a/api-compose-object_test.go
+++ b/api-compose-object_test.go
@@ -33,21 +33,25 @@ const (
 
 func TestPartsRequired(t *testing.T) {
 	testCases := []struct {
-		size, ref int64
+		size, customPartSize, ref int64
 	}{
-		{0, 0},
-		{1, 1},
-		{gb5, 10},
-		{gb5p1, 10},
-		{2 * gb5, 20},
-		{gb10p1, 20},
-		{gb10p2, 20},
-		{gb10p1 + gb10p2, 40},
-		{maxMultipartPutObjectSize, 10000},
+		{0, 0, 0},
+		{1, 0, 1},
+		{gb5, 0, 10},
+		{gb5p1, 0, 10},
+		{2 * gb5, 0, 20},
+		{gb10p1, 0, 20},
+		{gb10p2, 0, 20},
+		{gb10p1 + gb10p2, 0, 40},
+		{maxMultipartPutObjectSize, 0, 10000},
+		// Test with custom part size (10 MiB)
+		{100 * 1024 * 1024, 10 * 1024 * 1024, 10},
+		// Test with custom part size (5 MiB)
+		{50 * 1024 * 1024, 5 * 1024 * 1024, 10},
 	}
 
 	for i, testCase := range testCases {
-		res := partsRequired(testCase.size)
+		res := partsRequired(testCase.size, testCase.customPartSize)
 		if res != testCase.ref {
 			t.Errorf("Test %d - output did not match with reference results, Expected %d, got %d", i+1, testCase.ref, res)
 		}
@@ -143,7 +147,7 @@ func TestCalculateEvenSplits(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		resStart, resEnd := calculateEvenSplits(testCase.size, testCase.src)
+		resStart, resEnd := calculateEvenSplits(testCase.size, testCase.src, 0)
 		if !reflect.DeepEqual(testCase.starts, resStart) || !reflect.DeepEqual(testCase.ends, resEnd) {
 			t.Errorf("Test %d - output did not match with reference results, Expected %d/%d, got %d/%d", i+1, testCase.starts, testCase.ends, resStart, resEnd)
 		}

--- a/examples/s3/compose-object-parallel.go
+++ b/examples/s3/compose-object-parallel.go
@@ -1,0 +1,91 @@
+//go:build ignore
+// +build ignore
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2024 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and my-objectname
+	// are dummy values, please replace them with original values.
+
+	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
+	// determined based on the Endpoint value.
+	s3Client, err := minio.New("s3.amazonaws.com", &minio.Options{
+		Creds:  credentials.NewStaticV4("YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", ""),
+		Secure: true,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Prepare source objects to concatenate. We need to specify information
+	// about the source objects being concatenated. Since we are using a
+	// list of copy sources, none of the source objects can be less than
+	// the minimum part size, except the last one.
+	srcOpts1 := minio.CopySrcOptions{
+		Bucket: "my-bucketname",
+		Object: "my-objectname-part-1",
+	}
+	srcOpts2 := minio.CopySrcOptions{
+		Bucket: "my-bucketname",
+		Object: "my-objectname-part-2",
+	}
+	srcOpts3 := minio.CopySrcOptions{
+		Bucket: "my-bucketname",
+		Object: "my-objectname-part-3",
+	}
+
+	// Prepare destination object.
+	dstOpts := minio.CopyDestOptions{
+		Bucket: "my-bucketname",
+		Object: "my-objectname-composite",
+
+		// Configure parallel uploads with 10 concurrent threads
+		NumThreads: 10,
+
+		// Configure custom part size (10 MiB)
+		// This is useful for controlling memory usage and optimizing for
+		// different network conditions. If not specified, uses automatic calculation.
+		PartSize: 10 * 1024 * 1024, // 10 MiB
+	}
+
+	// Perform the compose operation with parallel uploads
+	uploadInfo, err := s3Client.ComposeObject(context.Background(), dstOpts, srcOpts1, srcOpts2, srcOpts3)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Println("Composed object successfully:")
+	log.Printf("Bucket: %s\n", uploadInfo.Bucket)
+	log.Printf("Object: %s\n", uploadInfo.Key)
+	log.Printf("Size: %d bytes\n", uploadInfo.Size)
+	log.Printf("ETag: %s\n", uploadInfo.ETag)
+
+	log.Println("\nParallel compose completed with:")
+	log.Printf("- %d concurrent threads\n", dstOpts.NumThreads)
+	log.Printf("- Part size: %d bytes\n", dstOpts.PartSize)
+}

--- a/examples/s3/go.sum
+++ b/examples/s3/go.sum
@@ -60,6 +60,7 @@ golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
 golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
# Overview

I have a fast k8s on prem cluster and have proposed adding `--part-size` and `--parallel` flags for supporting fast streaming (copy) of large files >= 5TB in [PR 5257 on mc cli repo](https://github.com/minio/mc/pull/5257)

From that PR  I discovered the server-server copy methods don't have configurable `--part-size` or `--parallel`. This means I can configure `mc cp` for very large files but ironically have less control for smaller ones < 5TB.

This PR enables ComposeObject to be configurable by equivalent args `PartSize` and `NumThreads` (--parallel).