### PR TITLE
feat: add object annotation client APIs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,6 @@ jobs:
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
             -e MINIO_CI_CD=true \
-            -e MINIO_SITE_REGION=us-east-1 \
             -e MINIO_KMS_SECRET_KEY="${MINIO_KMS_SECRET_KEY}" \
             -e MINIO_LICENSE="${MINIO_LICENSE}" \
             registry.min.dev/aistor/minio:edge \

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,9 +43,32 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt install devscripts -y
-          wget -O /tmp/minio https://dl.minio.io/server/minio/release/linux-amd64/minio
-          chmod +x /tmp/minio
           mkdir -p /tmp/certs-dir
           cp testcerts/* /tmp/certs-dir
-          /tmp/minio server --quiet -S /tmp/certs-dir /tmp/fs{1...4} &
+          # Test against the AIStor :edge image so the latest AIStor APIs
+          # (object annotations) and checksum algorithms (xxhash3/xxhash128,
+          # sha512, md5) are available to the functional tests.
+          docker pull registry.min.dev/aistor/minio:edge
+          # Free-tier AIStor license so the server allows writes (without a
+          # license the server boots read-only). This is a public FREE-plan
+          # license, not a secret.
+          MINIO_LICENSE="eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhaWQiOjAsImNhcCI6MCwiaWF0IjoxLjc4MDAzMTY0NTUyMzA5ODM1OGU5LCJpc3MiOiJzdWJuZXRAbWluLmlvIiwibGlkIjoiYjNhYTliNGQtOTUxYy00MjIzLTgyMmEtZGY2NjE5MDNjOWFkIiwibm9kZXMiOjEsIm9yZyI6IiIsInBsYW4iOiJGUkVFIiwicHJvZHVjdCI6IkFJU3RvciIsInN1YiI6ImRldkBtaW5pby5pbyIsInRyaWFsIjpmYWxzZX0.Aq0kaFgd5SMHYEK7fIYzPsU4xlS119sj-BSyftCDpmtHIbW6KNFXGA9nbKPc17ZXKgcQgUoaPncsq30EOy7PyH-lp3LPpy3rPoD7ptJHI2v0jqpvlnP0cVGK0Yuw3vib"
+          docker rm -f aistor >/dev/null 2>&1 || true
+          docker run -d --name aistor \
+            -p 9000:9000 \
+            -v /tmp/certs-dir:/certs \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            -e MINIO_CI_CD=true \
+            -e MINIO_SITE_REGION=us-east-1 \
+            -e MINIO_KMS_SECRET_KEY="${MINIO_KMS_SECRET_KEY}" \
+            -e MINIO_LICENSE="${MINIO_LICENSE}" \
+            registry.min.dev/aistor/minio:edge \
+            server --quiet --certs-dir /certs /data/{1...4}
+          for _ in $(seq 1 60); do
+            if curl -sf --cacert /tmp/certs-dir/public.crt https://localhost:9000/minio/health/ready >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
           make

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ The full API Reference is available here.
 -	[`RemoveObjects`](https://min.io/docs/minio/linux/developers/go/API.html#RemoveObjects)
 -	[`RemoveIncompleteUpload`](https://min.io/docs/minio/linux/developers/go/API.html#RemoveIncompleteUpload)
 -	[`SelectObjectContent`](https://min.io/docs/minio/linux/developers/go/API.html#SelectObjectContent)
+-	[`PutObjectAnnotation`](https://min.io/docs/minio/linux/developers/go/API.html#PutObjectAnnotation)
+-	[`GetObjectAnnotation`](https://min.io/docs/minio/linux/developers/go/API.html#GetObjectAnnotation)
+-	[`ListObjectAnnotations`](https://min.io/docs/minio/linux/developers/go/API.html#ListObjectAnnotations)
+-	[`RemoveObjectAnnotation`](https://min.io/docs/minio/linux/developers/go/API.html#RemoveObjectAnnotation)
 
 ### API Reference : Presigned Operations
 
@@ -286,6 +290,10 @@ Full Examples
 -	[removeobject.go](https://github.com/minio/minio-go/blob/master/examples/s3/removeobject.go)
 -	[removeincompleteupload.go](https://github.com/minio/minio-go/blob/master/examples/s3/removeincompleteupload.go)
 -	[removeobjects.go](https://github.com/minio/minio-go/blob/master/examples/s3/removeobjects.go)
+-	[putobjectannotation.go](https://github.com/minio/minio-go/blob/master/examples/s3/putobjectannotation.go)
+-	[getobjectannotation.go](https://github.com/minio/minio-go/blob/master/examples/s3/getobjectannotation.go)
+-	[listobjectannotations.go](https://github.com/minio/minio-go/blob/master/examples/s3/listobjectannotations.go)
+-	[removeobjectannotation.go](https://github.com/minio/minio-go/blob/master/examples/s3/removeobjectannotation.go)
 
 ### Full Examples : Encrypted Object Operations
 

--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -85,7 +85,21 @@ type CopyDestOptions struct {
 	// PartSize specifies the part size for multipart copy operations.
 	// If not specified, defaults to maxPartSize (5 GiB).
 	PartSize uint64
+
+	// AnnotationDirective controls whether the source object's annotations are
+	// copied to the destination. Valid values are CopyAnnotationsDirective
+	// ("COPY", the default when unset) and ExcludeAnnotationsDirective
+	// ("EXCLUDE"). Sent as the x-amz-annotation-directive header.
+	AnnotationDirective string
 }
+
+// Annotation directives for CopyDestOptions.AnnotationDirective.
+const (
+	// CopyAnnotationsDirective copies the source object's annotations to the destination.
+	CopyAnnotationsDirective = "COPY"
+	// ExcludeAnnotationsDirective excludes the source object's annotations from the destination.
+	ExcludeAnnotationsDirective = "EXCLUDE"
+)
 
 // Process custom-metadata to remove a `x-amz-meta-` prefix if
 // present and validate that keys are distinct (after this
@@ -147,6 +161,10 @@ func (opts CopyDestOptions) Marshal(header http.Header) {
 	}
 	if opts.ChecksumType.IsSet() {
 		header.Set(amzChecksumAlgo, opts.ChecksumType.String())
+	}
+
+	if opts.AnnotationDirective != "" {
+		header.Set("x-amz-annotation-directive", opts.AnnotationDirective)
 	}
 
 	if opts.ReplaceMetadata {

--- a/api-object-annotation.go
+++ b/api-object-annotation.go
@@ -1,0 +1,251 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/minio/minio-go/v7/pkg/s3utils"
+)
+
+// Object annotations are named payloads (1 byte to 1 MiB of UTF-8 text)
+// attached to a specific object version, independent of the object's data.
+// Up to 1,000 annotations may be attached per object version.
+
+const (
+	amzObjectIfMatchHeader = "x-amz-object-if-match"
+
+	// maxAnnotationPayloadBytes is the maximum size of a single annotation payload (1 MiB).
+	maxAnnotationPayloadBytes = 1 << 20
+)
+
+// PutObjectAnnotationOptions configures a PutObjectAnnotation request.
+type PutObjectAnnotationOptions struct {
+	// VersionID targets a specific object version (versioned buckets).
+	VersionID string
+	// IfMatch, when set, only applies the annotation if the parent object's
+	// ETag matches this value (sent as x-amz-object-if-match).
+	IfMatch string
+}
+
+// GetObjectAnnotationOptions configures a GetObjectAnnotation request.
+type GetObjectAnnotationOptions struct {
+	VersionID string
+}
+
+// ListObjectAnnotationsOptions configures a ListObjectAnnotations request.
+type ListObjectAnnotationsOptions struct {
+	VersionID string
+}
+
+// RemoveObjectAnnotationOptions configures a DeleteObjectAnnotation request.
+type RemoveObjectAnnotationOptions struct {
+	VersionID string
+	IfMatch   string
+}
+
+// ObjectAnnotation describes a single annotation as returned by ListObjectAnnotations.
+type ObjectAnnotation struct {
+	Name         string
+	Size         int64
+	ETag         string
+	LastModified time.Time
+}
+
+// putObjectAnnotationOutput maps the PutObjectAnnotation XML response.
+type putObjectAnnotationOutput struct {
+	XMLName        xml.Name `xml:"PutObjectAnnotationOutput"`
+	Key            string   `xml:"Key"`
+	AnnotationName string   `xml:"AnnotationName"`
+}
+
+// listObjectAnnotationsOutput maps the ListObjectAnnotations XML response.
+type listObjectAnnotationsOutput struct {
+	XMLName     xml.Name `xml:"ListObjectAnnotationsOutput"`
+	Annotations []struct {
+		AnnotationName string `xml:"AnnotationName"`
+		Size           int64  `xml:"Size"`
+		ETag           string `xml:"ETag"`
+		LastModified   string `xml:"LastModified"`
+	} `xml:"Annotation"`
+}
+
+func annotationQueryValues(name, versionID string) url.Values {
+	urlValues := make(url.Values)
+	urlValues.Set("annotation", "")
+	if name != "" {
+		urlValues.Set("annotationName", name)
+	}
+	if versionID != "" {
+		urlValues.Set("versionId", versionID)
+	}
+	return urlValues
+}
+
+// PutObjectAnnotation creates or overwrites a named annotation on an object
+// version. The payload is read from the supplied reader and must be 1 byte to
+// 1 MiB of valid UTF-8 (mirrors the AWS AnnotationPayload streaming body). It
+// returns the annotation's ETag. The parent object's ETag is never modified.
+func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, payload io.Reader, opts PutObjectAnnotationOptions) (string, error) {
+	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
+		return "", err
+	}
+	if err := s3utils.CheckValidObjectName(objectName); err != nil {
+		return "", err
+	}
+
+	// The payload is capped at 1 MiB; materialize it so the request is
+	// signable and a precise Content-Length/Content-MD5 can be sent.
+	data, err := io.ReadAll(io.LimitReader(payload, maxAnnotationPayloadBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(data) == 0 {
+		return "", errInvalidArgument("annotation payload must be at least 1 byte")
+	}
+	if len(data) > maxAnnotationPayloadBytes {
+		return "", errInvalidArgument("annotation payload exceeds the 1 MiB maximum")
+	}
+
+	headers := make(http.Header)
+	if opts.IfMatch != "" {
+		headers.Set(amzObjectIfMatchHeader, opts.IfMatch)
+	}
+
+	resp, err := c.executeMethod(ctx, http.MethodPut, requestMetadata{
+		bucketName:       bucketName,
+		objectName:       objectName,
+		queryValues:      annotationQueryValues(annotationName, opts.VersionID),
+		contentBody:      bytes.NewReader(data),
+		contentLength:    int64(len(data)),
+		contentMD5Base64: sumMD5Base64(data),
+		customHeader:     headers,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return "", err
+	}
+	if resp != nil && resp.StatusCode != http.StatusOK {
+		return "", httpRespToErrorResponse(resp, bucketName, objectName)
+	}
+	return trimEtag(resp.Header.Get("ETag")), nil
+}
+
+// GetObjectAnnotation returns the payload of a single named annotation.
+func (c *Client) GetObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts GetObjectAnnotationOptions) ([]byte, error) {
+	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
+		return nil, err
+	}
+	if err := s3utils.CheckValidObjectName(objectName); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{
+		bucketName:  bucketName,
+		objectName:  objectName,
+		queryValues: annotationQueryValues(annotationName, opts.VersionID),
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp != nil && resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp, bucketName, objectName)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// ListObjectAnnotations returns all annotations attached to an object version.
+func (c *Client) ListObjectAnnotations(ctx context.Context, bucketName, objectName string, opts ListObjectAnnotationsOptions) ([]ObjectAnnotation, error) {
+	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
+		return nil, err
+	}
+	if err := s3utils.CheckValidObjectName(objectName); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{
+		bucketName:  bucketName,
+		objectName:  objectName,
+		queryValues: annotationQueryValues("", opts.VersionID),
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp != nil && resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp, bucketName, objectName)
+	}
+
+	var out listObjectAnnotationsOutput
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	annotations := make([]ObjectAnnotation, 0, len(out.Annotations))
+	for _, a := range out.Annotations {
+		var lastModified time.Time
+		if a.LastModified != "" {
+			lastModified, _ = time.Parse(time.RFC3339, a.LastModified)
+		}
+		annotations = append(annotations, ObjectAnnotation{
+			Name:         a.AnnotationName,
+			Size:         a.Size,
+			ETag:         trimEtag(a.ETag),
+			LastModified: lastModified,
+		})
+	}
+	return annotations, nil
+}
+
+// RemoveObjectAnnotation permanently deletes a single named annotation. Deletion
+// is irreversible: annotations have no version history.
+func (c *Client) RemoveObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts RemoveObjectAnnotationOptions) error {
+	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
+		return err
+	}
+	if err := s3utils.CheckValidObjectName(objectName); err != nil {
+		return err
+	}
+
+	headers := make(http.Header)
+	if opts.IfMatch != "" {
+		headers.Set(amzObjectIfMatchHeader, opts.IfMatch)
+	}
+
+	resp, err := c.executeMethod(ctx, http.MethodDelete, requestMetadata{
+		bucketName:   bucketName,
+		objectName:   objectName,
+		queryValues:  annotationQueryValues(annotationName, opts.VersionID),
+		customHeader: headers,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+	if resp != nil && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp, bucketName, objectName)
+	}
+	return nil
+}

--- a/api-object-annotation.go
+++ b/api-object-annotation.go
@@ -73,13 +73,6 @@ type ObjectAnnotation struct {
 	LastModified time.Time
 }
 
-// putObjectAnnotationOutput maps the PutObjectAnnotation XML response.
-type putObjectAnnotationOutput struct {
-	XMLName        xml.Name `xml:"PutObjectAnnotationOutput"`
-	Key            string   `xml:"Key"`
-	AnnotationName string   `xml:"AnnotationName"`
-}
-
 // listObjectAnnotationsOutput maps the ListObjectAnnotations XML response.
 type listObjectAnnotationsOutput struct {
 	XMLName     xml.Name `xml:"ListObjectAnnotationsOutput"`

--- a/api-object-annotation.go
+++ b/api-object-annotation.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+	"unicode/utf8"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
@@ -119,6 +120,9 @@ func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName
 	}
 	if len(data) > maxAnnotationPayloadBytes {
 		return "", errInvalidArgument("annotation payload exceeds the 1 MiB maximum")
+	}
+	if !utf8.Valid(data) {
+		return "", errInvalidArgument("annotation payload must be valid UTF-8 text")
 	}
 
 	headers := make(http.Header)

--- a/api-object-annotation.go
+++ b/api-object-annotation.go
@@ -39,7 +39,23 @@ const (
 
 	// maxAnnotationPayloadBytes is the maximum size of a single annotation payload (1 MiB).
 	maxAnnotationPayloadBytes = 1 << 20
+
+	// maxAnnotationNameBytes is the maximum length of an annotation name.
+	maxAnnotationNameBytes = 512
 )
+
+// validateAnnotationName performs a minimal client-side check on the annotation
+// name (non-empty, within the length limit). The server enforces the full
+// naming rules (allowed characters, reserved prefixes).
+func validateAnnotationName(name string) error {
+	if name == "" {
+		return errInvalidArgument("annotation name must not be empty")
+	}
+	if len(name) > maxAnnotationNameBytes {
+		return errInvalidArgument("annotation name exceeds 512 bytes")
+	}
+	return nil
+}
 
 // PutObjectAnnotationOptions configures a PutObjectAnnotation request.
 type PutObjectAnnotationOptions struct {
@@ -108,6 +124,9 @@ func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return "", err
 	}
+	if err := validateAnnotationName(annotationName); err != nil {
+		return "", err
+	}
 
 	// The payload is capped at 1 MiB; materialize it so the request is
 	// signable and a precise Content-Length/Content-MD5 can be sent.
@@ -157,6 +176,9 @@ func (c *Client) GetObjectAnnotation(ctx context.Context, bucketName, objectName
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
 		return nil, err
 	}
+	if err := validateAnnotationName(annotationName); err != nil {
+		return nil, err
+	}
 
 	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{
 		bucketName:  bucketName,
@@ -202,6 +224,9 @@ func (c *Client) ListObjectAnnotations(ctx context.Context, bucketName, objectNa
 
 	annotations := make([]ObjectAnnotation, 0, len(out.Annotations))
 	for _, a := range out.Annotations {
+		// LastModified is an RFC3339 timestamp. A malformed value from the
+		// server leaves LastModified as the zero time rather than failing the
+		// entire listing for one bad entry.
 		var lastModified time.Time
 		if a.LastModified != "" {
 			lastModified, _ = time.Parse(time.RFC3339, a.LastModified)
@@ -223,6 +248,9 @@ func (c *Client) RemoveObjectAnnotation(ctx context.Context, bucketName, objectN
 		return err
 	}
 	if err := s3utils.CheckValidObjectName(objectName); err != nil {
+		return err
+	}
+	if err := validateAnnotationName(annotationName); err != nil {
 		return err
 	}
 

--- a/core_test.go
+++ b/core_test.go
@@ -431,6 +431,11 @@ func TestCoreCopyObject(t *testing.T) {
 		t.Fatalf("Error: number of bytes does not match, want %v, got %v\n", len(buf), st.Size)
 	}
 
+	// When the server auto-encrypts objects (e.g. SSE-KMS), the ETag is not the
+	// content MD5 and a metadata-only copy re-encrypts the object, producing a
+	// new ETag. Only assert ETag equality for unencrypted objects.
+	srcEncrypted := st.Metadata.Get("X-Amz-Server-Side-Encryption") != ""
+
 	destBucketName := bucketName
 	destObjectName := objectName + "-dest"
 
@@ -441,7 +446,7 @@ func TestCoreCopyObject(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err, bucketName, objectName, destBucketName, destObjectName)
 	}
-	if cuploadInfo.ETag != uploadInfo.ETag {
+	if !srcEncrypted && cuploadInfo.ETag != uploadInfo.ETag {
 		t.Fatalf("Error: expected etag to be same as source object %s, but found different etag %s", uploadInfo.ETag, cuploadInfo.ETag)
 	}
 
@@ -465,7 +470,7 @@ func TestCoreCopyObject(t *testing.T) {
 		t.Fatalf("Error: Content types don't match, expected: application/javascript, found: %+v\n", st.ContentType)
 	}
 
-	if st.ETag != uploadInfo.ETag {
+	if !srcEncrypted && st.ETag != uploadInfo.ETag {
 		t.Fatalf("Error: expected etag to be same as source object %s, but found different etag :%s", uploadInfo.ETag, st.ETag)
 	}
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -84,6 +84,10 @@ func main() {
 |                                                               | [`PutObjectTagging`](#PutObjectTagging)             |                                               |                                                               |                                                       |
 |                                                               | [`GetObjectTagging`](#GetObjectTagging)             |                                               |                                                               |                                                       |
 |                                                               | [`RemoveObjectTagging`](#RemoveObjectTagging)       |                                               |                                                               |                                                       |
+|                                                               | [`PutObjectAnnotation`](#PutObjectAnnotation)       |                                               |                                                               |                                                       |
+|                                                               | [`GetObjectAnnotation`](#GetObjectAnnotation)       |                                               |                                                               |                                                       |
+|                                                               | [`ListObjectAnnotations`](#ListObjectAnnotations)   |                                               |                                                               |                                                       |
+|                                                               | [`RemoveObjectAnnotation`](#RemoveObjectAnnotation) |                                               |                                                               |                                                       |
 |                                                               | [`RestoreObject`](#RestoreObject)                   |                                               |                                                               |                                                       |
 |                                                               | [`GetObjectAttributes`](#GetObjectAttributes)       |                                               |                                                               |                                                       |
 |                                                               | [`PromptObject`](#PromptObject)                     |                                               |                                                               |                                                       |
@@ -1331,6 +1335,115 @@ Remove Object Tags from the given object
 
 ```go
 err = minioClient.RemoveObjectTagging(context.Background(), bucketName, objectName)
+if err != nil {
+	fmt.Println(err)
+	return
+}
+```
+
+<a name="PutObjectAnnotation"></a>
+
+### PutObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, payload io.Reader, opts PutObjectAnnotationOptions) (string, error)
+
+Create or overwrite a named annotation on an object version. An annotation is a named payload (1 byte to 1 MiB of UTF-8 text) attached to a specific object version, independent of the object's data. Up to 1,000 annotations may be attached per object version. The parent object's ETag is not modified. Returns the annotation's ETag.
+
+**Parameters**
+
+| Param            | Type                          | Description                                                       |
+|:-----------------|:------------------------------|:------------------------------------------------------------------|
+| `ctx`            | *context.Context*             | Custom context for timeout/cancellation of the call               |
+| `bucketName`     | *string*                      | Name of the bucket                                                |
+| `objectName`     | *string*                      | Name of the object                                                |
+| `annotationName` | *string*                      | Name of the annotation (1-512 bytes)                              |
+| `payload`        | *io.Reader*                   | Annotation payload (1 byte to 1 MiB of valid UTF-8)               |
+| `opts`           | *PutObjectAnnotationOptions*  | Options: `VersionID`, `IfMatch` (x-amz-object-if-match precondition) |
+
+**Example**
+
+```go
+payload := strings.NewReader(`{"label":"cat","confidence":0.98}`)
+etag, err := minioClient.PutObjectAnnotation(context.Background(), bucketName, objectName, "model.labels.json", payload, minio.PutObjectAnnotationOptions{})
+if err != nil {
+	fmt.Println(err)
+	return
+}
+```
+
+<a name="GetObjectAnnotation"></a>
+
+### GetObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts GetObjectAnnotationOptions) ([]byte, error)
+
+Return the payload of a single named annotation.
+
+**Parameters**
+
+| Param            | Type                          | Description                                         |
+|:-----------------|:------------------------------|:----------------------------------------------------|
+| `ctx`            | *context.Context*             | Custom context for timeout/cancellation of the call |
+| `bucketName`     | *string*                      | Name of the bucket                                  |
+| `objectName`     | *string*                      | Name of the object                                  |
+| `annotationName` | *string*                      | Name of the annotation                              |
+| `opts`           | *GetObjectAnnotationOptions*  | Options: `VersionID`                                |
+
+**Example**
+
+```go
+payload, err := minioClient.GetObjectAnnotation(context.Background(), bucketName, objectName, "model.labels.json", minio.GetObjectAnnotationOptions{})
+if err != nil {
+	fmt.Println(err)
+	return
+}
+fmt.Println(string(payload))
+```
+
+<a name="ListObjectAnnotations"></a>
+
+### ListObjectAnnotations(ctx context.Context, bucketName, objectName string, opts ListObjectAnnotationsOptions) ([]ObjectAnnotation, error)
+
+Return all annotations attached to an object version. Each `ObjectAnnotation` has `Name`, `Size`, `ETag` and `LastModified`.
+
+**Parameters**
+
+| Param        | Type                            | Description                                         |
+|:-------------|:--------------------------------|:----------------------------------------------------|
+| `ctx`        | *context.Context*               | Custom context for timeout/cancellation of the call |
+| `bucketName` | *string*                        | Name of the bucket                                  |
+| `objectName` | *string*                        | Name of the object                                  |
+| `opts`       | *ListObjectAnnotationsOptions*  | Options: `VersionID`                                |
+
+**Example**
+
+```go
+annotations, err := minioClient.ListObjectAnnotations(context.Background(), bucketName, objectName, minio.ListObjectAnnotationsOptions{})
+if err != nil {
+	fmt.Println(err)
+	return
+}
+for _, a := range annotations {
+	fmt.Printf("%s (%d bytes)\n", a.Name, a.Size)
+}
+```
+
+<a name="RemoveObjectAnnotation"></a>
+
+### RemoveObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts RemoveObjectAnnotationOptions) error
+
+Permanently delete a single named annotation. Deletion is irreversible: annotations have no version history.
+
+**Parameters**
+
+| Param            | Type                            | Description                                         |
+|:-----------------|:--------------------------------|:----------------------------------------------------|
+| `ctx`            | *context.Context*               | Custom context for timeout/cancellation of the call |
+| `bucketName`     | *string*                        | Name of the bucket                                  |
+| `objectName`     | *string*                        | Name of the object                                  |
+| `annotationName` | *string*                        | Name of the annotation                              |
+| `opts`           | *RemoveObjectAnnotationOptions* | Options: `VersionID`, `IfMatch`                     |
+
+**Example**
+
+```go
+err = minioClient.RemoveObjectAnnotation(context.Background(), bucketName, objectName, "model.labels.json", minio.RemoveObjectAnnotationOptions{})
 if err != nil {
 	fmt.Println(err)
 	return

--- a/examples/s3/getobjectannotation.go
+++ b/examples/s3/getobjectannotation.go
@@ -1,0 +1,49 @@
+//go:build example
+// +build example
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func main() {
+	// Note: my-bucketname, my-objectname and my-annotationname are dummy
+	// values, please replace them with original values.
+
+	s3Client, err := minio.New("play.min.io", &minio.Options{
+		Creds:  credentials.NewStaticV4("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG", ""),
+		Secure: true,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	payload, err := s3Client.GetObjectAnnotation(context.Background(), "my-bucketname", "my-objectname", "model.labels.json", minio.GetObjectAnnotationOptions{})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Printf("annotation payload: %s\n", payload)
+}

--- a/examples/s3/listobjectannotations.go
+++ b/examples/s3/listobjectannotations.go
@@ -1,0 +1,51 @@
+//go:build example
+// +build example
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func main() {
+	// Note: my-bucketname and my-objectname are dummy values, please replace
+	// them with original values.
+
+	s3Client, err := minio.New("play.min.io", &minio.Options{
+		Creds:  credentials.NewStaticV4("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG", ""),
+		Secure: true,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	annotations, err := s3Client.ListObjectAnnotations(context.Background(), "my-bucketname", "my-objectname", minio.ListObjectAnnotationsOptions{})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	for _, a := range annotations {
+		log.Printf("name=%s size=%d etag=%s lastModified=%s\n", a.Name, a.Size, a.ETag, a.LastModified)
+	}
+}

--- a/examples/s3/putobjectannotation.go
+++ b/examples/s3/putobjectannotation.go
@@ -1,0 +1,56 @@
+//go:build example
+// +build example
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func main() {
+	// Note: my-bucketname, my-objectname and my-annotationname are dummy
+	// values, please replace them with original values.
+
+	s3Client, err := minio.New("play.min.io", &minio.Options{
+		Creds:  credentials.NewStaticV4("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG", ""),
+		Secure: true,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// The annotation payload is any UTF-8 text (JSON/XML/YAML/plain), 1 byte to 1 MiB.
+	payload := strings.NewReader(`{"label":"cat","confidence":0.98}`)
+
+	etag, err := s3Client.PutObjectAnnotation(context.Background(), "my-bucketname", "my-objectname", "model.labels.json", payload, minio.PutObjectAnnotationOptions{
+		// VersionID: "target a specific object version",
+		// IfMatch:   "only write if the object's ETag matches",
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Printf("annotation written, etag: %s\n", etag)
+}

--- a/examples/s3/removeobjectannotation.go
+++ b/examples/s3/removeobjectannotation.go
@@ -1,0 +1,50 @@
+//go:build example
+// +build example
+
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func main() {
+	// Note: my-bucketname, my-objectname and my-annotationname are dummy
+	// values, please replace them with original values.
+
+	s3Client, err := minio.New("play.min.io", &minio.Options{
+		Creds:  credentials.NewStaticV4("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG", ""),
+		Secure: true,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Annotation deletion is permanent and irreversible.
+	err = s3Client.RemoveObjectAnnotation(context.Background(), "my-bucketname", "my-objectname", "model.labels.json", minio.RemoveObjectAnnotationOptions{})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Println("annotation removed")
+}

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -1838,6 +1838,104 @@ func testRemoveObjectsWithVersioning() {
 	logSuccess(testName, function, args, startTime)
 }
 
+// Tests {Put,Get,List,Remove}ObjectAnnotation APIs end to end. Servers that do
+// not implement annotations are detected and skipped (logIgnored) rather than
+// failed: a non-implementing server silently treats the ?annotation request as
+// a plain object write, which is caught here via the parent ETag invariant.
+func testObjectAnnotations() {
+	startTime := time.Now()
+	testName := getFuncName()
+	function := "{Put,Get,List,Remove}ObjectAnnotation()"
+	args := map[string]interface{}{}
+
+	c, err := NewClient(ClientConfig{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "MinIO client object creation failed", err)
+		return
+	}
+
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()), "minio-go-test-")
+	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
+	args["bucketName"] = bucketName
+	args["objectName"] = objectName
+
+	if err = c.MakeBucket(context.Background(), bucketName, minio.MakeBucketOptions{Region: "us-east-1"}); err != nil {
+		logError(testName, function, args, startTime, "", "MakeBucket failed", err)
+		return
+	}
+	defer cleanupBucket(bucketName, c)
+
+	const parentContent = "annotation-parent-content"
+	ui, err := c.PutObject(context.Background(), bucketName, objectName, strings.NewReader(parentContent), int64(len(parentContent)), minio.PutObjectOptions{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "PutObject (parent) failed", err)
+		return
+	}
+
+	annName := "model.labels.json"
+	annPayload := []byte(`{"label":"cat","score":0.98}`)
+	args["annotationName"] = annName
+
+	_, err = c.PutObjectAnnotation(context.Background(), bucketName, objectName, annName, bytes.NewReader(annPayload), minio.PutObjectAnnotationOptions{})
+	if err != nil {
+		if isErrNotImplemented(err) {
+			logIgnored(testName, function, args, startTime, "PutObjectAnnotation")
+			return
+		}
+		logError(testName, function, args, startTime, "", "PutObjectAnnotation failed", err)
+		return
+	}
+
+	// On a server without annotation support the request falls through to a
+	// regular PutObject, changing the parent ETag. Treat that as unsupported.
+	st, err := c.StatObject(context.Background(), bucketName, objectName, minio.StatObjectOptions{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "StatObject failed", err)
+		return
+	}
+	if st.ETag != ui.ETag {
+		logIgnored(testName, function, args, startTime, "PutObjectAnnotation")
+		return
+	}
+
+	got, err := c.GetObjectAnnotation(context.Background(), bucketName, objectName, annName, minio.GetObjectAnnotationOptions{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "GetObjectAnnotation failed", err)
+		return
+	}
+	if !bytes.Equal(got, annPayload) {
+		logError(testName, function, args, startTime, "", "GetObjectAnnotation payload mismatch", fmt.Errorf("got %q want %q", got, annPayload))
+		return
+	}
+
+	anns, err := c.ListObjectAnnotations(context.Background(), bucketName, objectName, minio.ListObjectAnnotationsOptions{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "ListObjectAnnotations failed", err)
+		return
+	}
+	if len(anns) != 1 || anns[0].Name != annName {
+		logError(testName, function, args, startTime, "", "ListObjectAnnotations unexpected result", fmt.Errorf("got %+v", anns))
+		return
+	}
+
+	if err = c.RemoveObjectAnnotation(context.Background(), bucketName, objectName, annName, minio.RemoveObjectAnnotationOptions{}); err != nil {
+		logError(testName, function, args, startTime, "", "RemoveObjectAnnotation failed", err)
+		return
+	}
+
+	anns, err = c.ListObjectAnnotations(context.Background(), bucketName, objectName, minio.ListObjectAnnotationsOptions{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "ListObjectAnnotations (after remove) failed", err)
+		return
+	}
+	if len(anns) != 0 {
+		logError(testName, function, args, startTime, "", "annotation not removed", fmt.Errorf("remaining %d", len(anns)))
+		return
+	}
+
+	logSuccess(testName, function, args, startTime)
+}
+
 func testObjectTaggingWithVersioning() {
 	// initialize logging params
 	startTime := time.Now()
@@ -15026,6 +15124,7 @@ func main() {
 		testRemoveObjectWithVersioning()
 		testRemoveObjectsWithVersioning()
 		testObjectTaggingWithVersioning()
+		testObjectAnnotations()
 		testTrailingChecksums()
 		testPutObjectWithAutomaticChecksums()
 		testGetBucketTagging()

--- a/utils.go
+++ b/utils.go
@@ -517,6 +517,7 @@ var supportedHeaders = map[string]bool{
 	"x-amz-website-redirect-location":     true,
 	"x-amz-object-lock-mode":              true,
 	"x-amz-metadata-directive":            true,
+	"x-amz-annotation-directive":          true,
 	"x-amz-object-lock-retain-until-date": true,
 	"expires":                             true,
 	"x-amz-replication-status":            true,


### PR DESCRIPTION
Adds client methods for the S3 object annotation APIs:

- `PutObjectAnnotation` (payload as a streaming `io.Reader` body, mirroring AWS `AnnotationPayload`; name/versionId as query params; `IfMatch` -> `x-amz-object-if-match`)
- `GetObjectAnnotation`
- `ListObjectAnnotations` (returns `[]ObjectAnnotation`)
- `RemoveObjectAnnotation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MinIO/S3-compatible **object annotations** for versioned objects, with **put**, **get**, **list**, and **remove** support.
  * Adds client-side validation for bucket/object/annotation names and **payload** checks (non-empty, UTF-8 valid, up to **1 MiB**).
  * Supports optional match conditions for **put** and **remove**.
  * Returns the annotation **ETag** on put, **payload bytes** on get, and **last-modified timestamps** (invalid values → zero) on list.
* **Documentation / Examples**
  * Updated API docs, README, and added new examples for all annotation operations.
* **Tests**
  * Added functional end-to-end coverage for put/get/list/remove.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->