### PR TITLE
fix: enable TraceOn will cause OOM when putting a large object

### DIFF
--- a/api.go
+++ b/api.go
@@ -567,7 +567,12 @@ func (c *Client) dumpHTTP(req *http.Request, resp *http.Response) error {
 		req.Header.Set("Authorization", redactSignature(origAuth))
 	}
 
-	// Only display request header.
+	//// Only display request header.
+	if req.Body != nil {
+		// httputil.DumpRequestOut call io.Copy(io.Discard, req.Body), then that would call the singer.getSigningKey.
+		// This is useless action.
+		req.Body = http.NoBody
+	}
 	reqTrace, err := httputil.DumpRequestOut(req, false)
 	if err != nil {
 		return err

--- a/api.go
+++ b/api.go
@@ -567,10 +567,8 @@ func (c *Client) dumpHTTP(req *http.Request, resp *http.Response) error {
 		req.Header.Set("Authorization", redactSignature(origAuth))
 	}
 
-	//// Only display request header.
+	// Only display request header.
 	if req.Body != nil {
-		// httputil.DumpRequestOut call io.Copy(io.Discard, req.Body), then that would call the singer.getSigningKey.
-		// This is useless action.
 		req.Body = http.NoBody
 	}
 	reqTrace, err := httputil.DumpRequestOut(req, false)

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,52 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"bytes"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestDumpHTTPLargeBodyDoesNotAllocate tests that dumpHTTP does not allocate
+func TestDumpHTTPLargeBodyDoesNotAllocate(t *testing.T) {
+	var trace bytes.Buffer
+	c := &Client{traceOutput: &trace, isTraceEnabled: true}
+	req, err := http.NewRequest(http.MethodPut, "http://example.com/bucket/object", strings.NewReader("x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.ContentLength = 1 << 30 // pretend a 1 GiB upload was sent
+	resp := &http.Response{StatusCode: http.StatusOK, Proto: "HTTP/1.1", ProtoMajor: 1, ProtoMinor: 1, Header: http.Header{}, Body: http.NoBody}
+
+	var m0, m1 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m0)
+	if err := c.dumpHTTP(req, resp); err != nil {
+		t.Fatal(err)
+	}
+	runtime.ReadMemStats(&m1)
+	if got := m1.TotalAlloc - m0.TotalAlloc; got > 64<<20 {
+		t.Fatalf("dumpHTTP allocated %d bytes for a 1 GiB Content-Length; the dump is buffering a body-sized dummy", got)
+	}
+	if !bytes.Contains(trace.Bytes(), []byte("PUT /bucket/object")) {
+		t.Fatal("trace output missing the request line")
+	}
+}


### PR DESCRIPTION
fix: enable TraceOn will cause OOM when putting a large object
fix #1771
before pr:
<img width="1355" height="384" alt="image" src="https://github.com/user-attachments/assets/8043328c-bbec-43a5-b2e3-e244ceaa0fcd" />
we can see max memory is 10GB and CPU is 100%
with this pr:
<img width="553" height="746" alt="image" src="https://github.com/user-attachments/assets/8e7b6cde-3dc9-47b5-8c92-f2e10411092a" />
we can see max memory is 26MB and CPU is 34%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved HTTP tracing to avoid handling/suspending large request bodies during trace output, ensuring trace logs focus on request headers without buffering upload-sized content.

* **Tests**
  * Added a regression test to confirm tracing with very large payloads keeps memory allocations under control and still includes the request line in the trace output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->