### PR TITLE
Only marshal lifecycle rule Filter XML when not empty

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -267,6 +267,10 @@ func (f Filter) MarshalJSON() ([]byte, error) {
 // MarshalXML - produces the xml representation of the Filter struct
 // only one of Prefix, And and Tag should be present in the output.
 func (f Filter) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if f.IsNull() {
+		return nil
+	}
+
 	if err := e.EncodeToken(start); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a backport of sorts of https://github.com/minio/minio/pull/10851. Some server implementations (namely, DigitalOcean Spaces) a) do not work with the modern `Rule.Filter.Prefix` structure, and b) actively ignore any `Rule.Prefix` when any `Filter` whatsoever appears in the XML.