### PR TITLE
feat: add request/response middleware pipeline

### DIFF
--- a/200OKwithError_test.go
+++ b/200OKwithError_test.go
@@ -53,7 +53,8 @@ func Test200MultipartUploadWithSpaces(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
 			Secure: srv.Scheme == "https",
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -63,7 +64,8 @@ func Test200MultipartUploadWithSpaces(t *testing.T) {
 		{PartNumber: 2, ETag: "78c577a580bbbba92845789cda1fa932"},
 	}
 
-	foundUploadInfo, err := core.CompleteMultipartUpload(context.Background(),
+	foundUploadInfo, err := core.CompleteMultipartUpload(
+		context.Background(),
 		"bucket",
 		"object",
 		"jY1M2U5NWMtZGY2OC00ZjYyLTljZGYtYmZlOWEzODM3MDMwLjlmZWY5OGNlLWQ1Y2EtNDgwMC04N2Y4LWZkNTNkMDM4ZDdiMXgxNzQ4NjA0NzI0NzE4NjU3MTY3",
@@ -116,7 +118,8 @@ func Test200MultipartUploadWithError(t *testing.T) {
 			Secure:     srv.Scheme == "https",
 			Region:     "us-east-1",
 			MaxRetries: retries,
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -126,7 +129,8 @@ func Test200MultipartUploadWithError(t *testing.T) {
 		{PartNumber: 2, ETag: "78c577a580bbbba92845789cda1fa932"},
 	}
 
-	_, err = core.CompleteMultipartUpload(context.Background(),
+	_, err = core.CompleteMultipartUpload(
+		context.Background(),
 		"bucket",
 		"object",
 		"jY1M2U5NWMtZGY2OC00ZjYyLTljZGYtYmZlOWEzODM3MDMwLjlmZWY5OGNlLWQ1Y2EtNDgwMC04N2Y4LWZkNTNkMDM4ZDdiMXgxNzQ4NjA0NzI0NzE4NjU3MTY3",
@@ -177,7 +181,8 @@ func Test200DeleteObjectsWithError(t *testing.T) {
 			Secure:     srv.Scheme == "https",
 			Region:     "us-east-1",
 			MaxRetries: retries,
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}

--- a/api-compose-object.go
+++ b/api-compose-object.go
@@ -470,7 +470,8 @@ func (c *Client) ComposeObject(ctx context.Context, dst CopyDestOptions, srcs ..
 			if src.End >= srcCopySize || src.Start < 0 {
 				return UploadInfo{}, errInvalidArgument(
 					fmt.Sprintf("CopySrcOptions %d has invalid segment-to-copy [%d, %d] (size is %d)",
-						i, src.Start, src.End, srcCopySize))
+						i, src.Start, src.End, srcCopySize),
+				)
 			}
 			srcCopySize = src.End - src.Start + 1
 		}
@@ -478,7 +479,8 @@ func (c *Client) ComposeObject(ctx context.Context, dst CopyDestOptions, srcs ..
 		// Only the last source may be less than `absMinPartSize`
 		if srcCopySize < absMinPartSize && i < len(srcs)-1 {
 			return UploadInfo{}, errInvalidArgument(
-				fmt.Sprintf("CopySrcOptions %d is too small (%d) and it is not the last part", i, srcCopySize))
+				fmt.Sprintf("CopySrcOptions %d is too small (%d) and it is not the last part", i, srcCopySize),
+			)
 		}
 
 		// Is data to copy too large?
@@ -495,7 +497,8 @@ func (c *Client) ComposeObject(ctx context.Context, dst CopyDestOptions, srcs ..
 		// Do we need more parts than we are allowed?
 		if totalParts > maxPartsCount {
 			return UploadInfo{}, errInvalidArgument(fmt.Sprintf(
-				"Your proposed compose object requires more than %d parts", maxPartsCount))
+				"Your proposed compose object requires more than %d parts", maxPartsCount,
+			))
 		}
 	}
 

--- a/api-get-options.go
+++ b/api-get-options.go
@@ -183,7 +183,9 @@ func (o *GetObjectOptions) SetRange(start, end int64) error {
 		return errInvalidArgument(
 			fmt.Sprintf(
 				"Invalid range specified: start=%d end=%d",
-				start, end))
+				start, end,
+			),
+		)
 	}
 	return nil
 }

--- a/api.go
+++ b/api.go
@@ -563,9 +563,6 @@ type requestMetadata struct {
 	trailer          http.Header // (http.Request).Trailer. Requires v4 signature.
 
 	expect200OKWithError bool
-
-	// s3 operation name
-	s3Operation string
 }
 
 // dumpHTTP - dump HTTP request and response.
@@ -721,16 +718,11 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 		metadata.trailer.Set(metadata.addCrc.Key(), base64.StdEncoding.EncodeToString(crc.Sum(nil)))
 	}
 
-	opt := metadata.s3Operation
-	if opt == "" {
-		opt = resolveS3Operation(method, metadata)
-	}
-	metadata.s3Operation = opt
-
 	execCtx := ExecutionContext{
-		Operation:  opt,
-		BucketName: metadata.bucketName,
-		ObjectName: metadata.objectName,
+		Method:      method,
+		BucketName:  metadata.bucketName,
+		ObjectName:  metadata.objectName,
+		QueryValues: metadata.queryValues,
 	}
 
 	for _, m := range c.middlewares {
@@ -782,18 +774,19 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 			}
 			return nil, err
 		}
+
 		var mwError error
 		for _, m := range c.middlewares {
 			if deserializeM, ok := m.(DeserializeMiddleware); ok {
-				if dErr := deserializeM.Deserialize(ctx, execCtx, res, err); dErr != nil {
+				if dErr := deserializeM.Deserialize(ctx, execCtx, res); dErr != nil {
 					mwError = errors.Join(mwError, dErr)
 				}
 			}
 		}
+
 		if mwError != nil {
 			err = errors.Join(err, mwError)
 		}
-
 		success := successStatus.Contains(res.StatusCode)
 		if success && !metadata.expect200OKWithError {
 			if mwError != nil {
@@ -946,12 +939,10 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		return nil, err
 	}
 	execCtx := ExecutionContext{
-		Operation:  metadata.s3Operation,
-		BucketName: metadata.bucketName,
-		ObjectName: metadata.objectName,
-	}
-	if execCtx.Operation == "" {
-		execCtx.Operation = resolveS3Operation(method, metadata)
+		Method:      method,
+		BucketName:  metadata.bucketName,
+		ObjectName:  metadata.objectName,
+		QueryValues: metadata.queryValues,
 	}
 	for _, m := range c.middlewares {
 		if serializeM, ok := m.(SerializeMiddleware); ok {
@@ -1234,152 +1225,4 @@ func (c *Client) GetCreds() (credentials.Value, error) {
 		return credentials.Value{}, errors.New("no credentials provider")
 	}
 	return c.credsProvider.GetWithContext(c.CredContext())
-}
-
-func resolveS3Operation(method string, metadata requestMetadata) string {
-	if metadata.s3Operation != "" {
-		return metadata.s3Operation
-	}
-
-	hasQuery := func(key string) bool {
-		return metadata.queryValues.Get(key) != "" || metadata.queryValues.Has(key)
-	}
-
-	isObject := metadata.objectName != ""
-
-	switch method {
-	case http.MethodGet:
-		if isObject {
-			if hasQuery("tagging") {
-				return "GetObjectTagging"
-			}
-			if hasQuery("acl") {
-				return "GetObjectAcl"
-			}
-			if hasQuery("legal-hold") {
-				return "GetObjectLegalHold"
-			}
-			if hasQuery("retention") {
-				return "GetObjectRetention"
-			}
-			return "GetObject"
-		} else {
-			if hasQuery("lifecycle") {
-				return "GetBucketLifecycle"
-			}
-			if hasQuery("policy") {
-				return "GetBucketPolicy"
-			}
-			if hasQuery("notification") {
-				return "GetBucketNotification"
-			}
-			if hasQuery("cors") {
-				return "GetBucketCors"
-			}
-			if hasQuery("encryption") {
-				return "GetBucketEncryption"
-			}
-			if hasQuery("tagging") {
-				return "GetBucketTagging"
-			}
-			if hasQuery("versioning") {
-				return "GetBucketVersioning"
-			}
-			if metadata.bucketName != "" {
-				return "ListObjectsV2"
-			}
-			return "ListBuckets"
-		}
-
-	case http.MethodPut:
-		if isObject {
-			if hasQuery("tagging") {
-				return "PutObjectTagging"
-			}
-			if hasQuery("acl") {
-				return "PutObjectAcl"
-			}
-			if hasQuery("legal-hold") {
-				return "PutObjectLegalHold"
-			}
-			if hasQuery("retention") {
-				return "PutObjectRetention"
-			}
-			return "PutObject"
-		} else {
-			if hasQuery("lifecycle") {
-				return "PutBucketLifecycle"
-			}
-			if hasQuery("policy") {
-				return "PutBucketPolicy"
-			}
-			if hasQuery("notification") {
-				return "PutBucketNotification"
-			}
-			if hasQuery("cors") {
-				return "PutBucketCors"
-			}
-			if hasQuery("encryption") {
-				return "PutBucketEncryption"
-			}
-			if hasQuery("tagging") {
-				return "PutBucketTagging"
-			}
-			if hasQuery("versioning") {
-				return "PutBucketVersioning"
-			}
-			return "CreateBucket"
-		}
-
-	case http.MethodDelete:
-		if isObject {
-			if hasQuery("tagging") {
-				return "DeleteObjectTagging"
-			}
-			return "DeleteObject"
-		} else {
-			if hasQuery("lifecycle") {
-				return "DeleteBucketLifecycle"
-			}
-			if hasQuery("policy") {
-				return "DeleteBucketPolicy"
-			}
-			if hasQuery("cors") {
-				return "DeleteBucketCors"
-			}
-			if hasQuery("encryption") {
-				return "DeleteBucketEncryption"
-			}
-			if hasQuery("tagging") {
-				return "DeleteBucketTagging"
-			}
-			return "DeleteBucket"
-		}
-
-	case http.MethodHead:
-		if isObject {
-			return "HeadObject"
-		}
-		return "HeadBucket"
-
-	case http.MethodPost:
-		if isObject {
-			if hasQuery("uploads") {
-				return "CreateMultipartUpload"
-			}
-			if hasQuery("restore") {
-				return "RestoreObject"
-			}
-			if hasQuery("select") {
-				return "SelectObjectContent"
-			}
-			return "PostObject"
-		} else {
-			if hasQuery("delete") {
-				return "DeleteObjects"
-			}
-		}
-	}
-
-	return method
 }

--- a/api.go
+++ b/api.go
@@ -118,6 +118,9 @@ type Client struct {
 	rdmaOnce    sync.Once         //nolint:unused
 	rdmaHandle  *rdmaClientHandle //nolint:unused
 	rdmaInitErr error             //nolint:unused
+
+	// Middlewares
+	middlewares []Middleware
 }
 
 // Options for New method
@@ -170,6 +173,9 @@ type Options struct {
 	// when the caller supplies PutObjectOptions.RDMABuffer / GetObjectOptions.RDMABuffer.
 	// No-op unless built with -tags=rdma.
 	EnableRDMA bool
+
+	// Middlewares to run on s3 operations.
+	Middlewares []Middleware
 }
 
 // Global constants.
@@ -218,6 +224,11 @@ func New(endpoint string, opts *Options) (*Client, error) {
 	}
 
 	return clnt, nil
+}
+
+// AddMiddleware adds a middleware to the chain.
+func (c *Client) AddMiddleware(m Middleware) {
+	c.middlewares = append(c.middlewares, m)
 }
 
 // EndpointURL returns the URL of the S3-compatible endpoint that this client connects to.
@@ -340,6 +351,7 @@ func privateNew(endpoint string, opts *Options) (*Client, error) {
 		clnt.maxRetries = opts.MaxRetries
 	}
 
+	clnt.middlewares = opts.Middlewares
 	// Return.
 	return clnt, nil
 }
@@ -551,6 +563,9 @@ type requestMetadata struct {
 	trailer          http.Header // (http.Request).Trailer. Requires v4 signature.
 
 	expect200OKWithError bool
+
+	// s3 operation name
+	s3Operation string
 }
 
 // dumpHTTP - dump HTTP request and response.
@@ -706,6 +721,26 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 		metadata.trailer.Set(metadata.addCrc.Key(), base64.StdEncoding.EncodeToString(crc.Sum(nil)))
 	}
 
+	opt := metadata.s3Operation
+	if opt == "" {
+		opt = resolveS3Operation(method, metadata)
+	}
+	metadata.s3Operation = opt
+
+	execCtx := ExecutionContext{
+		Operation:  opt,
+		BucketName: metadata.bucketName,
+		ObjectName: metadata.objectName,
+	}
+
+	for _, m := range c.middlewares {
+		if initM, ok := m.(InitializeMiddleware); ok {
+			if ctx, err = initM.Initialize(ctx, execCtx); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	for range c.newRetryTimer(ctx, reqRetry, DefaultRetryUnit, DefaultRetryCap, MaxJitter) {
 		// Retry executes the following function body if request has an
 		// error until maxRetries have been exhausted, retry attempts are
@@ -730,6 +765,13 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 
 			return nil, err
 		}
+		for _, m := range c.middlewares {
+			if finalizeM, ok := m.(FinalizeMiddleware); ok {
+				if err = finalizeM.Finalize(ctx, execCtx, req); err != nil {
+					return nil, err
+				}
+			}
+		}
 
 		// Initiate the request.
 		res, err = c.do(req)
@@ -740,10 +782,24 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 			}
 			return nil, err
 		}
+		var mwError error
+		for _, m := range c.middlewares {
+			if deserializeM, ok := m.(DeserializeMiddleware); ok {
+				if dErr := deserializeM.Deserialize(ctx, execCtx, res, err); dErr != nil {
+					mwError = errors.Join(mwError, dErr)
+				}
+			}
+		}
+		if mwError != nil {
+			err = errors.Join(err, mwError)
+		}
 
 		success := successStatus.Contains(res.StatusCode)
 		if success && !metadata.expect200OKWithError {
-			// We do not expect 2xx to return an error return.
+			if mwError != nil {
+				closeResponse(res)
+				return nil, err
+			}
 			return res, nil
 		} // in all other situations we must first parse the body as ErrorResponse
 
@@ -888,6 +944,21 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 	req, err = http.NewRequestWithContext(ctx, method, targetURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+	execCtx := ExecutionContext{
+		Operation:  metadata.s3Operation,
+		BucketName: metadata.bucketName,
+		ObjectName: metadata.objectName,
+	}
+	if execCtx.Operation == "" {
+		execCtx.Operation = resolveS3Operation(method, metadata)
+	}
+	for _, m := range c.middlewares {
+		if serializeM, ok := m.(SerializeMiddleware); ok {
+			if err = serializeM.Serialize(ctx, execCtx, req); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	var (
@@ -1163,4 +1234,152 @@ func (c *Client) GetCreds() (credentials.Value, error) {
 		return credentials.Value{}, errors.New("no credentials provider")
 	}
 	return c.credsProvider.GetWithContext(c.CredContext())
+}
+
+func resolveS3Operation(method string, metadata requestMetadata) string {
+	if metadata.s3Operation != "" {
+		return metadata.s3Operation
+	}
+
+	hasQuery := func(key string) bool {
+		return metadata.queryValues.Get(key) != "" || metadata.queryValues.Has(key)
+	}
+
+	isObject := metadata.objectName != ""
+
+	switch method {
+	case http.MethodGet:
+		if isObject {
+			if hasQuery("tagging") {
+				return "GetObjectTagging"
+			}
+			if hasQuery("acl") {
+				return "GetObjectAcl"
+			}
+			if hasQuery("legal-hold") {
+				return "GetObjectLegalHold"
+			}
+			if hasQuery("retention") {
+				return "GetObjectRetention"
+			}
+			return "GetObject"
+		} else {
+			if hasQuery("lifecycle") {
+				return "GetBucketLifecycle"
+			}
+			if hasQuery("policy") {
+				return "GetBucketPolicy"
+			}
+			if hasQuery("notification") {
+				return "GetBucketNotification"
+			}
+			if hasQuery("cors") {
+				return "GetBucketCors"
+			}
+			if hasQuery("encryption") {
+				return "GetBucketEncryption"
+			}
+			if hasQuery("tagging") {
+				return "GetBucketTagging"
+			}
+			if hasQuery("versioning") {
+				return "GetBucketVersioning"
+			}
+			if metadata.bucketName != "" {
+				return "ListObjectsV2"
+			}
+			return "ListBuckets"
+		}
+
+	case http.MethodPut:
+		if isObject {
+			if hasQuery("tagging") {
+				return "PutObjectTagging"
+			}
+			if hasQuery("acl") {
+				return "PutObjectAcl"
+			}
+			if hasQuery("legal-hold") {
+				return "PutObjectLegalHold"
+			}
+			if hasQuery("retention") {
+				return "PutObjectRetention"
+			}
+			return "PutObject"
+		} else {
+			if hasQuery("lifecycle") {
+				return "PutBucketLifecycle"
+			}
+			if hasQuery("policy") {
+				return "PutBucketPolicy"
+			}
+			if hasQuery("notification") {
+				return "PutBucketNotification"
+			}
+			if hasQuery("cors") {
+				return "PutBucketCors"
+			}
+			if hasQuery("encryption") {
+				return "PutBucketEncryption"
+			}
+			if hasQuery("tagging") {
+				return "PutBucketTagging"
+			}
+			if hasQuery("versioning") {
+				return "PutBucketVersioning"
+			}
+			return "CreateBucket"
+		}
+
+	case http.MethodDelete:
+		if isObject {
+			if hasQuery("tagging") {
+				return "DeleteObjectTagging"
+			}
+			return "DeleteObject"
+		} else {
+			if hasQuery("lifecycle") {
+				return "DeleteBucketLifecycle"
+			}
+			if hasQuery("policy") {
+				return "DeleteBucketPolicy"
+			}
+			if hasQuery("cors") {
+				return "DeleteBucketCors"
+			}
+			if hasQuery("encryption") {
+				return "DeleteBucketEncryption"
+			}
+			if hasQuery("tagging") {
+				return "DeleteBucketTagging"
+			}
+			return "DeleteBucket"
+		}
+
+	case http.MethodHead:
+		if isObject {
+			return "HeadObject"
+		}
+		return "HeadBucket"
+
+	case http.MethodPost:
+		if isObject {
+			if hasQuery("uploads") {
+				return "CreateMultipartUpload"
+			}
+			if hasQuery("restore") {
+				return "RestoreObject"
+			}
+			if hasQuery("select") {
+				return "SelectObjectContent"
+			}
+			return "PostObject"
+		} else {
+			if hasQuery("delete") {
+				return "DeleteObjects"
+			}
+		}
+	}
+
+	return method
 }

--- a/core_test.go
+++ b/core_test.go
@@ -54,7 +54,8 @@ func TestGetObjectCore(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -251,7 +252,8 @@ func TestGetObjectContentEncoding(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -324,7 +326,8 @@ func TestGetBucketPolicy(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -387,7 +390,8 @@ func TestCoreCopyObject(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -515,7 +519,8 @@ func TestCoreCopyObjectPart(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -668,7 +673,8 @@ func TestCorePutObject(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -761,7 +767,8 @@ func TestCoreGetObjectMetadata(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -822,7 +829,8 @@ func TestCoreMultipartUpload(t *testing.T) {
 		&Options{
 			Creds:  credentials.NewStaticV4(os.Getenv(accessKey), os.Getenv(secretKey), ""),
 			Secure: mustParseBool(os.Getenv(enableSecurity)),
-		})
+		},
+	)
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
@@ -862,7 +870,8 @@ func TestCoreMultipartUpload(t *testing.T) {
 			partID++
 			data := bytes.NewReader(partBuf[:n])
 			dataLen := int64(len(partBuf[:n]))
-			objectPart, err := core.PutObjectPart(context.Background(), bucketName, objectName, uploadID, partID,
+			objectPart, err := core.PutObjectPart(
+				context.Background(), bucketName, objectName, uploadID, partID,
 				data, dataLen,
 				PutObjectPartOptions{
 					Md5Base64:    "",

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -10238,7 +10238,8 @@ func testSSECMultipartEncryptedToSSECCopyObjectPart() {
 
 	var completeParts []minio.CompletePart
 
-	part, err := c.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1,
+	part, err := c.PutObjectPart(
+		context.Background(), bucketName, objectName, uploadID, 1,
 		bytes.NewReader(buf[:5*1024*1024]), 5*1024*1024,
 		minio.PutObjectPartOptions{SSE: srcencryption},
 	)
@@ -10248,7 +10249,8 @@ func testSSECMultipartEncryptedToSSECCopyObjectPart() {
 	}
 	completeParts = append(completeParts, minio.CompletePart{PartNumber: part.PartNumber, ETag: part.ETag})
 
-	part, err = c.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 2,
+	part, err = c.PutObjectPart(
+		context.Background(), bucketName, objectName, uploadID, 2,
 		bytes.NewReader(buf[5*1024*1024:]), 1024*1024,
 		minio.PutObjectPartOptions{SSE: srcencryption},
 	)

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,61 @@
+package minio
+
+import (
+	"context"
+	"net/http"
+)
+
+// ExecutionContext provides context metadata about the S3 operation currently running.
+type ExecutionContext struct {
+	Operation  string // e.g. "GetObject", "PutObject", "ListBuckets"
+	BucketName string
+	ObjectName string
+}
+
+// Middleware is the base interface for all pipeline interceptors.
+type Middleware interface {
+	ID() string
+}
+
+// InitializeMiddleware runs BEFORE the HTTP request is built.
+// It can mutate the context or alter metadata.
+//
+// NOTE: This runs once per API call (outside the retry loop), safe for
+// one-shot setup or pre-validation.
+type InitializeMiddleware interface {
+	Middleware
+	Initialize(ctx context.Context, execCtx ExecutionContext) (context.Context, error)
+}
+
+// SerializeMiddleware runs AFTER the request is created, but BEFORE it is signed.
+// It can mutate headers, query parameters, etc.
+//
+// NOTE: This is the safe phase for one-shot logging — it runs once per API call
+// before the retry loop (unlike Finalize/Deserialize which fire on every retry).
+type SerializeMiddleware interface {
+	Middleware
+	Serialize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error
+}
+
+// FinalizeMiddleware runs AFTER the request is signed and ready to go out.
+// Ideal for logging request sizes, outbound traffic, or tracing.
+//
+// NOTE: This fires on EVERY retry attempt inside the retry loop, not once per
+// top-level API call. If you only want to log/logic once, use SerializeMiddleware
+// instead.
+type FinalizeMiddleware interface {
+	Middleware
+	Finalize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error
+}
+
+// DeserializeMiddleware runs AFTER the HTTP response is received from the server.
+// It can inspect status codes, headers, or modify/log errors.
+//
+// NOTE: This fires on EVERY retry attempt inside the retry loop. Errors from all
+// Deserialize middleware are stacked via errors.Join with the transport error.
+// If any middleware returns a non-nil error, the request is aborted even on 2xx
+// responses. Use this for response validation.
+type DeserializeMiddleware interface {
+	Middleware
+	Deserialize(ctx context.Context, execCtx ExecutionContext, resp *http.Response, err error) error
+}

--- a/middleware.go
+++ b/middleware.go
@@ -1,15 +1,34 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package minio
 
 import (
 	"context"
 	"net/http"
+	"net/url"
 )
 
 // ExecutionContext provides context metadata about the S3 operation currently running.
 type ExecutionContext struct {
-	Operation  string // e.g. "GetObject", "PutObject", "ListBuckets"
-	BucketName string
-	ObjectName string
+	Method      string // e.g. "GET", "PUT", "DELETE"
+	BucketName  string
+	ObjectName  string
+	QueryValues url.Values // e.g. ?policy, ?tagging, ?versioning
 }
 
 // Middleware is the base interface for all pipeline interceptors.
@@ -30,8 +49,7 @@ type InitializeMiddleware interface {
 // SerializeMiddleware runs AFTER the request is created, but BEFORE it is signed.
 // It can mutate headers, query parameters, etc.
 //
-// NOTE: This fires on EVERY retry attempt (new request per attempt).
-// Only InitializeMiddleware runs once per API call.
+// NOTE: This fires on every retry attempt. Only Initialize runs once.
 type SerializeMiddleware interface {
 	Middleware
 	Serialize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error
@@ -40,8 +58,7 @@ type SerializeMiddleware interface {
 // FinalizeMiddleware runs AFTER the request is signed and ready to go out.
 // Ideal for logging request sizes, outbound traffic, or tracing.
 //
-// NOTE: This fires on EVERY retry attempt inside the retry loop, not once per
-// top-level API call. Only InitializeMiddleware runs once.
+// NOTE: This fires on every retry attempt. Only Initialize runs once.
 type FinalizeMiddleware interface {
 	Middleware
 	Finalize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error
@@ -50,12 +67,11 @@ type FinalizeMiddleware interface {
 // DeserializeMiddleware runs AFTER the HTTP response is received from the server.
 // It can inspect status codes, headers, or modify/log errors.
 //
-// NOTE: This fires on EVERY retry attempt inside the retry loop.
-// Only InitializeMiddleware runs once per API call.
+// NOTE: This fires on every retry attempt. Only Initialize runs once.
 // Errors from all Deserialize middleware stack via errors.Join with the transport
 // error. If any middleware returns a non-nil error, the request aborts even on
-// 2xx responses. Use this for response validation.
+// 2xx responses.
 type DeserializeMiddleware interface {
 	Middleware
-	Deserialize(ctx context.Context, execCtx ExecutionContext, resp *http.Response, err error) error
+	Deserialize(ctx context.Context, execCtx ExecutionContext, resp *http.Response) error
 }

--- a/middleware.go
+++ b/middleware.go
@@ -30,8 +30,8 @@ type InitializeMiddleware interface {
 // SerializeMiddleware runs AFTER the request is created, but BEFORE it is signed.
 // It can mutate headers, query parameters, etc.
 //
-// NOTE: This is the safe phase for one-shot logging — it runs once per API call
-// before the retry loop (unlike Finalize/Deserialize which fire on every retry).
+// NOTE: This fires on EVERY retry attempt (new request per attempt).
+// Only InitializeMiddleware runs once per API call.
 type SerializeMiddleware interface {
 	Middleware
 	Serialize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error
@@ -41,8 +41,7 @@ type SerializeMiddleware interface {
 // Ideal for logging request sizes, outbound traffic, or tracing.
 //
 // NOTE: This fires on EVERY retry attempt inside the retry loop, not once per
-// top-level API call. If you only want to log/logic once, use SerializeMiddleware
-// instead.
+// top-level API call. Only InitializeMiddleware runs once.
 type FinalizeMiddleware interface {
 	Middleware
 	Finalize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error
@@ -51,10 +50,11 @@ type FinalizeMiddleware interface {
 // DeserializeMiddleware runs AFTER the HTTP response is received from the server.
 // It can inspect status codes, headers, or modify/log errors.
 //
-// NOTE: This fires on EVERY retry attempt inside the retry loop. Errors from all
-// Deserialize middleware are stacked via errors.Join with the transport error.
-// If any middleware returns a non-nil error, the request is aborted even on 2xx
-// responses. Use this for response validation.
+// NOTE: This fires on EVERY retry attempt inside the retry loop.
+// Only InitializeMiddleware runs once per API call.
+// Errors from all Deserialize middleware stack via errors.Join with the transport
+// error. If any middleware returns a non-nil error, the request aborts even on
+// 2xx responses. Use this for response validation.
 type DeserializeMiddleware interface {
 	Middleware
 	Deserialize(ctx context.Context, execCtx ExecutionContext, resp *http.Response, err error) error

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,101 @@
+package minio
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+type mockMiddleware struct {
+	mu           sync.Mutex
+	initialized  []string
+	serialized   []string
+	finalized    []string
+	deserialized []string
+}
+
+func (m *mockMiddleware) ID() string {
+	return "mock-middleware"
+}
+
+func (m *mockMiddleware) Initialize(ctx context.Context, execCtx ExecutionContext) (context.Context, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.initialized = append(m.initialized, execCtx.Operation)
+	return ctx, nil
+}
+
+func (m *mockMiddleware) Serialize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.serialized = append(m.serialized, execCtx.Operation)
+	req.Header.Set("X-Mock-Header", "Hello")
+	return nil
+}
+
+func (m *mockMiddleware) Finalize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.finalized = append(m.finalized, execCtx.Operation)
+	return nil
+}
+
+func (m *mockMiddleware) Deserialize(ctx context.Context, execCtx ExecutionContext, resp *http.Response, err error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deserialized = append(m.deserialized, execCtx.Operation)
+	return nil
+}
+
+func TestMiddlewareIntegration(t *testing.T) {
+	// Start local mock S3 server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify custom header was injected by Serialize middleware
+		if r.Header.Get("X-Mock-Header") != "Hello" {
+			t.Errorf("Expected X-Mock-Header: 'Hello', got '%s'", r.Header.Get("X-Mock-Header"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mw := &mockMiddleware{}
+
+	// Instantiate client with middleware options
+	client, err := New(server.URL[7:], &Options{
+		Creds:        credentials.NewStaticV4("mockkey", "mocksecret", ""),
+		Secure:       false,
+		Region:       "us-east-1",
+		Middlewares:  []Middleware{mw},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create minio client: %v", err)
+	}
+
+	// Make a GetBucketPolicy request (which uses executeMethod under the hood)
+	_, err = client.GetBucketPolicy(context.Background(), "mybucket")
+	// Since the mock server returns 200 OK but empty payload, GetBucketPolicy may return XML parsing error or nil, but HTTP request was triggered.
+
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+
+	// Verify the S3 Operation was correctly resolved by resolveS3Operation (GetBucketPolicy)
+	if len(mw.initialized) != 1 || mw.initialized[0] != "GetBucketPolicy" {
+		t.Errorf("Expected initialized operation to be 'GetBucketPolicy', got %v", mw.initialized)
+	}
+
+	if len(mw.serialized) != 1 || mw.serialized[0] != "GetBucketPolicy" {
+		t.Errorf("Expected serialized operation to be 'GetBucketPolicy', got %v", mw.serialized)
+	}
+
+	if len(mw.finalized) != 1 || mw.finalized[0] != "GetBucketPolicy" {
+		t.Errorf("Expected finalized operation to be 'GetBucketPolicy', got %v", mw.finalized)
+	}
+
+	if len(mw.deserialized) != 1 || mw.deserialized[0] != "GetBucketPolicy" {
+		t.Errorf("Expected deserialized operation to be 'GetBucketPolicy', got %v", mw.deserialized)
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,21 +1,47 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package minio
 
 import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
+type recordedPhase struct {
+	method      string
+	bucketName  string
+	objectName  string
+	queryValues url.Values
+}
+
 type mockMiddleware struct {
 	mu           sync.Mutex
-	initialized  []string
-	serialized   []string
-	finalized    []string
-	deserialized []string
+	initialized  []recordedPhase
+	serialized   []recordedPhase
+	finalized    []recordedPhase
+	deserialized []recordedPhase
 }
 
 func (m *mockMiddleware) ID() string {
@@ -25,14 +51,14 @@ func (m *mockMiddleware) ID() string {
 func (m *mockMiddleware) Initialize(ctx context.Context, execCtx ExecutionContext) (context.Context, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.initialized = append(m.initialized, execCtx.Operation)
+	m.initialized = append(m.initialized, recordedPhase{method: execCtx.Method, bucketName: execCtx.BucketName, objectName: execCtx.ObjectName, queryValues: execCtx.QueryValues})
 	return ctx, nil
 }
 
 func (m *mockMiddleware) Serialize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.serialized = append(m.serialized, execCtx.Operation)
+	m.serialized = append(m.serialized, recordedPhase{method: execCtx.Method, bucketName: execCtx.BucketName, objectName: execCtx.ObjectName, queryValues: execCtx.QueryValues})
 	req.Header.Set("X-Mock-Header", "Hello")
 	return nil
 }
@@ -40,21 +66,19 @@ func (m *mockMiddleware) Serialize(ctx context.Context, execCtx ExecutionContext
 func (m *mockMiddleware) Finalize(ctx context.Context, execCtx ExecutionContext, req *http.Request) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.finalized = append(m.finalized, execCtx.Operation)
+	m.finalized = append(m.finalized, recordedPhase{method: execCtx.Method, bucketName: execCtx.BucketName, objectName: execCtx.ObjectName, queryValues: execCtx.QueryValues})
 	return nil
 }
 
-func (m *mockMiddleware) Deserialize(ctx context.Context, execCtx ExecutionContext, resp *http.Response, err error) error {
+func (m *mockMiddleware) Deserialize(ctx context.Context, execCtx ExecutionContext, resp *http.Response) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.deserialized = append(m.deserialized, execCtx.Operation)
+	m.deserialized = append(m.deserialized, recordedPhase{method: execCtx.Method, bucketName: execCtx.BucketName, objectName: execCtx.ObjectName, queryValues: execCtx.QueryValues})
 	return nil
 }
 
 func TestMiddlewareIntegration(t *testing.T) {
-	// Start local mock S3 server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify custom header was injected by Serialize middleware
 		if r.Header.Get("X-Mock-Header") != "Hello" {
 			t.Errorf("Expected X-Mock-Header: 'Hello', got '%s'", r.Header.Get("X-Mock-Header"))
 		}
@@ -64,38 +88,46 @@ func TestMiddlewareIntegration(t *testing.T) {
 
 	mw := &mockMiddleware{}
 
-	// Instantiate client with middleware options
-	client, err := New(server.URL[7:], &Options{
-		Creds:        credentials.NewStaticV4("mockkey", "mocksecret", ""),
-		Secure:       false,
-		Region:       "us-east-1",
-		Middlewares:  []Middleware{mw},
+	client, err := New(strings.TrimPrefix(server.URL, "http://"), &Options{
+		Creds:       credentials.NewStaticV4("mockkey", "mocksecret", ""),
+		Secure:      false,
+		Region:      "us-east-1",
+		Middlewares: []Middleware{mw},
 	})
 	if err != nil {
 		t.Fatalf("Failed to create minio client: %v", err)
 	}
 
-	// Make a GetBucketPolicy request (which uses executeMethod under the hood)
 	_, err = client.GetBucketPolicy(context.Background(), "mybucket")
-	// Since the mock server returns 200 OK but empty payload, GetBucketPolicy may return XML parsing error or nil, but HTTP request was triggered.
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 
 	mw.mu.Lock()
 	defer mw.mu.Unlock()
 
-	// Verify the S3 Operation was correctly resolved by resolveS3Operation (GetBucketPolicy)
-	if len(mw.initialized) != 1 || mw.initialized[0] != "GetBucketPolicy" {
-		t.Errorf("Expected initialized operation to be 'GetBucketPolicy', got %v", mw.initialized)
+	if len(mw.initialized) != 1 {
+		t.Fatalf("Expected 1 initialized call, got %d", len(mw.initialized))
+	}
+	if mw.initialized[0].method != "GET" {
+		t.Errorf("Expected method GET, got %s", mw.initialized[0].method)
+	}
+	if !mw.initialized[0].queryValues.Has("policy") {
+		t.Errorf("Expected queryValues to have 'policy', got %v", mw.initialized[0].queryValues)
 	}
 
-	if len(mw.serialized) != 1 || mw.serialized[0] != "GetBucketPolicy" {
-		t.Errorf("Expected serialized operation to be 'GetBucketPolicy', got %v", mw.serialized)
+	if len(mw.serialized) != 1 {
+		t.Fatalf("Expected 1 serialized call, got %d", len(mw.serialized))
+	}
+	if mw.serialized[0].method != "GET" {
+		t.Errorf("Expected method GET, got %s", mw.serialized[0].method)
 	}
 
-	if len(mw.finalized) != 1 || mw.finalized[0] != "GetBucketPolicy" {
-		t.Errorf("Expected finalized operation to be 'GetBucketPolicy', got %v", mw.finalized)
+	if len(mw.finalized) != 1 {
+		t.Fatalf("Expected 1 finalized call, got %d", len(mw.finalized))
 	}
 
-	if len(mw.deserialized) != 1 || mw.deserialized[0] != "GetBucketPolicy" {
-		t.Errorf("Expected deserialized operation to be 'GetBucketPolicy', got %v", mw.deserialized)
+	if len(mw.deserialized) != 1 {
+		t.Fatalf("Expected 1 deserialized call, got %d", len(mw.deserialized))
 	}
 }


### PR DESCRIPTION
## Summary

Adds a middleware pipeline to the minio-go client. You hook into
four phases: Initialize, Serialize, Finalize, Deserialize.

Pulled from AWS SDK's middleware.Stack. Same shape.

## Architecture

The pipeline lives inside `executeMethod()` and `newRequest()`.
No public API changes. Each middleware implements `Middleware`
(`ID() string`) plus one or more phase interfaces:

InitializeMiddleware  → Initialize(ctx, execCtx)
SerializeMiddleware   → Serialize(ctx, execCtx, req)
FinalizeMiddleware    → Finalize(ctx, execCtx, req)
DeserializeMiddleware → Deserialize(ctx, execCtx, resp, err)

`ExecutionContext` carries `Operation`, `BucketName`,
`ObjectName`. Scope middleware logic to specific S3 operations
(verify integrity on GetObject, skip on ListBuckets).

### Execution order

Initialize  (once, before retry loop)
retry loop
  Serialize    once per attempt, before signing
  Finalize     once per attempt, before do()
  do()
  Deserialize  once per attempt, after response

### Error handling

- Deserialize middleware errors stack with the transport error
  via `errors.Join`. Any error aborts the request, even on 2xx.
  Use this for response validation.
- Initialize, Serialize, and Finalize errors short-circuit.

## Why this instead of the old way

Before this, if you wanted custom headers, request logging, or
response verification, you had three options:

1. Wrap the whole client. Hundreds of methods to duplicate.
2. Swap `http.RoundTripper`. You lose bucket name, operation
   type, anything S3-specific.
3. Fork the SDK.



## Related

Prerequisite for #2246 (GetObject/FGetObject integrity verification).
The verifier will be a DeserializeMiddleware that wraps resp.Body
with a hash reader and checks against ETag or x-amz-checksum-*
headers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable client-side middleware for the S3/HTTP request lifecycle, with hooks for initialization, request serialization/signing, finalization, and response deserialization.
  * Middleware receives an execution context (HTTP method, bucket/object info, and query parameters); initialization can adjust the request context.
  * Middleware can be registered via client options or `AddMiddleware`.
* **Bug Fixes**
  * Deserialize middleware failures are now treated as request failures, even if the HTTP status indicates success.
* **Tests**
  * Added an integration test covering hook order, single invocation per call, execution context capture, and header injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->