### PR TITLE
fix: caching defer bug

### DIFF
--- a/create-session.go
+++ b/create-session.go
@@ -88,14 +88,15 @@ func (c *Client) CreateSession(ctx context.Context, bucketName string, sessionMo
 		return credentials.Value{}, err
 	}
 
-	defer c.bucketSessionCache.Set(bucketName, cred)
-
-	return credentials.Value{
+	cred = credentials.Value{
 		AccessKeyID:     credSession.Credentials.AccessKey,
 		SecretAccessKey: credSession.Credentials.SecretKey,
 		SessionToken:    credSession.Credentials.SessionToken,
 		Expiration:      credSession.Credentials.Expiration,
-	}, nil
+	}
+
+	c.bucketSessionCache.Set(bucketName, cred)
+	return cred, nil
 }
 
 // createSessionRequest - Wrapper creates a new CreateSession request.


### PR DESCRIPTION
`defer c.bucketSessionCache.Set(bucketName, cred)` captures `cred` as zero-value because Go evaluates deferred arguments immediately. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session credential handling to ensure cache updates only occur after successful credential validation, enhancing reliability and consistency of session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->