### PR TITLE
fix: treat HTTP 202 Accepted as success in executeMethod

### DIFF
--- a/api.go
+++ b/api.go
@@ -403,7 +403,7 @@ func (c *Client) TraceOff() {
 // SetS3TransferAccelerate - turns s3 accelerated endpoint on or off for all your
 // requests. This feature is only specific to S3 for all other endpoints this
 // function does nothing. To read further details on s3 transfer acceleration
-// please vist -
+// please visit -
 // http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html
 func (c *Client) SetS3TransferAccelerate(accelerateEndpoint string) {
 	if s3utils.IsAmazonEndpoint(*c.endpointURL) {
@@ -641,7 +641,7 @@ func (c *Client) do(req *http.Request) (resp *http.Response, err error) {
 	}
 
 	// If trace is enabled, dump http request and response,
-	// except when the traceErrorsOnly enabled and the response's status code is ok
+	// except when traceErrorsOnly is enabled and the response has a success status code
 	if c.isTraceEnabled && (!c.traceErrorsOnly || !successStatus.Contains(resp.StatusCode)) {
 		err = c.dumpHTTP(req, resp)
 		if err != nil {

--- a/api.go
+++ b/api.go
@@ -583,9 +583,7 @@ func (c *Client) dumpHTTP(req *http.Request, resp *http.Response) error {
 	var respTrace []byte
 
 	// For errors we make sure to dump response body as well.
-	if resp.StatusCode != http.StatusOK &&
-		resp.StatusCode != http.StatusPartialContent &&
-		resp.StatusCode != http.StatusNoContent {
+	if !successStatus.Contains(resp.StatusCode) {
 		respTrace, err = httputil.DumpResponse(resp, true)
 		if err != nil {
 			return err
@@ -644,7 +642,7 @@ func (c *Client) do(req *http.Request) (resp *http.Response, err error) {
 
 	// If trace is enabled, dump http request and response,
 	// except when the traceErrorsOnly enabled and the response's status code is ok
-	if c.isTraceEnabled && (!c.traceErrorsOnly || resp.StatusCode != http.StatusOK) {
+	if c.isTraceEnabled && (!c.traceErrorsOnly || !successStatus.Contains(resp.StatusCode)) {
 		err = c.dumpHTTP(req, resp)
 		if err != nil {
 			return nil, err
@@ -657,6 +655,7 @@ func (c *Client) do(req *http.Request) (resp *http.Response, err error) {
 // List of success status.
 var successStatus = set.CreateIntSet(
 	http.StatusOK,
+	http.StatusAccepted,
 	http.StatusNoContent,
 	http.StatusPartialContent,
 )

--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -18,12 +18,73 @@
 package minio
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/policy"
 )
+
+func TestSuccessStatusIncludesAccepted(t *testing.T) {
+	if !successStatus.Contains(http.StatusAccepted) {
+		t.Fatal("expected 202 Accepted to be treated as a successful response")
+	}
+}
+
+// TestRestoreObjectAccepts202 verifies that RestoreObject treats the
+// documented AWS success response for POST ?restore (202 Accepted, empty
+// body) as success, while a genuine error response still surfaces.
+// Regression test for https://github.com/minio/minio-go/issues/2223.
+func TestRestoreObjectAccepts202(t *testing.T) {
+	var restoreCalls int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Query().Has("restore") {
+			if atomic.AddInt64(&restoreCalls, 1) == 1 {
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>RestoreAlreadyInProgress</Code><Message>Object restore is already in progress</Message><Resource>/bkt/obj</Resource><RequestId>REQ</RequestId></Error>`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := New(u.Host, &Options{
+		Creds:  credentials.NewStaticV4("ak", "sk", ""),
+		Secure: false,
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := RestoreRequest{}
+	req.SetDays(1)
+
+	if err := c.RestoreObject(context.Background(), "bkt", "obj", "", req); err != nil {
+		t.Fatalf("first restore request: expected success on 202 Accepted, got: %v", err)
+	}
+	err = c.RestoreObject(context.Background(), "bkt", "obj", "", req)
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("second restore request: expected RestoreAlreadyInProgress error, got: %v", err)
+	}
+	if n := atomic.LoadInt64(&restoreCalls); n != 2 {
+		t.Fatalf("expected exactly 2 restore requests (no retries), server saw %d", n)
+	}
+}
 
 // Tests valid hosts for location.
 func TestValidBucketLocation(t *testing.T) {

--- a/api_unit_test.go
+++ b/api_unit_test.go
@@ -18,11 +18,11 @@
 package minio
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -78,11 +78,70 @@ func TestRestoreObjectAccepts202(t *testing.T) {
 		t.Fatalf("first restore request: expected success on 202 Accepted, got: %v", err)
 	}
 	err = c.RestoreObject(context.Background(), "bkt", "obj", "", req)
-	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+	if err == nil {
+		t.Fatal("second restore request: expected RestoreAlreadyInProgress error, got success")
+	}
+	errResp := ToErrorResponse(err)
+	if errResp.Code != "RestoreAlreadyInProgress" || errResp.StatusCode != http.StatusConflict {
 		t.Fatalf("second restore request: expected RestoreAlreadyInProgress error, got: %v", err)
 	}
 	if n := atomic.LoadInt64(&restoreCalls); n != 2 {
 		t.Fatalf("expected exactly 2 restore requests (no retries), server saw %d", n)
+	}
+}
+
+// TestTraceErrorsOnlySkipsSuccessStatuses verifies that errors-only tracing
+// suppresses every successStatus member (200, 202, 204, 206) uniformly and
+// still dumps a genuine error response.
+func TestTraceErrorsOnlySkipsSuccessStatuses(t *testing.T) {
+	var wantStatus int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(int(atomic.LoadInt32(&wantStatus)))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := New(u.Host, &Options{
+		Creds:  credentials.NewStaticV4("ak", "sk", ""),
+		Secure: false,
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	c.TraceErrorsOnlyOn(&buf)
+
+	doRequest := func(status int32) {
+		t.Helper()
+		atomic.StoreInt32(&wantStatus, status)
+		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.do(req)
+		if err != nil {
+			t.Fatalf("status %d: unexpected transport error: %v", status, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("status %d: closing response body: %v", status, err)
+		}
+	}
+
+	for _, code := range []int32{http.StatusOK, http.StatusAccepted, http.StatusNoContent, http.StatusPartialContent} {
+		doRequest(code)
+		if buf.Len() != 0 {
+			t.Fatalf("status %d: expected no trace output in errors-only mode, got %d bytes", code, buf.Len())
+		}
+	}
+
+	doRequest(http.StatusConflict)
+	if buf.Len() == 0 {
+		t.Fatal("status 409: expected error response to be traced in errors-only mode")
 	}
 }
 


### PR DESCRIPTION
## Description

- Add `http.StatusAccepted` to `successStatus` so `executeMethod` treats HTTP 202 as success instead of synthesizing an `ErrorResponse{Code: "202 Accepted"}` from the empty body.
- Unify `dumpHTTP` and the `traceErrorsOnly` check on `successStatus.Contains(...)`, removing two duplicated hardcoded status lists so the success definition is single-sourced.
- Behavior notes beyond the headline fix: (a) with `TraceErrorsOnly`, every success status (200/202/204/206) is now suppressed from the trace — previously only 200 was exempt, so successful 204 (e.g. DeleteObject) and 206 (ranged GET) responses were dumped as if they were errors; (b) in full trace mode, 202 response bodies are no longer dumped; (c) since `successStatus` is transport-wide, an unexpected 202 whose body is not an `<Error>` XML document now maps to a nil error inside `httpRespToErrorResponse`, exactly as already true for 204/206 — safe because every non-restore caller re-validates `resp.StatusCode` (see the 83-site audit below). `TestTraceErrorsOnlySkipsSuccessStatuses` pins (a).
- Assert the second-restore error via `ToErrorResponse(err).Code`/`StatusCode` (structured contract) rather than message text.
- Add `TestSuccessStatusIncludesAccepted`, `TestRestoreObjectAccepts202` (httptest replay of the exact wire exchange: 202 empty body, then 409 `RestoreAlreadyInProgress`, asserted via the structured `ToErrorResponse` contract), and `TestTraceErrorsOnlySkipsSuccessStatuses` (errors-only tracing suppresses every success status uniformly).

## Motivation and Context

- Fixes #2223: `RestoreObject` reports the documented AWS success response for `POST ?restore` (HTTP 202, [AWS RestoreObject API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html)) as a fatal error, so every successful restore initiation looks like a failure.
- The 200/202 acceptance check inside `RestoreObject` (api-restore.go, added by #1621) is dead code for real 202 responses because `executeMethod` errors out first.
- Supersedes #2227 (same fix, approved by @klauspost with all CI checks green, closed unmerged by its author).
- Real-world impact: restic has an open fix PR (restic/restic#5660) working around exactly this behavior downstream.

## How to test this PR?

### 1. Live AIStor server (Enterprise license) — real 202 on the wire

End-to-end against a real licensed AIStor deployment, not a mock. Setup: single-node AIStor (`DEVELOPMENT.2026-07-13`, AIStor Enterprise license) with a remote tier pointing to a second licensed AIStor deployment; an ILM transition rule moves an object to the tier; `RestoreObject` is then called twice. Per `PostRestoreObjectHandler` (`cmd/object-handlers.go`) the server returns **200** on the first (initiate) call and **202 Accepted** on a re-request of the already-restored object — the exact response #2223 mishandles.

The same repro built via a `replace` directive against this branch, toggling only `successStatus` between runs against the identical server and transitioned object:

| Step | Pre-fix client (`successStatus` without 202) | Fixed client (this PR) |
|---|---|---|
| CALL1 — initiate restore, server 200 | `err=<nil>` | `err=<nil>` |
| CALL2 — re-request already-restored object, server 202 | `err=202 Accepted` — success surfaced as a fatal error | `err=<nil>` |
| Verdict | `RESULT: BUG-PRESENT`, exit 1 | `RESULT: FIXED`, exit 0 |

### 2. httptest wire replay (AWS restore semantics)

Deterministic mock replaying the AWS exchange: first `POST ?restore` → 202 empty body, second → 409 `RestoreAlreadyInProgress` XML; client calls `RestoreObject` twice.

| Check | Pre-fix (`master` @ ccfaaed, same on v7.2.1) | With this PR |
|---|---|---|
| First `RestoreObject` (server sent 202 Accepted, empty body) | `err=202 Accepted` — success misreported as failure | `err=<nil>` |
| Second `RestoreObject` (server sent 409 RestoreAlreadyInProgress) | `err=Object restore is already in progress` (correct) | `err=Object restore is already in progress` (unchanged) |
| Restore POSTs seen by server across the two calls | 2 (no retry storm — 202 is not retried, single hard error) | 2 (no retry introduced) |

### 3. Test suite and lint

| Validation | Command | Result |
|---|---|---|
| New regression tests, race detector, 3 iterations | `go test -race -count=3 -run 'TestSuccessStatusIncludesAccepted\|TestRestoreObjectAccepts202\|TestTraceErrorsOnlySkipsSuccessStatuses' -v .` | 9/9 PASS (3× all three tests) |
| Full unit suite with race detector | `go test -short -race ./...` | 12 packages ok, 0 failures |
| Lint | `golangci-lint run --config ./.golangci.yml` | 0 issues |
| Side-effect audit | all 83 non-test `executeMethod` call sites classified for post-call status handling | no caller depends on 202-as-error; sole no-check site (`RemoveBucketLifecycle` DELETE) would treat a hypothetical 202 as harmless success (spec response there is 204) |

To reproduce locally: run the two new tests in `api_unit_test.go`, or point `RestoreObject` at any endpoint returning 202 for `POST ?restore` (checkout of this branch → `err=nil`; master → `err=202 Accepted`).

## Cross-server validation summary (AIStor master + community MinIO master)

Reproduced independently against two live servers with a two-node tiering setup (primary + remote tier, versioned bucket, ILM transition, first restore via `mc`, second restore via the SDK), toggling only `successStatus` between a pre-fix and fixed client build:

| Server | Re-restore wire status | Pre-fix client | Fixed client (this PR) |
|---|---|---|---|
| AIStor master (dev 2026-07-16, licensed) | **202 Accepted** | `err="202 Accepted"` (bug) | `err=<nil>` ✓ |
| Community MinIO master (`7aac2a2`, built from source) | 200 OK | `err=<nil>` | `err=<nil>` |

- AIStor emits the real 202 that #2223 mishandles; the fixed client accepts it while the pre-fix client surfaces it as a fatal error — the bug reproduced end-to-end on a real server, not a mock.
- Community MinIO master returns 200 for the same re-restore, so that run confirms no regression on the 200 path; its 202 branch (`cmd/object-handlers.go`) is exercised by the httptest replay in section 2.
- Both server responses flow through the same patched `executeMethod`; the fix is server-agnostic.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/miniohq/aistor-object-store-docs/issues/new)
- [x] No internode changes / version interoperability introduced




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of successful HTTP responses, including 202 Accepted.
  * Restore operations now correctly recognize successful asynchronous responses and report when restoration is already in progress.
  * HTTP tracing and response diagnostics now consistently distinguish successful responses from errors.
  * Corrected a documentation typo related to S3 transfer acceleration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->