### PR TITLE
GetObjectAttributes: Add missing checksum & type

### DIFF
--- a/api-get-object-attributes.go
+++ b/api-get-object-attributes.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/encrypt"
@@ -88,10 +89,12 @@ type ObjectAttributesResponse struct {
 	StorageClass string
 	ObjectSize   int
 	Checksum     struct {
-		ChecksumCRC32  string `xml:",omitempty"`
-		ChecksumCRC32C string `xml:",omitempty"`
-		ChecksumSHA1   string `xml:",omitempty"`
-		ChecksumSHA256 string `xml:",omitempty"`
+		ChecksumCRC32     string `xml:",omitempty"`
+		ChecksumCRC32C    string `xml:",omitempty"`
+		ChecksumCRC64NVME string `xml:",omitempty"`
+		ChecksumSHA1      string `xml:",omitempty"`
+		ChecksumSHA256    string `xml:",omitempty"`
+		ChecksumType      string `xml:",omitempty"`
 	}
 	ObjectParts struct {
 		PartsCount           int
@@ -105,12 +108,75 @@ type ObjectAttributesResponse struct {
 
 // ObjectAttributePart is used by ObjectAttributesResponse to describe an object part
 type ObjectAttributePart struct {
-	ChecksumCRC32  string `xml:",omitempty"`
-	ChecksumCRC32C string `xml:",omitempty"`
-	ChecksumSHA1   string `xml:",omitempty"`
-	ChecksumSHA256 string `xml:",omitempty"`
-	PartNumber     int
-	Size           int
+	ChecksumCRC32     string `xml:",omitempty"`
+	ChecksumCRC32C    string `xml:",omitempty"`
+	ChecksumCRC64NVME string `xml:",omitempty"`
+	ChecksumSHA1      string `xml:",omitempty"`
+	ChecksumSHA256    string `xml:",omitempty"`
+	PartNumber        int
+	Size              int
+}
+
+// ChecksumMap returns a map of checksums for the object.
+func (o *ObjectAttributesResponse) ChecksumMap() map[string]string {
+	res := make(map[string]string)
+	setif := func(typ ChecksumType, value string) {
+		if value != "" {
+			res[typ.Key()] = value
+		}
+	}
+	setif(ChecksumCRC32C, o.Checksum.ChecksumCRC32C)
+	setif(ChecksumCRC32, o.Checksum.ChecksumCRC32)
+	setif(ChecksumCRC64NVME, o.Checksum.ChecksumCRC64NVME)
+	setif(ChecksumSHA1, o.Checksum.ChecksumSHA1)
+	setif(ChecksumSHA256, o.Checksum.ChecksumSHA256)
+	return res
+}
+
+// ChecksumMode returns the checksum mode of the object.
+// If unable to determine, returns ChecksumUnknownMode.
+func (o *ObjectAttributesResponse) ChecksumMode() ChecksumMode {
+	t := o.ChecksumType()
+	if !t.IsSet() {
+		return ChecksumUnknownMode
+	}
+	switch o.Checksum.ChecksumType {
+	case amzChecksumModeComposite:
+		return ChecksumCompositeMode
+	case amzChecksumModeFullObject:
+		return ChecksumFullObjectMode
+	case "":
+		// Likely not supported by the server.
+		if o.Checksum.ChecksumCRC64NVME != "" || !strings.ContainsRune(o.ETag, '-') {
+			// Always full object.
+			return ChecksumFullObjectMode
+		}
+		if !t.CanMergeCRC() {
+			// Only composite possible.
+			return ChecksumCompositeMode
+		}
+	}
+	return ChecksumUnknownMode
+}
+
+// ChecksumType returns the checksum type of the object.
+// If none is set, returns ChecksumNone.
+func (o *ObjectAttributesResponse) ChecksumType() ChecksumType {
+	t := ChecksumNone
+	setif := func(typ ChecksumType, value string) {
+		if value != "" {
+			t = typ
+		}
+	}
+	setif(ChecksumCRC32C, o.Checksum.ChecksumCRC32C)
+	setif(ChecksumCRC32, o.Checksum.ChecksumCRC32)
+	setif(ChecksumCRC64NVME, o.Checksum.ChecksumCRC64NVME)
+	setif(ChecksumSHA1, o.Checksum.ChecksumSHA1)
+	setif(ChecksumSHA256, o.Checksum.ChecksumSHA256)
+	if t.IsSet() && o.Checksum.ChecksumType == amzChecksumModeFullObject {
+		t |= ChecksumFullObject
+	}
+	return t
 }
 
 func (o *ObjectAttributes) parseResponse(resp *http.Response) (err error) {

--- a/checksum.go
+++ b/checksum.go
@@ -49,6 +49,9 @@ const (
 
 	// checksumModeMask is a mask for valid checksum mode types.
 	checksumModeMask = checksumLastMode - 1
+
+	// ChecksumUnknownMode indicates no or unknown checksum mode.
+	ChecksumUnknownMode ChecksumMode = 0
 )
 
 // Is returns if c is all of t.
@@ -64,9 +67,9 @@ func (c ChecksumMode) Key() string {
 func (c ChecksumMode) String() string {
 	switch c & checksumModeMask {
 	case ChecksumFullObjectMode:
-		return "FULL_OBJECT"
+		return amzChecksumModeFullObject
 	case ChecksumCompositeMode:
-		return "COMPOSITE"
+		return amzChecksumModeComposite
 	}
 	return ""
 }
@@ -113,6 +116,9 @@ const (
 	amzChecksumSHA256    = "x-amz-checksum-sha256"
 	amzChecksumCRC64NVME = "x-amz-checksum-crc64nvme"
 	amzChecksumMode      = "x-amz-checksum-type"
+
+	amzChecksumModeComposite  = "COMPOSITE"
+	amzChecksumModeFullObject = "FULL_OBJECT"
 )
 
 // Base returns the base type, without modifiers.

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -2418,6 +2418,11 @@ func testPutObjectWithTrailingChecksums() {
 		cmpChecksum(s.Checksum.ChecksumSHA1, meta["x-amz-checksum-sha1"])
 		cmpChecksum(s.Checksum.ChecksumCRC32, meta["x-amz-checksum-crc32"])
 		cmpChecksum(s.Checksum.ChecksumCRC32C, meta["x-amz-checksum-crc32c"])
+		cmpChecksum(s.Checksum.ChecksumCRC64NVME, meta["x-amz-checksum-crc64nvme"])
+		if s.Checksum.ChecksumType != "" && s.Checksum.ChecksumType != minio.ChecksumFullObjectMode.String() {
+			logError(testName, function, args, startTime, "", "ChecksumType mismatch in GetObjectAttributes", fmt.Errorf("want %s, got %s", minio.ChecksumFullObjectMode.String(), s.Checksum.ChecksumType))
+			return
+		}
 
 		delete(args, "range")
 		delete(args, "metadata")
@@ -2644,6 +2649,25 @@ func testPutMultipartObjectWithChecksums() {
 			cmpChecksum(s.Checksum.ChecksumSHA1, wantChksm)
 		case minio.ChecksumSHA256:
 			cmpChecksum(s.Checksum.ChecksumSHA256, wantChksm)
+		case minio.ChecksumCRC64NVME:
+			cmpChecksum(s.Checksum.ChecksumCRC64NVME, wantChksm)
+		}
+
+		if s.Checksum.ChecksumType != "" {
+			var wantType string
+			if test.cs.FullObjectRequested() {
+				wantType = minio.ChecksumFullObjectMode.String()
+			} else {
+				wantType = minio.ChecksumCompositeMode.String()
+			}
+			cmpChecksum(s.Checksum.ChecksumType, wantType)
+		}
+
+		for _, part := range s.ObjectParts.Parts {
+			if test.cs == minio.ChecksumCRC64NVME && part.ChecksumCRC64NVME == "" {
+				logError(testName, function, args, startTime, "", "Part missing CRC64NVME checksum in GetObjectAttributes", fmt.Errorf("part %d", part.PartNumber))
+				return
+			}
 		}
 
 		// Read the data back
@@ -3475,6 +3499,8 @@ func validateObjectAttributeRequest(OA *minio.ObjectAttributes, opts *minio.Obje
 			checksumFound = true
 		} else if v.ChecksumCRC32C != "" {
 			checksumFound = true
+		} else if v.ChecksumCRC64NVME != "" {
+			checksumFound = true
 		}
 		if !checksumFound {
 			partsMissingChecksum = true
@@ -3497,6 +3523,7 @@ func validateObjectAttributeRequest(OA *minio.ObjectAttributes, opts *minio.Obje
 
 	hasFullObjectChecksum := (OA.Checksum.ChecksumCRC32 != "" ||
 		OA.Checksum.ChecksumCRC32C != "" ||
+		OA.Checksum.ChecksumCRC64NVME != "" ||
 		OA.Checksum.ChecksumSHA1 != "" ||
 		OA.Checksum.ChecksumSHA256 != "")
 


### PR DESCRIPTION
Adds `ChecksumCRC64NVME` and `ChecksumType` to GetObjectAttributes.

Adds helpers.

ref: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAttributes.html

AIStor already returns these fields.