### PR TITLE
feat: stream PutObjectAnnotation payload via io.ReadSeeker

### DIFF
--- a/api-object-annotation.go
+++ b/api-object-annotation.go
@@ -18,14 +18,12 @@
 package minio
 
 import (
-	"bytes"
 	"context"
 	"encoding/xml"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
-	"unicode/utf8"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
@@ -114,10 +112,11 @@ func annotationQueryValues(name, versionID string) url.Values {
 }
 
 // PutObjectAnnotation creates or overwrites a named annotation on an object
-// version. The payload is read from the supplied reader and must be 1 byte to
-// 1 MiB of valid UTF-8 (mirrors the AWS AnnotationPayload streaming body). It
-// returns the annotation's ETag. The parent object's ETag is never modified.
-func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, payload io.Reader, opts PutObjectAnnotationOptions) (string, error) {
+// version. The payload (1 byte to 1 MiB) is streamed directly from the supplied
+// ReadSeeker: its size is taken from a seek to the end, so the body is sent with
+// an exact Content-Length and never buffered in memory. It returns the
+// annotation's ETag. The parent object's ETag is never modified.
+func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, payload io.ReadSeeker, opts PutObjectAnnotationOptions) (string, error) {
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return "", err
 	}
@@ -127,21 +126,25 @@ func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName
 	if err := validateAnnotationName(annotationName); err != nil {
 		return "", err
 	}
+	if payload == nil {
+		return "", errInvalidArgument("annotation payload must not be nil")
+	}
 
-	// The payload is capped at 1 MiB; materialize it so the request is
-	// signable and a precise Content-Length/Content-MD5 can be sent.
-	data, err := io.ReadAll(io.LimitReader(payload, maxAnnotationPayloadBytes+1))
+	// Derive the payload size from the seeker and enforce the limits before
+	// uploading; the server reads the body raw, so it is sent with UNSIGNED-PAYLOAD
+	// (no streaming-chunked signature) and streamed without buffering.
+	size, err := payload.Seek(0, io.SeekEnd)
 	if err != nil {
 		return "", err
 	}
-	if len(data) == 0 {
+	if _, err := payload.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	if size == 0 {
 		return "", errInvalidArgument("annotation payload must be at least 1 byte")
 	}
-	if len(data) > maxAnnotationPayloadBytes {
+	if size > maxAnnotationPayloadBytes {
 		return "", errInvalidArgument("annotation payload exceeds the 1 MiB maximum")
-	}
-	if !utf8.Valid(data) {
-		return "", errInvalidArgument("annotation payload must be valid UTF-8 text")
 	}
 
 	headers := make(http.Header)
@@ -150,13 +153,12 @@ func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName
 	}
 
 	resp, err := c.executeMethod(ctx, http.MethodPut, requestMetadata{
-		bucketName:       bucketName,
-		objectName:       objectName,
-		queryValues:      annotationQueryValues(annotationName, opts.VersionID),
-		contentBody:      bytes.NewReader(data),
-		contentLength:    int64(len(data)),
-		contentMD5Base64: sumMD5Base64(data),
-		customHeader:     headers,
+		bucketName:    bucketName,
+		objectName:    objectName,
+		queryValues:   annotationQueryValues(annotationName, opts.VersionID),
+		contentBody:   payload,
+		contentLength: size,
+		customHeader:  headers,
 	})
 	defer closeResponse(resp)
 	if err != nil {

--- a/examples/s3/putobjectannotation.go
+++ b/examples/s3/putobjectannotation.go
@@ -41,7 +41,8 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// The annotation payload is any UTF-8 text (JSON/XML/YAML/plain), 1 byte to 1 MiB.
+	// The annotation payload is any byte stream (JSON/XML/YAML/plain), 1 byte to
+	// 1 MiB, supplied as an io.ReadSeeker so it can be streamed without buffering.
 	payload := strings.NewReader(`{"label":"cat","confidence":0.98}`)
 
 	etag, err := s3Client.PutObjectAnnotation(context.Background(), "my-bucketname", "my-objectname", "model.labels.json", payload, minio.PutObjectAnnotationOptions{


### PR DESCRIPTION
`PutObjectAnnotation` currently buffers the entire payload with `io.ReadAll(io.LimitReader(...))` to derive a `Content-Length`/`Content-MD5`. Since the annotation API is unreleased, change the parameter from `io.Reader` to `io.ReadSeeker` so the size comes from a seek and the body streams without buffering.

- Size is taken from `Seek(0, io.SeekEnd)`, then rewound; the 1 byte..1 MiB limit is enforced before any upload.
- Body is sent with `UNSIGNED-PAYLOAD` (no `Content-MD5`, no streaming-chunked signature) because the server reads the request body raw. The seekable body stays retryable.
- Drops the in-memory copy and the client-side UTF-8 check (payload is an arbitrary byte stream; the server enforces its own rules).

Existing callers (`strings.NewReader`, `bytes.NewReader`) already satisfy `io.ReadSeeker`, so they compile unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated annotation payload upload to stream data directly, eliminating buffering requirements
  * Annotations now accept any data format, removing prior UTF-8 text limitations
  * Automatic payload validation with size constraints (maximum 1 MiB)

* **Documentation**
  * Updated example documentation to reflect annotation payload streaming capabilities and format flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->