### PR TITLE
fix: return io.EOF when seeking to object size

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -572,12 +572,12 @@ func (o *Object) Seek(offset int64, whence int) (n int64, err error) {
 	default:
 		return 0, errInvalidArgument(fmt.Sprintf("Invalid whence %d", whence))
 	case 0:
-		if o.objectInfo.Size > -1 && offset > o.objectInfo.Size {
+		if o.objectInfo.Size > -1 && offset >= o.objectInfo.Size {
 			return 0, io.EOF
 		}
 		newOffset = offset
 	case 1:
-		if o.objectInfo.Size > -1 && o.currOffset+offset > o.objectInfo.Size {
+		if o.objectInfo.Size > -1 && o.currOffset+offset >= o.objectInfo.Size {
 			return 0, io.EOF
 		}
 		newOffset += offset

--- a/api-get-object_test.go
+++ b/api-get-object_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 )
 
@@ -144,5 +145,25 @@ func TestGetObjectReturnErrorIfServerSendsMore(t *testing.T) {
 	// We expect an error when reading back.
 	if _, err = io.ReadAll(obj); err != io.ErrUnexpectedEOF {
 		t.Fatalf("Expected %v, got %v", io.ErrUnexpectedEOF, err)
+	}
+}
+
+func TestObjectSeekAtObjectSizeReturnsEOF(t *testing.T) {
+	o := &Object{
+		mutex:         &sync.Mutex{},
+		objectInfo:    ObjectInfo{Size: 10},
+		objectInfoSet: true,
+		isStarted:     true,
+	}
+
+	_, err := o.Seek(10, io.SeekStart)
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF when seeking to object size, got %v", err)
+	}
+
+	o.currOffset = 9
+	_, err = o.Seek(1, io.SeekCurrent)
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF when seeking past object size, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

When seeking to `offset == object size`, return `io.EOF` instead of issuing a range request that produces `bytes=N--1` and fails with HTTP 416.

## Changes

- Treat `offset >= size` as EOF for `SeekStart` (whence 0)
- Treat `currOffset + offset >= size` as EOF for `SeekCurrent` (whence 1)
- Add unit test `TestObjectSeekAtObjectSizeReturnsEOF`

Fixes #2166