### PR TITLE
feat: stream GetObjectAnnotation payload via io.ReadCloser

### DIFF
--- a/api-object-annotation.go
+++ b/api-object-annotation.go
@@ -170,8 +170,11 @@ func (c *Client) PutObjectAnnotation(ctx context.Context, bucketName, objectName
 	return trimEtag(resp.Header.Get("ETag")), nil
 }
 
-// GetObjectAnnotation returns the payload of a single named annotation.
-func (c *Client) GetObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts GetObjectAnnotationOptions) ([]byte, error) {
+// GetObjectAnnotation returns the payload of a single named annotation as a
+// stream. The returned ReadCloser is the response body; the caller must Close it
+// once the payload has been read so the underlying connection can be reused. The
+// payload is server-capped at 1 MiB.
+func (c *Client) GetObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts GetObjectAnnotationOptions) (io.ReadCloser, error) {
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return nil, err
 	}
@@ -187,14 +190,15 @@ func (c *Client) GetObjectAnnotation(ctx context.Context, bucketName, objectName
 		objectName:  objectName,
 		queryValues: annotationQueryValues(annotationName, opts.VersionID),
 	})
-	defer closeResponse(resp)
 	if err != nil {
+		closeResponse(resp)
 		return nil, err
 	}
 	if resp != nil && resp.StatusCode != http.StatusOK {
+		defer closeResponse(resp)
 		return nil, httpRespToErrorResponse(resp, bucketName, objectName)
 	}
-	return io.ReadAll(resp.Body)
+	return resp.Body, nil
 }
 
 // ListObjectAnnotations returns all annotations attached to an object version.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1371,9 +1371,9 @@ if err != nil {
 
 <a name="GetObjectAnnotation"></a>
 
-### GetObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts GetObjectAnnotationOptions) ([]byte, error)
+### GetObjectAnnotation(ctx context.Context, bucketName, objectName, annotationName string, opts GetObjectAnnotationOptions) (io.ReadCloser, error)
 
-Return the payload of a single named annotation.
+Return the payload of a single named annotation as a stream. The caller must Close the returned reader.
 
 **Parameters**
 
@@ -1388,12 +1388,16 @@ Return the payload of a single named annotation.
 **Example**
 
 ```go
-payload, err := minioClient.GetObjectAnnotation(context.Background(), bucketName, objectName, "model.labels.json", minio.GetObjectAnnotationOptions{})
+body, err := minioClient.GetObjectAnnotation(context.Background(), bucketName, objectName, "model.labels.json", minio.GetObjectAnnotationOptions{})
 if err != nil {
 	fmt.Println(err)
 	return
 }
-fmt.Println(string(payload))
+defer body.Close()
+if _, err := io.Copy(os.Stdout, body); err != nil {
+	fmt.Println(err)
+	return
+}
 ```
 
 <a name="ListObjectAnnotations"></a>

--- a/examples/s3/getobjectannotation.go
+++ b/examples/s3/getobjectannotation.go
@@ -22,7 +22,9 @@ package main
 
 import (
 	"context"
+	"io"
 	"log"
+	"os"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -40,10 +42,14 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	payload, err := s3Client.GetObjectAnnotation(context.Background(), "my-bucketname", "my-objectname", "model.labels.json", minio.GetObjectAnnotationOptions{})
+	// GetObjectAnnotation returns a stream; read it and close it when done.
+	body, err := s3Client.GetObjectAnnotation(context.Background(), "my-bucketname", "my-objectname", "model.labels.json", minio.GetObjectAnnotationOptions{})
 	if err != nil {
 		log.Fatalln(err)
 	}
+	defer body.Close()
 
-	log.Printf("annotation payload: %s\n", payload)
+	if _, err := io.Copy(os.Stdout, body); err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -1898,9 +1898,15 @@ func testObjectAnnotations() {
 		return
 	}
 
-	got, err := c.GetObjectAnnotation(context.Background(), bucketName, objectName, annName, minio.GetObjectAnnotationOptions{})
+	annReader, err := c.GetObjectAnnotation(context.Background(), bucketName, objectName, annName, minio.GetObjectAnnotationOptions{})
 	if err != nil {
 		logError(testName, function, args, startTime, "", "GetObjectAnnotation failed", err)
+		return
+	}
+	got, err := io.ReadAll(annReader)
+	annReader.Close()
+	if err != nil {
+		logError(testName, function, args, startTime, "", "GetObjectAnnotation read failed", err)
 		return
 	}
 	if !bytes.Equal(got, annPayload) {


### PR DESCRIPTION
Follow-up to #2242. `GetObjectAnnotation` buffered the whole payload with `io.ReadAll(resp.Body)` and returned `[]byte`. Since the annotation API is unreleased, change it to return the response body as an `io.ReadCloser` so callers can stream the (server-capped 1 MiB) payload and close it when done.

- Success path returns `resp.Body`; error paths close the response.
- Example uses `io.Copy(os.Stdout, body)` to demonstrate streaming.
- Functional test reads + closes the returned stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * `GetObjectAnnotation` now returns a streamed response (`io.ReadCloser`) instead of loading the entire annotation into memory, so callers must read from the stream and close it.

* **Documentation**
  * Updated API documentation and examples to demonstrate consuming and closing the returned stream.

* **Tests**
  * Updated functional tests to read annotation contents from the returned stream before asserting correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->