### PR TITLE
Wrap brackets only for  IPv6 address

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -142,7 +142,7 @@ func (c *Client) getBucketLocationRequest(ctx context.Context, bucketName string
 	if h, p, err := net.SplitHostPort(targetURL.Host); err == nil {
 		if targetURL.Scheme == "http" && p == "80" || targetURL.Scheme == "https" && p == "443" {
 			targetURL.Host = h
-			if ip := net.ParseIP(h); ip != nil && ip.To16() != nil {
+			if ip := net.ParseIP(h); ip != nil && ip.To4() == nil {
 				targetURL.Host = "[" + h + "]"
 			}
 		}

--- a/create-session.go
+++ b/create-session.go
@@ -114,7 +114,7 @@ func (c *Client) createSessionRequest(ctx context.Context, bucketName string, se
 	if h, p, err := net.SplitHostPort(host); err == nil {
 		if targetURL.Scheme == "http" && p == "80" || targetURL.Scheme == "https" && p == "443" {
 			host = h
-			if ip := net.ParseIP(h); ip != nil && ip.To16() != nil {
+			if ip := net.ParseIP(h); ip != nil && ip.To4() == nil {
 				host = "[" + h + "]"
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/miniohq/aistor-console/issues/5067

When minio runs on port 443, for api calls that uses minio-go in console throws error (api calls that uses madmin-go works fine)

**ip.To16()** always returns non-nil for valid IPs → wraps ALL IPs in brackets 

```
{
    "errorMessage": "parse \"https://[127.0.0.1]/abc/?location=\": invalid IPv6 host",
    "detailedError": "parse \"https://[127.0.0.1]/abc/?location=\": invalid IPv6 host",
    "validations": []
}
```