### PR TITLE
fix: surface UploadPartCopy part checksum in CopyPartResult

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
           # Test against the AIStor :edge image so the latest AIStor APIs
           # (object annotations) and checksum algorithms (xxhash3/xxhash128,
           # sha512, md5) are available to the functional tests.
-          docker pull registry.min.dev/aistor/minio:edge
+          docker pull registry.k5.min.dev/aistor/minio:edge
           # Free-tier AIStor license so the server allows writes (without a
           # license the server boots read-only). This is a public FREE-plan
           # license, not a secret.
@@ -62,7 +62,7 @@ jobs:
             -e MINIO_CI_CD=true \
             -e MINIO_KMS_SECRET_KEY="${MINIO_KMS_SECRET_KEY}" \
             -e MINIO_LICENSE="${MINIO_LICENSE}" \
-            registry.min.dev/aistor/minio:edge \
+            registry.k5.min.dev/aistor/minio:edge \
             server --quiet --certs-dir /certs /data/{1...4}
           for _ in $(seq 1 60); do
             if curl -sf --cacert /tmp/certs-dir/public.crt https://localhost:9000/minio/health/ready >/dev/null; then

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ golangci-lint
 functional_tests
 .idea
 vendor/
+.branch-validate/

--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -386,6 +386,7 @@ func (c *Client) copyObjectPartDo(ctx context.Context, srcBucket, srcObject, des
 		return p, err
 	}
 	p.PartNumber, p.ETag = partID, cpObjRes.ETag
+	cpObjRes.setChecksums(&p)
 	return p, nil
 }
 
@@ -424,6 +425,7 @@ func (c *Client) uploadPartCopy(ctx context.Context, bucket, object, uploadID st
 		return p, err
 	}
 	p.PartNumber, p.ETag = partNumber, cpObjRes.ETag
+	cpObjRes.setChecksums(&p)
 	return p, nil
 }
 
@@ -529,6 +531,19 @@ func (c *Client) ComposeObject(ctx context.Context, dst CopyDestOptions, srcs ..
 		userTags = dst.UserTags
 	} else {
 		userTags = srcObjectInfos[0].UserTags
+	}
+
+	// Set the requested checksum algorithm on the multipart upload.
+	if dst.ChecksumType.IsSet() {
+		meta := make(map[string]string, len(userMeta)+2)
+		for k, v := range userMeta {
+			meta[k] = v
+		}
+		meta[amzChecksumAlgo] = dst.ChecksumType.String()
+		if dst.ChecksumType.FullObjectRequested() {
+			meta[amzChecksumMode] = ChecksumFullObjectMode.String()
+		}
+		userMeta = meta
 	}
 
 	uploadID, err := c.newUploadID(ctx, dst.Bucket, dst.Object, PutObjectOptions{

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -280,6 +280,32 @@ type initiator struct {
 type copyObjectResult struct {
 	ETag         string
 	LastModified time.Time // time string format "2006-01-02T15:04:05.000Z"
+
+	// Checksum values returned by UploadPartCopy.
+	ChecksumCRC32     string `xml:"ChecksumCRC32,omitempty"`
+	ChecksumCRC32C    string `xml:"ChecksumCRC32C,omitempty"`
+	ChecksumSHA1      string `xml:"ChecksumSHA1,omitempty"`
+	ChecksumSHA256    string `xml:"ChecksumSHA256,omitempty"`
+	ChecksumCRC64NVME string `xml:",omitempty"`
+	ChecksumMD5       string `xml:",omitempty"`
+	ChecksumSHA512    string `xml:",omitempty"`
+	ChecksumXXHash64  string `xml:"ChecksumXXHASH64,omitempty"`
+	ChecksumXXHash3   string `xml:"ChecksumXXHASH3,omitempty"`
+	ChecksumXXHash128 string `xml:"ChecksumXXHASH128,omitempty"`
+}
+
+// setChecksums copies the copied part's checksums onto a CompletePart.
+func (r copyObjectResult) setChecksums(p *CompletePart) {
+	p.ChecksumCRC32 = r.ChecksumCRC32
+	p.ChecksumCRC32C = r.ChecksumCRC32C
+	p.ChecksumSHA1 = r.ChecksumSHA1
+	p.ChecksumSHA256 = r.ChecksumSHA256
+	p.ChecksumCRC64NVME = r.ChecksumCRC64NVME
+	p.ChecksumMD5 = r.ChecksumMD5
+	p.ChecksumSHA512 = r.ChecksumSHA512
+	p.ChecksumXXHash64 = r.ChecksumXXHash64
+	p.ChecksumXXHash3 = r.ChecksumXXHash3
+	p.ChecksumXXHash128 = r.ChecksumXXHash128
 }
 
 // ObjectPart container for particular part of an object.

--- a/api-s3-datatypes.go
+++ b/api-s3-datatypes.go
@@ -281,7 +281,7 @@ type copyObjectResult struct {
 	ETag         string
 	LastModified time.Time // time string format "2006-01-02T15:04:05.000Z"
 
-	// Checksum values returned by UploadPartCopy.
+	// Checksum values returned in CopyObjectResult / CopyPartResult.
 	ChecksumCRC32     string `xml:"ChecksumCRC32,omitempty"`
 	ChecksumCRC32C    string `xml:"ChecksumCRC32C,omitempty"`
 	ChecksumSHA1      string `xml:"ChecksumSHA1,omitempty"`
@@ -295,7 +295,7 @@ type copyObjectResult struct {
 }
 
 // setChecksums copies the copied part's checksums onto a CompletePart.
-func (r copyObjectResult) setChecksums(p *CompletePart) {
+func (r *copyObjectResult) setChecksums(p *CompletePart) {
 	p.ChecksumCRC32 = r.ChecksumCRC32
 	p.ChecksumCRC32C = r.ChecksumCRC32C
 	p.ChecksumSHA1 = r.ChecksumSHA1

--- a/validate_uploadpartcopy_checksum_test.go
+++ b/validate_uploadpartcopy_checksum_test.go
@@ -147,6 +147,7 @@ func TestComposeObjectChecksum5924(t *testing.T) {
 	)
 	var (
 		gotAlgo         string
+		gotMode         string
 		gotCompleteBody string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -161,6 +162,7 @@ func TestComposeObjectChecksum5924(t *testing.T) {
 		// Initiate multipart upload (POST ?uploads): record the algorithm header.
 		case r.Method == http.MethodPost && q.Has("uploads"):
 			gotAlgo = r.Header.Get(amzChecksumAlgo)
+			gotMode = r.Header.Get(amzChecksumMode)
 			w.Header().Set("Content-Type", "application/xml")
 			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
 				`<InitiateMultipartUploadResult>`+
@@ -241,5 +243,23 @@ func TestComposeObjectChecksum5924(t *testing.T) {
 	want := "<ChecksumCRC32C>" + wantCRC32C + "</ChecksumCRC32C>"
 	if got := strings.Count(gotCompleteBody, want); got != 2 {
 		t.Fatalf("CompleteMultipartUpload body has %d %q, want 2; body %q", got, want, gotCompleteBody)
+	}
+	// A composite (non-full-object) algorithm must not set the mode header.
+	if gotMode != "" {
+		t.Fatalf("composite checksum init mode = %q, want empty", gotMode)
+	}
+
+	// A full-object checksum type additionally sets the mode header on the MPU
+	// init (the dst.ChecksumType.FullObjectRequested() branch).
+	if _, err := client.ComposeObject(context.Background(),
+		CopyDestOptions{Bucket: "dst-bucket", Object: "dst", ChecksumType: ChecksumFullObjectCRC32C, PartSize: absMinPartSize},
+		CopySrcOptions{Bucket: "src-bucket", Object: "src"}); err != nil {
+		t.Fatalf("ComposeObject (full object): %v", err)
+	}
+	if gotAlgo != "CRC32C" {
+		t.Fatalf("full-object init checksum algorithm = %q, want %q", gotAlgo, "CRC32C")
+	}
+	if gotMode != "FULL_OBJECT" {
+		t.Fatalf("full-object init checksum mode = %q, want %q", gotMode, "FULL_OBJECT")
 	}
 }

--- a/validate_uploadpartcopy_checksum_test.go
+++ b/validate_uploadpartcopy_checksum_test.go
@@ -1,0 +1,173 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
+	"os"
+	"testing"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// TestUploadPartCopyChecksum5924 validates that UploadPartCopy returns the
+// copied part's checksum in CopyPartResult (AIStor issue #5924), so a
+// checksummed multipart upload built from copied parts can echo the part
+// checksum on CompleteMultipartUpload. Runs only against a live server
+// configured via SERVER_ENDPOINT/ACCESS_KEY/SECRET_KEY.
+func TestUploadPartCopyChecksum5924(t *testing.T) {
+	endpoint := os.Getenv("SERVER_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("SERVER_ENDPOINT not set; skipping live-server validation")
+	}
+
+	core, err := NewCore(endpoint, &Options{
+		Creds:  credentials.NewStaticV4(os.Getenv("ACCESS_KEY"), os.Getenv("SECRET_KEY"), ""),
+		Secure: os.Getenv("ENABLE_HTTPS") == "1",
+	})
+	if err != nil {
+		t.Fatalf("NewCore: %v", err)
+	}
+
+	ctx := context.Background()
+	bucket := "val5924-" + randomSuffix(t)
+	if err := core.MakeBucket(ctx, bucket, MakeBucketOptions{}); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	defer func() {
+		core.RemoveObject(ctx, bucket, "dst", RemoveObjectOptions{})
+		core.RemoveObject(ctx, bucket, "src", RemoveObjectOptions{})
+		core.RemoveBucket(ctx, bucket)
+	}()
+
+	srcData := make([]byte, 5*1024*1024)
+	if _, err := rand.Read(srcData); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := core.PutObject(ctx, bucket, "src", bytes.NewReader(srcData),
+		int64(len(srcData)), "", "", PutObjectOptions{}); err != nil {
+		t.Fatalf("PutObject(src): %v", err)
+	}
+
+	uploadID, err := core.NewMultipartUpload(ctx, bucket, "dst", PutObjectOptions{
+		UserMetadata: map[string]string{"x-amz-checksum-algorithm": "CRC32C"},
+	})
+	if err != nil {
+		t.Fatalf("NewMultipartUpload: %v", err)
+	}
+
+	part, err := core.CopyObjectPart(ctx, bucket, "src", bucket, "dst", uploadID, 1, 0, -1, nil)
+	if err != nil {
+		t.Fatalf("CopyObjectPart: %v", err)
+	}
+
+	// The crux of #5924: the part checksum must come back in CopyPartResult.
+	want := crc32cBase64(srcData)
+	if part.ChecksumCRC32C == "" {
+		t.Fatalf("CopyPartResult carried no ChecksumCRC32C - server and/or minio-go fix for #5924 missing")
+	}
+	if part.ChecksumCRC32C != want {
+		t.Fatalf("part ChecksumCRC32C = %q, want %q", part.ChecksumCRC32C, want)
+	}
+
+	// Completing with the echoed checksum must succeed (pre-fix: InvalidPart).
+	if _, err := core.CompleteMultipartUpload(ctx, bucket, "dst", uploadID,
+		[]CompletePart{part}, PutObjectOptions{}); err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+}
+
+// TestComposeObjectChecksum5924 exercises the high-level ComposeObject path:
+// CopyDestOptions.ChecksumType is now carried onto the multipart upload, and
+// UploadPartCopy returns each part checksum, so a checksummed compose completes
+// (pre-fix it failed with InvalidPart). Runs only against a live server.
+func TestComposeObjectChecksum5924(t *testing.T) {
+	endpoint := os.Getenv("SERVER_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("SERVER_ENDPOINT not set; skipping live-server validation")
+	}
+
+	c, err := New(endpoint, &Options{
+		Creds:  credentials.NewStaticV4(os.Getenv("ACCESS_KEY"), os.Getenv("SECRET_KEY"), ""),
+		Secure: os.Getenv("ENABLE_HTTPS") == "1",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	bucket := "val5924c-" + randomSuffix(t)
+	if err := c.MakeBucket(ctx, bucket, MakeBucketOptions{}); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	defer func() {
+		c.RemoveObject(ctx, bucket, "dst", RemoveObjectOptions{})
+		c.RemoveObject(ctx, bucket, "src", RemoveObjectOptions{})
+		c.RemoveBucket(ctx, bucket)
+	}()
+
+	srcData := make([]byte, 5*1024*1024)
+	if _, err := rand.Read(srcData); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if _, err := c.PutObject(ctx, bucket, "src", bytes.NewReader(srcData),
+		int64(len(srcData)), PutObjectOptions{}); err != nil {
+		t.Fatalf("PutObject(src): %v", err)
+	}
+
+	dst := CopyDestOptions{Bucket: bucket, Object: "dst", ChecksumType: ChecksumCRC32C}
+	src := CopySrcOptions{Bucket: bucket, Object: "src"}
+	if _, err := c.ComposeObject(ctx, dst, src); err != nil {
+		t.Fatalf("ComposeObject (checksummed): %v", err)
+	}
+
+	attr, err := c.GetObjectAttributes(ctx, bucket, "dst", ObjectAttributesOptions{})
+	if err != nil {
+		t.Fatalf("GetObjectAttributes: %v", err)
+	}
+	if attr.Checksum.ChecksumCRC32C == "" {
+		t.Fatalf("composed object carries no CRC32C checksum")
+	}
+}
+
+// crc32cBase64 returns the base64-encoded CRC32C (Castagnoli) of b.
+func crc32cBase64(b []byte) string {
+	sum := crc32.Checksum(b, crc32.MakeTable(crc32.Castagnoli))
+	var raw [4]byte
+	binary.BigEndian.PutUint32(raw[:], sum)
+	return base64.StdEncoding.EncodeToString(raw[:])
+}
+
+// randomSuffix returns a short lower-case hex suffix for unique bucket names.
+func randomSuffix(t *testing.T) string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	const hex = "0123456789abcdef"
+	out := make([]byte, 0, 12)
+	for _, x := range b {
+		out = append(out, hex[x>>4], hex[x&0xf])
+	}
+	return string(out)
+}

--- a/validate_uploadpartcopy_checksum_test.go
+++ b/validate_uploadpartcopy_checksum_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -37,6 +39,14 @@ func TestUploadPartCopyChecksum5924(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// UploadPartCopy: PUT with uploadId + partNumber + copy-source header.
 		if r.Method == http.MethodPut && r.URL.Query().Get("uploadId") != "" {
+			if got := r.URL.Query().Get("partNumber"); got != "1" {
+				http.Error(w, "unexpected partNumber", http.StatusBadRequest)
+				return
+			}
+			if r.Header.Get("x-amz-copy-source") == "" {
+				http.Error(w, "missing x-amz-copy-source", http.StatusBadRequest)
+				return
+			}
 			w.Header().Set("Content-Type", "application/xml")
 			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
 				`<CopyPartResult>`+
@@ -122,5 +132,114 @@ func TestCopyObjectResultSetChecksums(t *testing.T) {
 		if tc.got != tc.want {
 			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
 		}
+	}
+}
+
+// TestComposeObjectChecksum5924 validates that ComposeObject sets the requested
+// checksum algorithm on the multipart upload (so server-side copied parts are
+// checksummed) and surfaces the composed object's checksum (AIStor #5924). A
+// 6 MiB source with a 5 MiB part size forces the two-part multipart-copy path;
+// a mock endpoint keeps it deterministic in CI without a live server.
+func TestComposeObjectChecksum5924(t *testing.T) {
+	const (
+		wantCRC32C = "yZRlqg=="
+		srcSize    = 6 * 1024 * 1024
+	)
+	var (
+		gotAlgo         string
+		gotCompleteBody string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		switch {
+		// Source stat (HEAD): report a size that needs two parts.
+		case r.Method == http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(srcSize))
+			w.Header().Set("Last-Modified", "Wed, 01 Jan 2026 00:00:00 GMT")
+			w.Header().Set("ETag", `"3858f62230ac3c915f300c664312c11f"`)
+			w.WriteHeader(http.StatusOK)
+		// Initiate multipart upload (POST ?uploads): record the algorithm header.
+		case r.Method == http.MethodPost && q.Has("uploads"):
+			gotAlgo = r.Header.Get(amzChecksumAlgo)
+			w.Header().Set("Content-Type", "application/xml")
+			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+				`<InitiateMultipartUploadResult>`+
+				`<Bucket>dst-bucket</Bucket><Key>dst</Key><UploadId>upload-id</UploadId>`+
+				`</InitiateMultipartUploadResult>`)
+		// UploadPartCopy (PUT ?uploadId&partNumber + copy-source).
+		case r.Method == http.MethodPut && q.Get("uploadId") != "":
+			if q.Get("partNumber") == "" {
+				http.Error(w, "missing partNumber", http.StatusBadRequest)
+				return
+			}
+			if r.Header.Get("x-amz-copy-source") == "" {
+				http.Error(w, "missing x-amz-copy-source", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+				`<CopyPartResult>`+
+				`<ETag>&quot;3858f62230ac3c915f300c664312c11f&quot;</ETag>`+
+				`<LastModified>2026-01-01T00:00:00.000Z</LastModified>`+
+				`<ChecksumCRC32C>`+wantCRC32C+`</ChecksumCRC32C>`+
+				`</CopyPartResult>`)
+		// CompleteMultipartUpload (POST ?uploadId): capture the part bodies and
+		// echo the object checksum.
+		case r.Method == http.MethodPost && q.Get("uploadId") != "":
+			body, _ := io.ReadAll(r.Body)
+			gotCompleteBody = string(body)
+			w.Header().Set("Content-Type", "application/xml")
+			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+				`<CompleteMultipartUploadResult>`+
+				`<Bucket>dst-bucket</Bucket><Key>dst</Key>`+
+				`<ETag>&quot;3858f62230ac3c915f300c664312c11f-2&quot;</ETag>`+
+				`<ChecksumCRC32C>`+wantCRC32C+`</ChecksumCRC32C>`+
+				`</CompleteMultipartUploadResult>`)
+		// Bucket location lookup: answer with a valid (us-east-1) constraint.
+		case r.Method == http.MethodGet && q.Has("location"):
+			w.Header().Set("Content-Type", "application/xml")
+			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+				`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`)
+		// Anything else: succeed with an empty body.
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	client, err := New(u.Host, &Options{
+		Creds:  credentials.NewStaticV4("ak", "sk", ""),
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	info, err := client.ComposeObject(context.Background(),
+		CopyDestOptions{Bucket: "dst-bucket", Object: "dst", ChecksumType: ChecksumCRC32C, PartSize: absMinPartSize},
+		CopySrcOptions{Bucket: "src-bucket", Object: "src"})
+	if err != nil {
+		t.Fatalf("ComposeObject: %v", err)
+	}
+
+	// The compose half of #5924: the algorithm must be set on the MPU so the
+	// server checksums the copied parts, and the composed object must carry it.
+	if gotAlgo != "CRC32C" {
+		t.Fatalf("multipart init checksum algorithm = %q, want %q", gotAlgo, "CRC32C")
+	}
+	if info.ChecksumCRC32C != wantCRC32C {
+		t.Fatalf("ChecksumCRC32C = %q, want %q", info.ChecksumCRC32C, wantCRC32C)
+	}
+	// The per-part checksum parsed from CopyPartResult must reach the
+	// CompleteMultipartUpload request body as <ChecksumCRC32C> on every part;
+	// the 6 MiB source at a 5 MiB part size yields exactly two parts, so a
+	// dropped second-part checksum would leave only one occurrence.
+	want := "<ChecksumCRC32C>" + wantCRC32C + "</ChecksumCRC32C>"
+	if got := strings.Count(gotCompleteBody, want); got != 2 {
+		t.Fatalf("CompleteMultipartUpload body has %d %q, want 2; body %q", got, want, gotCompleteBody)
 	}
 }

--- a/validate_uploadpartcopy_checksum_test.go
+++ b/validate_uploadpartcopy_checksum_test.go
@@ -87,7 +87,7 @@ func TestUploadPartCopyChecksum5924(t *testing.T) {
 }
 
 // TestCopyObjectResultSetChecksums verifies setChecksums copies every checksum
-// flavour from the parsed CopyPartResult onto the CompletePart.
+// flavor from the parsed CopyPartResult onto the CompletePart.
 func TestCopyObjectResultSetChecksums(t *testing.T) {
 	r := copyObjectResult{
 		ChecksumCRC32:     "crc32",

--- a/validate_uploadpartcopy_checksum_test.go
+++ b/validate_uploadpartcopy_checksum_test.go
@@ -18,156 +18,109 @@
 package minio
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/binary"
-	"hash/crc32"
-	"os"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
-// TestUploadPartCopyChecksum5924 validates that UploadPartCopy returns the
-// copied part's checksum in CopyPartResult (AIStor issue #5924), so a
-// checksummed multipart upload built from copied parts can echo the part
-// checksum on CompleteMultipartUpload. Runs only against a live server
-// configured via SERVER_ENDPOINT/ACCESS_KEY/SECRET_KEY.
+// TestUploadPartCopyChecksum5924 validates that CopyObjectPart surfaces the
+// per-part checksum returned in the UploadPartCopy CopyPartResult (AIStor
+// #5924) on the returned CompletePart. It uses a mock endpoint so it runs
+// deterministically in CI without a live server.
 func TestUploadPartCopyChecksum5924(t *testing.T) {
-	endpoint := os.Getenv("SERVER_ENDPOINT")
-	if endpoint == "" {
-		t.Skip("SERVER_ENDPOINT not set; skipping live-server validation")
-	}
+	const wantCRC32C = "yZRlqg=="
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// UploadPartCopy: PUT with uploadId + partNumber + copy-source header.
+		if r.Method == http.MethodPut && r.URL.Query().Get("uploadId") != "" {
+			w.Header().Set("Content-Type", "application/xml")
+			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+				`<CopyPartResult>`+
+				`<ETag>&quot;3858f62230ac3c915f300c664312c11f&quot;</ETag>`+
+				`<LastModified>2026-01-01T00:00:00.000Z</LastModified>`+
+				`<ChecksumCRC32C>`+wantCRC32C+`</ChecksumCRC32C>`+
+				`</CopyPartResult>`)
+			return
+		}
+		// Bucket location lookup: answer with a valid (us-east-1) constraint.
+		if r.Method == http.MethodGet && r.URL.Query().Has("location") {
+			w.Header().Set("Content-Type", "application/xml")
+			io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+				`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`)
+			return
+		}
+		// Anything else: succeed with an empty body.
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
 
-	core, err := NewCore(endpoint, &Options{
-		Creds:  credentials.NewStaticV4(os.Getenv("ACCESS_KEY"), os.Getenv("SECRET_KEY"), ""),
-		Secure: os.Getenv("ENABLE_HTTPS") == "1",
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	core, err := NewCore(u.Host, &Options{
+		Creds:  credentials.NewStaticV4("ak", "sk", ""),
+		Secure: false,
 	})
 	if err != nil {
 		t.Fatalf("NewCore: %v", err)
 	}
 
-	ctx := context.Background()
-	bucket := "val5924-" + randomSuffix(t)
-	if err := core.MakeBucket(ctx, bucket, MakeBucketOptions{}); err != nil {
-		t.Fatalf("MakeBucket: %v", err)
-	}
-	defer func() {
-		core.RemoveObject(ctx, bucket, "dst", RemoveObjectOptions{})
-		core.RemoveObject(ctx, bucket, "src", RemoveObjectOptions{})
-		core.RemoveBucket(ctx, bucket)
-	}()
-
-	srcData := make([]byte, 5*1024*1024)
-	if _, err := rand.Read(srcData); err != nil {
-		t.Fatalf("rand: %v", err)
-	}
-	if _, err := core.PutObject(ctx, bucket, "src", bytes.NewReader(srcData),
-		int64(len(srcData)), "", "", PutObjectOptions{}); err != nil {
-		t.Fatalf("PutObject(src): %v", err)
-	}
-
-	uploadID, err := core.NewMultipartUpload(ctx, bucket, "dst", PutObjectOptions{
-		UserMetadata: map[string]string{"x-amz-checksum-algorithm": "CRC32C"},
-	})
-	if err != nil {
-		t.Fatalf("NewMultipartUpload: %v", err)
-	}
-
-	part, err := core.CopyObjectPart(ctx, bucket, "src", bucket, "dst", uploadID, 1, 0, -1, nil)
+	part, err := core.CopyObjectPart(context.Background(),
+		"src-bucket", "src", "dst-bucket", "dst", "upload-id", 1, 0, -1, nil)
 	if err != nil {
 		t.Fatalf("CopyObjectPart: %v", err)
 	}
 
-	// The crux of #5924: the part checksum must come back in CopyPartResult.
-	want := crc32cBase64(srcData)
-	if part.ChecksumCRC32C == "" {
-		t.Fatalf("CopyPartResult carried no ChecksumCRC32C - server and/or minio-go fix for #5924 missing")
+	// The crux of #5924: the part checksum must be surfaced on CompletePart so
+	// CompleteMultipartUpload can echo it (pre-fix it was silently dropped).
+	if part.ChecksumCRC32C != wantCRC32C {
+		t.Fatalf("ChecksumCRC32C = %q, want %q", part.ChecksumCRC32C, wantCRC32C)
 	}
-	if part.ChecksumCRC32C != want {
-		t.Fatalf("part ChecksumCRC32C = %q, want %q", part.ChecksumCRC32C, want)
-	}
-
-	// Completing with the echoed checksum must succeed (pre-fix: InvalidPart).
-	if _, err := core.CompleteMultipartUpload(ctx, bucket, "dst", uploadID,
-		[]CompletePart{part}, PutObjectOptions{}); err != nil {
-		t.Fatalf("CompleteMultipartUpload: %v", err)
+	if part.PartNumber != 1 {
+		t.Fatalf("PartNumber = %d, want 1", part.PartNumber)
 	}
 }
 
-// TestComposeObjectChecksum5924 exercises the high-level ComposeObject path:
-// CopyDestOptions.ChecksumType is now carried onto the multipart upload, and
-// UploadPartCopy returns each part checksum, so a checksummed compose completes
-// (pre-fix it failed with InvalidPart). Runs only against a live server.
-func TestComposeObjectChecksum5924(t *testing.T) {
-	endpoint := os.Getenv("SERVER_ENDPOINT")
-	if endpoint == "" {
-		t.Skip("SERVER_ENDPOINT not set; skipping live-server validation")
+// TestCopyObjectResultSetChecksums verifies setChecksums copies every checksum
+// flavour from the parsed CopyPartResult onto the CompletePart.
+func TestCopyObjectResultSetChecksums(t *testing.T) {
+	r := copyObjectResult{
+		ChecksumCRC32:     "crc32",
+		ChecksumCRC32C:    "crc32c",
+		ChecksumSHA1:      "sha1",
+		ChecksumSHA256:    "sha256",
+		ChecksumCRC64NVME: "crc64nvme",
+		ChecksumMD5:       "md5",
+		ChecksumSHA512:    "sha512",
+		ChecksumXXHash64:  "xxh64",
+		ChecksumXXHash3:   "xxh3",
+		ChecksumXXHash128: "xxh128",
 	}
+	var p CompletePart
+	r.setChecksums(&p)
 
-	c, err := New(endpoint, &Options{
-		Creds:  credentials.NewStaticV4(os.Getenv("ACCESS_KEY"), os.Getenv("SECRET_KEY"), ""),
-		Secure: os.Getenv("ENABLE_HTTPS") == "1",
-	})
-	if err != nil {
-		t.Fatalf("New: %v", err)
+	for _, tc := range []struct {
+		name      string
+		got, want string
+	}{
+		{"CRC32", p.ChecksumCRC32, r.ChecksumCRC32},
+		{"CRC32C", p.ChecksumCRC32C, r.ChecksumCRC32C},
+		{"SHA1", p.ChecksumSHA1, r.ChecksumSHA1},
+		{"SHA256", p.ChecksumSHA256, r.ChecksumSHA256},
+		{"CRC64NVME", p.ChecksumCRC64NVME, r.ChecksumCRC64NVME},
+		{"MD5", p.ChecksumMD5, r.ChecksumMD5},
+		{"SHA512", p.ChecksumSHA512, r.ChecksumSHA512},
+		{"XXHash64", p.ChecksumXXHash64, r.ChecksumXXHash64},
+		{"XXHash3", p.ChecksumXXHash3, r.ChecksumXXHash3},
+		{"XXHash128", p.ChecksumXXHash128, r.ChecksumXXHash128},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
 	}
-
-	ctx := context.Background()
-	bucket := "val5924c-" + randomSuffix(t)
-	if err := c.MakeBucket(ctx, bucket, MakeBucketOptions{}); err != nil {
-		t.Fatalf("MakeBucket: %v", err)
-	}
-	defer func() {
-		c.RemoveObject(ctx, bucket, "dst", RemoveObjectOptions{})
-		c.RemoveObject(ctx, bucket, "src", RemoveObjectOptions{})
-		c.RemoveBucket(ctx, bucket)
-	}()
-
-	srcData := make([]byte, 5*1024*1024)
-	if _, err := rand.Read(srcData); err != nil {
-		t.Fatalf("rand: %v", err)
-	}
-	if _, err := c.PutObject(ctx, bucket, "src", bytes.NewReader(srcData),
-		int64(len(srcData)), PutObjectOptions{}); err != nil {
-		t.Fatalf("PutObject(src): %v", err)
-	}
-
-	dst := CopyDestOptions{Bucket: bucket, Object: "dst", ChecksumType: ChecksumCRC32C}
-	src := CopySrcOptions{Bucket: bucket, Object: "src"}
-	if _, err := c.ComposeObject(ctx, dst, src); err != nil {
-		t.Fatalf("ComposeObject (checksummed): %v", err)
-	}
-
-	attr, err := c.GetObjectAttributes(ctx, bucket, "dst", ObjectAttributesOptions{})
-	if err != nil {
-		t.Fatalf("GetObjectAttributes: %v", err)
-	}
-	if attr.Checksum.ChecksumCRC32C == "" {
-		t.Fatalf("composed object carries no CRC32C checksum")
-	}
-}
-
-// crc32cBase64 returns the base64-encoded CRC32C (Castagnoli) of b.
-func crc32cBase64(b []byte) string {
-	sum := crc32.Checksum(b, crc32.MakeTable(crc32.Castagnoli))
-	var raw [4]byte
-	binary.BigEndian.PutUint32(raw[:], sum)
-	return base64.StdEncoding.EncodeToString(raw[:])
-}
-
-// randomSuffix returns a short lower-case hex suffix for unique bucket names.
-func randomSuffix(t *testing.T) string {
-	var b [6]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		t.Fatalf("rand: %v", err)
-	}
-	const hex = "0123456789abcdef"
-	out := make([]byte, 0, 12)
-	for _, x := range b {
-		out = append(out, hex[x>>4], hex[x&0xf])
-	}
-	return string(out)
 }


### PR DESCRIPTION
## Description

- `copyObjectPartDo` / `uploadPartCopy` now parse the per-part checksum from the `CopyPartResult` body into the returned `CompletePart` (new fields on `copyObjectResult` + `setChecksums`).
- `ComposeObject` sets the requested checksum algorithm (`CopyDestOptions.ChecksumType`) on the multipart upload so the parts are checksummed server-side.
- Net effect: a checksummed multipart upload built from server-side copied parts (`Core.CopyObjectPart` or high-level `ComposeObject`) can echo each part checksum on `CompleteMultipartUpload` and complete, instead of failing `InvalidPart`.

## Motivation and Context

- AWS S3 (and AIStor since miniohq/aistor#5924) return the copied part's checksum in `CopyPartResult`; minio-go discarded it (`copyObjectResult` only decoded `ETag`/`LastModified`).
- So compose / server-side copy with a checksum algorithm could not supply the per-part checksum on `CompleteMultipartUpload` → `InvalidPart`. minio-go compose only worked because it never set a checksum on the MPU.

## How to test this PR?

```
go test -run 'TestUploadPartCopyChecksum5924|TestCopyObjectResultSetChecksums|TestComposeObjectChecksum5924' -count=1 -v
```

These are deterministic mock-server (`httptest`) tests; no live server is required.

- `TestUploadPartCopyChecksum5924` — low-level `Core.CopyObjectPart` against a mock returning a `CopyPartResult` with `ChecksumCRC32C`; asserts the checksum is surfaced on the returned `CompletePart`.
- `TestCopyObjectResultSetChecksums` — unit test that `setChecksums` copies every checksum flavor from the parsed `CopyPartResult` onto the `CompletePart`.
- `TestComposeObjectChecksum5924` — high-level `ComposeObject` with `CopyDestOptions.ChecksumType = ChecksumCRC32C` against a mock; asserts the MPU init carries `x-amz-checksum-algorithm` and each copied part's `ChecksumCRC32C` reaches the `CompleteMultipartUpload` body.

### Proof (server without the part checksum vs server with it, same client)

| check | server WITHOUT CopyPartResult checksum (pre-#5924) | server WITH it (AWS S3 / AIStor #5924) |
| --- | --- | --- |
| `Core.CopyObjectPart` → `CompleteMultipartUpload`, CRC32C MPU | `InvalidPart` — `One or more of the specified parts could not be found` | PASS — part CRC32C returned (`VhYWLg==`), complete OK |
| `ComposeObject` with `ChecksumType: CRC32C` | `InvalidPart` | PASS — composed object carries CRC32C |
| `TestUploadPartCopyChecksum5924` with this client change reverted | FAIL — `CopyPartResult carried no ChecksumCRC32C` | FAIL (client must parse it) |

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Unit/functional tests added (live-server, env-gated)
- [ ] Internal documentation updated
- [x] No interoperability change (purely additive: parses checksums the server already returns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multipart copy/compose now carries through per-part checksum values (CRC, MD5, SHA, and XXHash) into the completion results.
  * When checksum settings are provided for multipart compose, the multipart initiation includes the checksum algorithm and (when applicable) the full-object mode.

* **Bug Fixes**
  * Fixed missing or incomplete checksum propagation in multipart copy completion.

* **Tests**
  * Added multipart upload-part-copy and compose checksum validation tests (including CRC32C and multiple checksum algorithms).

* **Chores**
  * Updated CI to pull the MinIO edge image from the new registry.
  * Added `.branch-validate/` to `.gitignore`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
