### PR TITLE
feat: add ObjectLocking field to BucketVersioningConfiguration

### DIFF
--- a/api-bucket-versioning.go
+++ b/api-bucket-versioning.go
@@ -91,6 +91,9 @@ type BucketVersioningConfiguration struct {
 	ExcludedPrefixes []ExcludedPrefix `xml:",omitempty"`
 	ExcludeFolders   bool             `xml:",omitempty"`
 	PurgeOnDelete    string           `xml:",omitempty"`
+	// MinIO extension - enables object locking on the bucket when set to true.
+	// Requires versioning to be enabled.
+	ObjectLocking bool `xml:",omitempty"`
 }
 
 // Various supported states

--- a/api-bucket-versioning.go
+++ b/api-bucket-versioning.go
@@ -92,13 +92,8 @@ type BucketVersioningConfiguration struct {
 	ExcludeFolders   bool             `xml:",omitempty"`
 	PurgeOnDelete    string           `xml:",omitempty"`
 	// MinIO extension - enables object locking on the bucket.
-	// Pointer so callers and the wire format can distinguish three
-	// states: nil (field absent / server does not support the
-	// extension — fall back to GetBucketObjectLockConfiguration),
-	// &false (server explicitly reports lock disabled), and &true
-	// (lock enabled). omitempty on a pointer omits only when nil, so
-	// explicit false is preserved on the wire.
-	// Requires versioning to be Enabled.
+	// Pointer so explicit false is preserved on the wire, distinct
+	// from unset. Requires versioning to be Enabled.
 	ObjectLocking *bool `xml:",omitempty"`
 }
 

--- a/api-bucket-versioning.go
+++ b/api-bucket-versioning.go
@@ -91,9 +91,15 @@ type BucketVersioningConfiguration struct {
 	ExcludedPrefixes []ExcludedPrefix `xml:",omitempty"`
 	ExcludeFolders   bool             `xml:",omitempty"`
 	PurgeOnDelete    string           `xml:",omitempty"`
-	// MinIO extension - enables object locking on the bucket when set to true.
-	// Requires versioning to be enabled.
-	ObjectLocking bool `xml:",omitempty"`
+	// MinIO extension - enables object locking on the bucket.
+	// Pointer so callers and the wire format can distinguish three
+	// states: nil (field absent / server does not support the
+	// extension — fall back to GetBucketObjectLockConfiguration),
+	// &false (server explicitly reports lock disabled), and &true
+	// (lock enabled). omitempty on a pointer omits only when nil, so
+	// explicit false is preserved on the wire.
+	// Requires versioning to be Enabled.
+	ObjectLocking *bool `xml:",omitempty"`
 }
 
 // Various supported states


### PR DESCRIPTION
## Summary
- Add `ObjectLocking bool` field to `BucketVersioningConfiguration` struct
- Allows clients to enable object locking on an existing bucket via a single `PutBucketVersioning` call
- This is a MinIO extension field (`xml:",omitempty"`) so it does not affect existing S3-compatible behavior

## Test plan
- [ ] Verify existing versioning operations are unaffected
- [ ] Test `mc version enable --with-lock` enables object locking on an existing bucket