### PR TITLE
Add RDMA / NVIDIA GPU Direct Storage support

### DIFF
--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -1,0 +1,73 @@
+name: Build (RDMA)
+
+on:
+  pull_request:
+    branches:
+    - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build with -tags=rdma against minio-cpp (${{ matrix.config.arch }})
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - { os: ubuntu-latest,    arch: "amd64" }
+        - { os: ubuntu-24.04-arm, arch: "arm64" }
+
+    steps:
+    - name: Checkout minio-go
+      uses: actions/checkout@v4
+      with:
+        path: "minio-go"
+
+    - name: Checkout minio-cpp
+      uses: actions/checkout@v4
+      with:
+        repository: minio/minio-cpp
+        path: "minio-cpp"
+
+    - name: Checkout vcpkg
+      uses: actions/checkout@v4
+      with:
+        repository: microsoft/vcpkg
+        path: "vcpkg"
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get -qy update
+        sudo apt-get -qy install cmake libibverbs-dev librdmacm-dev libnuma-dev
+
+    - name: Build and install libminiocpp.so with RDMA
+      shell: bash
+      run: |
+        ./vcpkg/bootstrap-vcpkg.sh
+        cd minio-cpp
+        ../vcpkg/vcpkg install
+        cmake . -B ./build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_SHARED_LIBS=ON \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
+          -DMINIO_CPP_ENABLE_RDMA:BOOL=ON
+        cmake --build ./build --config Release -j 4
+        sudo cmake --install ./build
+        cuobj_arch=$([ "${{ matrix.config.arch }}" = "amd64" ] && echo x86_64 || echo aarch64)
+        sudo cp -P vendor/cuobj/lib/${cuobj_arch}/* /usr/local/lib/
+        sudo ldconfig
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.25.x"
+
+    - name: Build minio-go with -tags=rdma
+      working-directory: minio-go
+      run: |
+        go build -tags=rdma ./...
+        go build -tags=rdma -o /tmp/rdma-test ./cmd/rdma-test

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -46,6 +46,22 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 		}
 	}
 
+	if opts.RDMABuffer != nil && c.rdmaEnabled {
+		n, err := c.getObjectRDMA(ctx, bucketName, objectName, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &Object{
+			mutex:    &sync.Mutex{},
+			isClosed: true,
+			objectInfo: ObjectInfo{
+				Key:  objectName,
+				Size: n,
+			},
+			objectInfoSet: true,
+		}, nil
+	}
+
 	gctx, cancel := context.WithCancel(ctx)
 
 	// Detect if snowball is server location we are talking to.

--- a/api-get-options.go
+++ b/api-get-options.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+	"unsafe"
 
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 )
@@ -47,6 +48,12 @@ type GetObjectOptions struct {
 	// For multipart objects this is a checksum of part checksums.
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
 	Checksum bool
+
+	// RDMABuffer, when non-nil and Options.EnableRDMA=true, downloads directly
+	// into a contiguous buffer via libminiocpp.so. The returned *Object's
+	// Read() returns EOF immediately; bytes-transferred is in Stat().Size.
+	RDMABuffer     unsafe.Pointer
+	RDMABufferSize int
 
 	// To be not used by external applications
 	Internal AdvancedGetOptions

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
@@ -110,6 +111,12 @@ type PutObjectOptions struct {
 	// This can be used for faster uploads on non-seekable or slow-to-seek input.
 	ConcurrentStreamParts bool
 	Internal              AdvancedPutOptions
+
+	// RDMABuffer, when non-nil and Options.EnableRDMA=true, selects the RDMA
+	// path via libminiocpp.so. Must reference RDMABufferSize contiguous bytes.
+	// When set, the reader / size args to PutObject are ignored.
+	RDMABuffer     unsafe.Pointer
+	RDMABufferSize int
 
 	customHeaders http.Header
 }
@@ -322,6 +329,9 @@ func (a completedParts) Less(i, j int) bool { return a[i].PartNumber < a[j].Part
 func (c *Client) PutObject(ctx context.Context, bucketName, objectName string, reader io.Reader, size int64,
 	opts PutObjectOptions,
 ) (info UploadInfo, err error) {
+	if opts.RDMABuffer != nil && c.rdmaEnabled {
+		return c.putObjectRDMA(ctx, bucketName, objectName, opts)
+	}
 	if size < 0 && opts.DisableMultipart {
 		return UploadInfo{}, errors.New("object size must be provided with disable multipart upload")
 	}

--- a/api.go
+++ b/api.go
@@ -109,6 +109,15 @@ type Client struct {
 
 	trailingHeaderSupport bool
 	maxRetries            int
+
+	// RDMA dispatch state. rdmaEnabled mirrors Options.EnableRDMA;
+	// the rest are only touched by rdma.go (built with -tags=rdma) but
+	// have to live on the struct so the stub and the tagged build share
+	// one shape.
+	rdmaEnabled bool
+	rdmaOnce    sync.Once         //nolint:unused
+	rdmaHandle  *rdmaClientHandle //nolint:unused
+	rdmaInitErr error             //nolint:unused
 }
 
 // Options for New method
@@ -156,6 +165,11 @@ type Options struct {
 	// Number of times a request is retried. Defaults to 10 retries if this option is not configured.
 	// Set to 1 to disable retries.
 	MaxRetries int
+
+	// EnableRDMA causes PutObject / GetObject to dispatch to libminiocpp.so
+	// when the caller supplies PutObjectOptions.RDMABuffer / GetObjectOptions.RDMABuffer.
+	// No-op unless built with -tags=rdma.
+	EnableRDMA bool
 }
 
 // Global constants.
@@ -311,6 +325,7 @@ func privateNew(endpoint string, opts *Options) (*Client, error) {
 	}
 
 	clnt.trailingHeaderSupport = opts.TrailingHeaders && clnt.overrideSignerType.IsV4()
+	clnt.rdmaEnabled = opts.EnableRDMA
 
 	// Sets bucket lookup style, whether server accepts DNS or Path lookup. Default is Auto - determined
 	// by the SDK. When Auto is specified, DNS lookup is used for Amazon/Google cloud endpoints and Path for all other endpoints.

--- a/cmd/rdma-test/main.go
+++ b/cmd/rdma-test/main.go
@@ -1,0 +1,118 @@
+// Copyright 2024-2026 - MinIO, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// rdma-test exercises the unified minio-go RDMA path against a running
+// MinIO server. Requires -tags=rdma at build time and libminiocpp.so on
+// the host's library search path.
+//
+//   go build -tags=rdma -o rdma-test ./cmd/rdma-test
+//   MINIO_ENDPOINT=coe01:9000 MINIO_ACCESS_KEY=... MINIO_SECRET_KEY=... ./rdma-test
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"unsafe"
+
+	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+const (
+	testBucket = "rdma-test"
+	testObject = "test-object-cpu"
+	testSize   = 1 << 20 // 1 MiB
+)
+
+func envOr(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	endpoint := envOr("MINIO_ENDPOINT", "coe01:9000")
+	accessKey := envOr("MINIO_ACCESS_KEY", "minioadmin")
+	secretKey := envOr("MINIO_SECRET_KEY", "minioadmin")
+
+	fmt.Printf("endpoint=%s rdma_available=%v\n", endpoint, minio.IsRDMAAvailable())
+
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:      credentials.NewStaticV4(accessKey, secretKey, ""),
+		Secure:     false,
+		EnableRDMA: true,
+	})
+	if err != nil {
+		return fmt.Errorf("New: %w", err)
+	}
+
+	ctx := context.Background()
+
+	exists, err := client.BucketExists(ctx, testBucket)
+	if err != nil {
+		return fmt.Errorf("BucketExists: %w", err)
+	}
+	if !exists {
+		if err := client.MakeBucket(ctx, testBucket, minio.MakeBucketOptions{}); err != nil {
+			return fmt.Errorf("MakeBucket: %w", err)
+		}
+	}
+
+	src := minio.AlignedBuffer(testSize)
+	if src == nil {
+		return fmt.Errorf("AlignedBuffer(%d) returned nil", testSize)
+	}
+	defer minio.FreeAlignedBuffer(src)
+	srcSlice := unsafe.Slice((*byte)(src), testSize)
+	for i := range srcSlice {
+		srcSlice[i] = byte(i)
+	}
+
+	fmt.Print("PutObject (RDMA)... ")
+	info, err := client.PutObject(ctx, testBucket, testObject, nil, 0, minio.PutObjectOptions{
+		RDMABuffer:     src,
+		RDMABufferSize: testSize,
+	})
+	if err != nil {
+		return fmt.Errorf("PutObject: %w", err)
+	}
+	fmt.Printf("ok etag=%s size=%d checksum=%s\n", info.ETag, info.Size, info.ChecksumCRC64NVME)
+
+	dst := minio.AlignedBuffer(testSize)
+	if dst == nil {
+		return fmt.Errorf("AlignedBuffer(%d) returned nil", testSize)
+	}
+	defer minio.FreeAlignedBuffer(dst)
+	dstSlice := unsafe.Slice((*byte)(dst), testSize)
+
+	fmt.Print("GetObject (RDMA)... ")
+	obj, err := client.GetObject(ctx, testBucket, testObject, minio.GetObjectOptions{
+		RDMABuffer:     dst,
+		RDMABufferSize: testSize,
+	})
+	if err != nil {
+		return fmt.Errorf("GetObject: %w", err)
+	}
+	stat, err := obj.Stat()
+	if err != nil {
+		return fmt.Errorf("Stat: %w", err)
+	}
+	fmt.Printf("ok size=%d\n", stat.Size)
+
+	if !bytes.Equal(srcSlice, dstSlice) {
+		return fmt.Errorf("FAIL: roundtrip data mismatch")
+	}
+	fmt.Println("PASS: roundtrip verified")
+	return nil
+}

--- a/rdma.go
+++ b/rdma.go
@@ -1,0 +1,140 @@
+//go:build rdma
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2024-2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package minio
+
+// #cgo CFLAGS: -DMINIO_CPP_RDMA
+// #cgo CXXFLAGS: --std=c++17 -DMINIO_CPP_RDMA
+// #cgo LDFLAGS: -lminiocpp
+// #include <stdlib.h>
+// #include <miniocpp/c_api.h>
+import "C"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"unsafe"
+)
+
+var ErrRDMANotConnected = errors.New("RDMA infrastructure not connected")
+
+type rdmaClientHandle struct {
+	cptr *C.miniocpp_client
+}
+
+func newRDMAClient(c *Client) (*rdmaClientHandle, error) {
+	creds, err := c.credsProvider.Get()
+	if err != nil {
+		return nil, fmt.Errorf("RDMA: credentials: %w", err)
+	}
+
+	endpoint := C.CString(c.endpointURL.Host)
+	defer C.free(unsafe.Pointer(endpoint))
+	region := C.CString(c.region)
+	defer C.free(unsafe.Pointer(region))
+	accessKey := C.CString(creds.AccessKeyID)
+	defer C.free(unsafe.Pointer(accessKey))
+	secretKey := C.CString(creds.SecretAccessKey)
+	defer C.free(unsafe.Pointer(secretKey))
+	sessionToken := C.CString(creds.SessionToken)
+	defer C.free(unsafe.Pointer(sessionToken))
+
+	var useHTTPS C.int
+	if c.secure {
+		useHTTPS = 1
+	}
+
+	cptr := C.miniocpp_client_new(endpoint, region, accessKey, secretKey,
+		sessionToken, useHTTPS)
+	if cptr == nil {
+		return nil, fmt.Errorf("RDMA: %s", lastRDMAError())
+	}
+	return &rdmaClientHandle{cptr: cptr}, nil
+}
+
+func (c *Client) putObjectRDMA(_ context.Context, bucketName, objectName string,
+	opts PutObjectOptions,
+) (UploadInfo, error) {
+	h, err := c.rdma()
+	if err != nil {
+		return UploadInfo{}, err
+	}
+
+	bucketC := C.CString(bucketName)
+	defer C.free(unsafe.Pointer(bucketC))
+	objectC := C.CString(objectName)
+	defer C.free(unsafe.Pointer(objectC))
+
+	var etagBuf, checksumBuf [64]C.char
+	n := C.miniocpp_put_object(h.cptr, bucketC, objectC,
+		opts.RDMABuffer, C.size_t(opts.RDMABufferSize),
+		nil, nil, &etagBuf[0], &checksumBuf[0])
+	if n < 0 {
+		return UploadInfo{}, fmt.Errorf("RDMA put: %s", lastRDMAError())
+	}
+
+	return UploadInfo{
+		Bucket:            bucketName,
+		Key:               objectName,
+		Size:              int64(n),
+		ETag:              C.GoString(&etagBuf[0]),
+		ChecksumCRC64NVME: C.GoString(&checksumBuf[0]),
+	}, nil
+}
+
+func (c *Client) getObjectRDMA(_ context.Context, bucketName, objectName string,
+	opts GetObjectOptions,
+) (int64, error) {
+	h, err := c.rdma()
+	if err != nil {
+		return 0, err
+	}
+
+	bucketC := C.CString(bucketName)
+	defer C.free(unsafe.Pointer(bucketC))
+	objectC := C.CString(objectName)
+	defer C.free(unsafe.Pointer(objectC))
+
+	n := C.miniocpp_get_object(h.cptr, bucketC, objectC,
+		opts.RDMABuffer, C.size_t(opts.RDMABufferSize), nil, nil)
+	if n < 0 {
+		return 0, fmt.Errorf("RDMA get: %s", lastRDMAError())
+	}
+	return int64(n), nil
+}
+
+func (c *Client) rdma() (*rdmaClientHandle, error) {
+	c.rdmaOnce.Do(func() {
+		c.rdmaHandle, c.rdmaInitErr = newRDMAClient(c)
+	})
+	return c.rdmaHandle, c.rdmaInitErr
+}
+
+func lastRDMAError() string {
+	msg := C.miniocpp_last_error()
+	if msg == nil {
+		return "unknown error"
+	}
+	return C.GoString(msg)
+}
+
+// AlignedBuffer allocates a page-aligned buffer of n bytes for use as
+// PutObjectOptions.RDMABuffer / GetObjectOptions.RDMABuffer. Release with
+// FreeAlignedBuffer. Returns nil on allocation failure.
+func AlignedBuffer(n int) unsafe.Pointer {
+	return C.miniocpp_alloc_aligned(C.size_t(n))
+}
+
+// FreeAlignedBuffer releases a buffer from AlignedBuffer.
+func FreeAlignedBuffer(p unsafe.Pointer) { C.miniocpp_free_aligned(p) }
+
+// IsRDMAAvailable reports whether cuObj is connected to a cuObjServer.
+func IsRDMAAvailable() bool { return C.miniocpp_rdma_available() != 0 }

--- a/rdma_stub.go
+++ b/rdma_stub.go
@@ -1,0 +1,42 @@
+//go:build !rdma
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2024-2026 MinIO, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package minio
+
+import (
+	"context"
+	"errors"
+	"unsafe"
+)
+
+// ErrRDMANotCompiled is returned when RDMA dispatch is requested but the
+// binary was built without -tags=rdma.
+var ErrRDMANotCompiled = errors.New("RDMA support not compiled in (build with -tags=rdma)")
+
+// rdmaClientHandle is the no-tag placeholder type so Client (in api.go)
+// has a stable shape regardless of build tags. The rdma.go variant
+// defines the real struct.
+type rdmaClientHandle struct{} //nolint:unused
+
+func (c *Client) putObjectRDMA(_ context.Context, _, _ string, _ PutObjectOptions) (UploadInfo, error) {
+	return UploadInfo{}, ErrRDMANotCompiled
+}
+
+func (c *Client) getObjectRDMA(_ context.Context, _, _ string, _ GetObjectOptions) (int64, error) {
+	return 0, ErrRDMANotCompiled
+}
+
+// AlignedBuffer is unavailable without -tags=rdma; returns nil.
+func AlignedBuffer(_ int) unsafe.Pointer { return nil }
+
+// FreeAlignedBuffer is a no-op without -tags=rdma.
+func FreeAlignedBuffer(_ unsafe.Pointer) {}
+
+// IsRDMAAvailable always returns false without -tags=rdma.
+func IsRDMAAvailable() bool { return false }


### PR DESCRIPTION
## Summary

- Adds opt-in RDMA dispatch to `*Client.PutObject` and `*Client.GetObject` via [minio-cpp](https://github.com/minio/minio-cpp)'s stable C ABI (`libminiocpp.so`). No new public methods, no separate `Client` class. Strictly opt-in: existing callers see zero behavior change.
- Gated behind the `rdma` Go build tag — default builds carry no cgo dependency and no need for `libminiocpp.so`.
- New CI workflow (`go-rdma.yml`) installs `libminiocpp.so` from minio-cpp `main` on Linux amd64 + arm64, then compiles minio-go and `cmd/rdma-test` with `-tags=rdma`. Validates that the cgo bindings stay in lockstep with minio-cpp's C ABI.

To use:

```go
client, _ := minio.New(endpoint, &minio.Options{
    Creds:      ...,
    EnableRDMA: true,
})

// Buffer-mode PUT — selects RDMA, falls back to HTTP-from-buf on decline.
buf := make([]byte, size)
_, err := client.PutObject(ctx, bucket, object,
    bytes.NewReader(buf), int64(size), minio.PutObjectOptions{RDMABuffer: unsafe.Pointer(&buf[0])})

// Buffer-mode GET — writes directly into the caller's buffer.
n, err := client.GetObject(ctx, bucket, object,
    minio.GetObjectOptions{RDMABuffer: unsafe.Pointer(&buf[0]), RDMABufferLen: size})
```

`libminiocpp.so` must be loadable at runtime (`LD_LIBRARY_PATH` or `MINIOCPP_LIB`). Without it, calling the buffer-mode path returns `ErrRDMANotCompiled` / `ErrRDMANotConnected`. Default `go build` (no `-tags=rdma`) compiles `rdma_stub.go` and has no native dependency.

## Test plan

- [x] Default `go.yml` matrix (Go 1.24, 1.25 × Linux) still passes
- [x] New `go-rdma.yml` matrix (Linux amd64, Linux arm64) builds minio-go and `cmd/rdma-test` against the freshly built `libminiocpp.so`
- [x] `go build ./...` succeeds without `-tags=rdma`