### PR TITLE
feat: add SetCannedBucketPolicy

### DIFF
--- a/api-bucket-policy.go
+++ b/api-bucket-policy.go
@@ -28,16 +28,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
 
-// accessPerms - access level.
-type cannedAccessPerms string
-
-// different types of Access perm's currently supported by policy command.
-const (
-	CannedAccessReadOnly  = cannedAccessPerms("readonly")
-	CannedAccessWriteOnly = cannedAccessPerms("writeonly")
-	CannedAccessReadWrite = cannedAccessPerms("readwrite")
-)
-
 // SetCannedBucketPolicy sets a canned (predefined) access policy on a bucket.
 // This is a convenience method that translates predefined access levels
 // (readonly, writeonly, readwrite) into the corresponding bucket policy.
@@ -49,9 +39,9 @@ const (
 //   - access: Canned access level (CannedAccessReadOnly, CannedAccessWriteOnly, CannedAccessReadWrite)
 //
 // Returns an error if the operation fails.
-func (c *Client) SetCannedBucketPolicy(ctx context.Context, bucketName string, access cannedAccessPerms) error {
+func (c *Client) SetCannedBucketPolicy(ctx context.Context, bucketName string, bucketPolicy policy.BucketPolicy) error {
 	p := policy.BucketAccessPolicy{Version: "2012-10-17"}
-	p.Statements = policy.SetPolicy(p.Statements, policy.BucketPolicy(access), bucketName, "")
+	p.Statements = policy.SetPolicy(p.Statements, bucketPolicy, bucketName, "")
 	if len(p.Statements) == 0 {
 		return c.SetBucketPolicy(ctx, bucketName, "")
 	}

--- a/api-bucket-policy.go
+++ b/api-bucket-policy.go
@@ -36,7 +36,7 @@ import (
 // Parameters:
 //   - ctx: Context for request cancellation and timeout
 //   - bucketName: Name of the bucket
-//   - access: Canned access level (CannedAccessReadOnly, CannedAccessWriteOnly, CannedAccessReadWrite)
+//   - access: Canned access level (policy.BucketPolicyNone, policy.BucketPolicyReadOnly, policy.BucketPolicyWriteOnly, policy.BucketPolicyReadWrite)
 //
 // Returns an error if the operation fails.
 func (c *Client) SetCannedBucketPolicy(ctx context.Context, bucketName string, bucketPolicy policy.BucketPolicy) error {

--- a/api-bucket-policy.go
+++ b/api-bucket-policy.go
@@ -1,6 +1,6 @@
 /*
  * MinIO Go Library for Amazon S3 Compatible Cloud Storage
- * Copyright 2020 MinIO, Inc.
+ * Copyright 2026 MinIO, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,13 +18,49 @@ package minio
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/minio/minio-go/v7/pkg/policy"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
+
+// accessPerms - access level.
+type cannedAccessPerms string
+
+// different types of Access perm's currently supported by policy command.
+const (
+	CannedAccessReadOnly  = cannedAccessPerms("readonly")
+	CannedAccessWriteOnly = cannedAccessPerms("writeonly")
+	CannedAccessReadWrite = cannedAccessPerms("readwrite")
+)
+
+// SetCannedBucketPolicy sets a canned (predefined) access policy on a bucket.
+// This is a convenience method that translates predefined access levels
+// (readonly, writeonly, readwrite) into the corresponding bucket policy.
+// If access is empty or results in no policy statements, the existing bucket policy will be removed.
+//
+// Parameters:
+//   - ctx: Context for request cancellation and timeout
+//   - bucketName: Name of the bucket
+//   - access: Canned access level (CannedAccessReadOnly, CannedAccessWriteOnly, CannedAccessReadWrite)
+//
+// Returns an error if the operation fails.
+func (c *Client) SetCannedBucketPolicy(ctx context.Context, bucketName string, access cannedAccessPerms) error {
+	p := policy.BucketAccessPolicy{Version: "2012-10-17"}
+	p.Statements = policy.SetPolicy(p.Statements, policy.BucketPolicy(access), bucketName, "")
+	if len(p.Statements) == 0 {
+		return c.SetBucketPolicy(ctx, bucketName, "")
+	}
+	policyB, e := json.Marshal(p)
+	if e != nil {
+		return e
+	}
+	return c.SetBucketPolicy(ctx, bucketName, string(policyB))
+}
 
 // SetBucketPolicy sets the access permissions policy on an existing bucket.
 // The policy should be a valid JSON string that conforms to the IAM policy format.

--- a/api-bucket-policy.go
+++ b/api-bucket-policy.go
@@ -19,6 +19,7 @@ package minio
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -40,6 +41,9 @@ import (
 //
 // Returns an error if the operation fails.
 func (c *Client) SetCannedBucketPolicy(ctx context.Context, bucketName string, bucketPolicy policy.BucketPolicy) error {
+	if !bucketPolicy.IsValidBucketPolicy() {
+		return fmt.Errorf("invalid bucket policy %q", bucketPolicy)
+	}
 	p := policy.BucketAccessPolicy{Version: "2012-10-17"}
 	p.Statements = policy.SetPolicy(p.Statements, bucketPolicy, bucketName, "")
 	if len(p.Statements) == 0 {


### PR DESCRIPTION
feat: add SetCannedBucketPolicy
fix #1136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-step support for applying preset (canned) bucket access policies.
  * Automatically updates the bucket’s access policy based on the preset’s computed statements.
  * If the preset produces no statements, the existing bucket policy is cleared automatically.
  * Invalid presets and unexpected policy serialization issues now return errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->