### PR TITLE
Replace gopkg.in/yaml.v3 with go.yaml.in/yaml/v3

### DIFF
--- a/api-bucket-qos.go
+++ b/api-bucket-qos.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // QOSConfigVersionCurrent is the current version of the QoS configuration.

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/minio/md5-simd v1.1.2
 	github.com/rs/xid v1.6.0
 	github.com/tinylib/msgp v1.3.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.36.0
 	golang.org/x/net v0.38.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tinylib/msgp v1.3.0 h1:ULuf7GPooDaIlbyvgAxBV/FI7ynli6LZ1/nVUNu+0ww=
 github.com/tinylib/msgp v1.3.0/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=


### PR DESCRIPTION
The [go-yaml/yaml](https://github.com/go-yaml/yaml/) project is unmaintained and the official YAML organization has taken over maintenance and development in the [yaml/go-yaml](https://github.com/yaml/go-yaml) fork.