### PR TITLE
fix: disable retries for non-seekable PutObject readers

### DIFF
--- a/hook-reader.go
+++ b/hook-reader.go
@@ -27,7 +27,7 @@ import (
 // notified about the exact number of bytes read from the primary
 // source on each Read operation. It deliberately implements neither
 // io.Seeker nor io.Closer: retry logic treats a seekable body as
-// rewindable, and the transport layer closes bodies that implement
+// rewindable, and executeMethod closes request bodies that implement
 // io.Closer — a caller-supplied reader must be shielded from both.
 type hookReader struct {
 	source io.Reader
@@ -41,18 +41,13 @@ type hookReader struct {
 // retrying over a drained reader.
 type hookReadSeeker struct {
 	hookReader
+	seeker io.Seeker
 }
 
 // Seek implements io.Seeker. Seeks source first, and if necessary
 // seeks hook if Seek method is appropriately found.
 func (hr *hookReadSeeker) Seek(offset int64, whence int) (n int64, err error) {
-	sourceSeeker, ok := hr.source.(io.Seeker)
-	if !ok {
-		// Unreachable by construction: newHook only builds a
-		// hookReadSeeker around a seekable source.
-		return 0, fmt.Errorf("source reader %T is not seekable", hr.source)
-	}
-	n, err = sourceSeeker.Seek(offset, whence)
+	n, err = hr.seeker.Seek(offset, whence)
 	if err != nil {
 		return 0, err
 	}
@@ -99,8 +94,8 @@ func (hr *hookReader) Read(b []byte) (n int, err error) {
 // when the source does.
 func newHook(source, hook io.Reader) io.Reader {
 	hr := hookReader{source: source, hook: hook}
-	if _, ok := source.(io.Seeker); ok {
-		return &hookReadSeeker{hookReader: hr}
+	if seeker, ok := source.(io.Seeker); ok {
+		return &hookReadSeeker{hookReader: hr, seeker: seeker}
 	}
 	return &hr
 }

--- a/hook-reader.go
+++ b/hook-reader.go
@@ -25,22 +25,36 @@ import (
 // hookReader hooks additional reader in the source stream. It is
 // useful for making progress bars. Second reader is appropriately
 // notified about the exact number of bytes read from the primary
-// source on each Read operation.
+// source on each Read operation. It deliberately implements neither
+// io.Seeker nor io.Closer: retry logic treats a seekable body as
+// rewindable, and the transport layer closes bodies that implement
+// io.Closer — a caller-supplied reader must be shielded from both.
 type hookReader struct {
 	source io.Reader
 	hook   io.Reader
 }
 
+// hookReadSeeker extends hookReader with seeking support. It is
+// constructed only when the source implements io.Seeker, so a wrapped
+// reader exposes Seek if and only if it can actually rewind. This lets
+// retry logic disable retries for non-seekable bodies instead of
+// retrying over a drained reader.
+type hookReadSeeker struct {
+	hookReader
+}
+
 // Seek implements io.Seeker. Seeks source first, and if necessary
 // seeks hook if Seek method is appropriately found.
-func (hr *hookReader) Seek(offset int64, whence int) (n int64, err error) {
-	// Verify for source has embedded Seeker, use it.
+func (hr *hookReadSeeker) Seek(offset int64, whence int) (n int64, err error) {
 	sourceSeeker, ok := hr.source.(io.Seeker)
-	if ok {
-		n, err = sourceSeeker.Seek(offset, whence)
-		if err != nil {
-			return 0, err
-		}
+	if !ok {
+		// Unreachable by construction: newHook only builds a
+		// hookReadSeeker around a seekable source.
+		return 0, fmt.Errorf("source reader %T is not seekable", hr.source)
+	}
+	n, err = sourceSeeker.Seek(offset, whence)
+	if err != nil {
+		return 0, err
 	}
 
 	if hr.hook != nil {
@@ -53,7 +67,7 @@ func (hr *hookReader) Seek(offset int64, whence int) (n int64, err error) {
 				return 0, err
 			}
 			if n != m {
-				return 0, fmt.Errorf("hook seeker seeked %d bytes, expected source %d bytes", m, n)
+				return 0, fmt.Errorf("hook seeker sought %d bytes, expected source %d bytes", m, n)
 			}
 		}
 	}
@@ -80,14 +94,13 @@ func (hr *hookReader) Read(b []byte) (n int, err error) {
 	return n, err
 }
 
-// newHook returns a io.ReadSeeker which implements hookReader that
-// reports the data read from the source to the hook.
+// newHook returns an io.Reader which implements hookReader that
+// reports the data read from the source to the hook. The returned
+// reader implements io.Seeker only when the source does.
 func newHook(source, hook io.Reader) io.Reader {
-	if hook == nil {
-		return &hookReader{source: source}
+	hr := hookReader{source: source, hook: hook}
+	if _, ok := source.(io.Seeker); ok {
+		return &hookReadSeeker{hookReader: hr}
 	}
-	return &hookReader{
-		source: source,
-		hook:   hook,
-	}
+	return &hr
 }

--- a/hook-reader.go
+++ b/hook-reader.go
@@ -67,7 +67,7 @@ func (hr *hookReadSeeker) Seek(offset int64, whence int) (n int64, err error) {
 				return 0, err
 			}
 			if n != m {
-				return 0, fmt.Errorf("hook seeker sought %d bytes, expected source %d bytes", m, n)
+				return 0, fmt.Errorf("hook seeker sought to offset %d, expected source offset %d", m, n)
 			}
 		}
 	}
@@ -94,9 +94,9 @@ func (hr *hookReader) Read(b []byte) (n int, err error) {
 	return n, err
 }
 
-// newHook returns an io.Reader which implements hookReader that
-// reports the data read from the source to the hook. The returned
-// reader implements io.Seeker only when the source does.
+// newHook returns an io.Reader that reports the data read from the
+// source to the hook. The returned reader implements io.Seeker only
+// when the source does.
 func newHook(source, hook io.Reader) io.Reader {
 	hr := hookReader{source: source, hook: hook}
 	if _, ok := source.(io.Seeker); ok {

--- a/hook-reader_test.go
+++ b/hook-reader_test.go
@@ -20,6 +20,7 @@ package minio
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -103,6 +104,78 @@ func TestHookReadSeekerSeek(t *testing.T) {
 	}
 }
 
+// TestHookReadSeekerSeekNonSeekableHook verifies Seek succeeds when the
+// source is seekable but the hook is not: the hook sync is skipped
+// rather than failing the seek. Progress readers are plain io.Readers,
+// so this is the shape a retried upload with a progress bar takes.
+func TestHookReadSeekerSeekNonSeekableHook(t *testing.T) {
+	payload := []byte("0123456789")
+	source := bytes.NewReader(payload)
+	hook := bytes.NewBuffer(nil)
+
+	rs, ok := newHook(source, hook).(io.ReadSeeker)
+	if !ok {
+		t.Fatal("newHook over a seekable source must return an io.ReadSeeker")
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(rs, buf); err != nil {
+		t.Fatal(err)
+	}
+	n, err := rs.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatalf("Seek with a non-seekable hook: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("Seek returned %d, want 0", n)
+	}
+	if _, err := io.ReadFull(rs, buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf); got != "0123" {
+		t.Fatalf("read after seek = %q, want %q", got, "0123")
+	}
+}
+
+// stubSeeker is a ReadSeeker whose Seek reports a fixed offset and
+// error, for driving the error paths of hookReadSeeker.Seek.
+type stubSeeker struct {
+	off int64
+	err error
+}
+
+func (s *stubSeeker) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (s *stubSeeker) Seek(int64, int) (int64, error) { return s.off, s.err }
+
+// TestHookReadSeekerSeekErrors pins the error paths of Seek: a
+// directly-constructed wrapper over a non-seekable source errors
+// instead of panicking, a failing source seek propagates, and a hook
+// offset diverging from the source is reported.
+func TestHookReadSeekerSeekErrors(t *testing.T) {
+	t.Run("non-seekable source errors", func(t *testing.T) {
+		hr := &hookReadSeeker{hookReader{source: bytes.NewBuffer(nil)}}
+		if _, err := hr.Seek(0, io.SeekStart); err == nil {
+			t.Fatal("Seek over a non-seekable source must error, not panic")
+		}
+	})
+	t.Run("source seek failure propagates", func(t *testing.T) {
+		wantErr := errors.New("seek failed")
+		hr := &hookReadSeeker{hookReader{source: &stubSeeker{err: wantErr}}}
+		n, err := hr.Seek(0, io.SeekStart)
+		if !errors.Is(err, wantErr) || n != 0 {
+			t.Fatalf("Seek = (%d, %v), want (0, %v)", n, err, wantErr)
+		}
+	})
+	t.Run("hook offset mismatch is reported", func(t *testing.T) {
+		source := bytes.NewReader([]byte("0123456789"))
+		hr := &hookReadSeeker{hookReader{source: source, hook: &stubSeeker{off: 5}}}
+		_, err := hr.Seek(2, io.SeekStart)
+		if err == nil || !strings.Contains(err.Error(), "hook seeker sought to offset 5, expected source offset 2") {
+			t.Fatalf("want offset-mismatch error, got %v", err)
+		}
+	})
+}
+
 // TestPutObjectRetryNonSeekable verifies retry behavior around
 // retryable server errors: a non-seekable body must be sent exactly
 // once and surface the server's error, while a seekable body is
@@ -181,10 +254,16 @@ func TestPutObjectRetryNonSeekable(t *testing.T) {
 		if len(got) != 2 {
 			t.Fatalf("seekable body sent %d times %v, want 2 attempts", len(got), got)
 		}
+		// The wire body carries aws-chunked signature framing on top
+		// of the payload, so assert a lower bound plus an identical
+		// resend rather than exact payload length.
 		for i, n := range got {
-			if n == 0 {
-				t.Fatalf("attempt %d sent an empty body", i+1)
+			if n < len(payload) {
+				t.Fatalf("attempt %d sent %d body bytes, want at least %d", i+1, n, len(payload))
 			}
+		}
+		if got[0] != got[1] {
+			t.Fatalf("retry sent %d body bytes, first attempt sent %d; retry must resend the identical body", got[1], got[0])
 		}
 	})
 

--- a/hook-reader_test.go
+++ b/hook-reader_test.go
@@ -147,20 +147,16 @@ func (s *stubSeeker) Read([]byte) (int, error) { return 0, io.EOF }
 
 func (s *stubSeeker) Seek(int64, int) (int64, error) { return s.off, s.err }
 
-// TestHookReadSeekerSeekErrors pins the error paths of Seek: a
-// directly-constructed wrapper over a non-seekable source errors
-// instead of panicking, a failing source seek propagates, and a hook
-// offset diverging from the source is reported.
+// TestHookReadSeekerSeekErrors pins the error paths of Seek: a failing
+// source seek propagates, and a hook offset diverging from the source
+// is reported.
 func TestHookReadSeekerSeekErrors(t *testing.T) {
-	t.Run("non-seekable source errors", func(t *testing.T) {
-		hr := &hookReadSeeker{hookReader{source: bytes.NewBuffer(nil)}}
-		if _, err := hr.Seek(0, io.SeekStart); err == nil {
-			t.Fatal("Seek over a non-seekable source must error, not panic")
-		}
-	})
 	t.Run("source seek failure propagates", func(t *testing.T) {
 		wantErr := errors.New("seek failed")
-		hr := &hookReadSeeker{hookReader{source: &stubSeeker{err: wantErr}}}
+		hr, ok := newHook(&stubSeeker{err: wantErr}, nil).(io.Seeker)
+		if !ok {
+			t.Fatal("newHook over a seekable source must return an io.Seeker")
+		}
 		n, err := hr.Seek(0, io.SeekStart)
 		if !errors.Is(err, wantErr) || n != 0 {
 			t.Fatalf("Seek = (%d, %v), want (0, %v)", n, err, wantErr)
@@ -168,7 +164,10 @@ func TestHookReadSeekerSeekErrors(t *testing.T) {
 	})
 	t.Run("hook offset mismatch is reported", func(t *testing.T) {
 		source := bytes.NewReader([]byte("0123456789"))
-		hr := &hookReadSeeker{hookReader{source: source, hook: &stubSeeker{off: 5}}}
+		hr, ok := newHook(source, &stubSeeker{off: 5}).(io.Seeker)
+		if !ok {
+			t.Fatal("newHook over a seekable source must return an io.Seeker")
+		}
 		_, err := hr.Seek(2, io.SeekStart)
 		if err == nil || !strings.Contains(err.Error(), "hook seeker sought to offset 5, expected source offset 2") {
 			t.Fatalf("want offset-mismatch error, got %v", err)

--- a/hook-reader_test.go
+++ b/hook-reader_test.go
@@ -1,0 +1,207 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// TestNewHookSeekability verifies that the reader returned by newHook
+// implements io.Seeker if and only if the source does, and never
+// implements io.Closer. Regression test for
+// https://github.com/minio/minio-go/issues/2078: a fake Seek on a
+// non-seekable source silently defeated executeMethod's no-retry path
+// and caused empty-body retries.
+func TestNewHookSeekability(t *testing.T) {
+	payload := []byte("hello world")
+	progress := bytes.NewBuffer(nil)
+
+	tests := []struct {
+		name       string
+		source     io.Reader
+		hook       io.Reader
+		wantSeeker bool
+	}{
+		{"non-seekable source, nil hook", bytes.NewBuffer(payload), nil, false},
+		{"non-seekable source, with hook", bytes.NewBuffer(payload), progress, false},
+		{"seekable source, nil hook", bytes.NewReader(payload), nil, true},
+		{"seekable source, with hook", bytes.NewReader(payload), progress, true},
+		{"non-seekable ReadCloser source", io.NopCloser(bytes.NewReader(payload)), nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newHook(tt.source, tt.hook)
+			if _, ok := r.(io.Seeker); ok != tt.wantSeeker {
+				t.Errorf("newHook(%T, %T) seekable = %v, want %v", tt.source, tt.hook, ok, tt.wantSeeker)
+			}
+			// The wrapper must never expose Close: executeMethod
+			// closes io.Closer bodies, and a caller-supplied reader
+			// must not be closed by the SDK.
+			if _, ok := r.(io.Closer); ok {
+				t.Errorf("newHook(%T, %T) implements io.Closer, must not", tt.source, tt.hook)
+			}
+		})
+	}
+}
+
+// TestHookReadSeekerSeek verifies seeking still works on a seekable
+// source and keeps a seekable hook in sync.
+func TestHookReadSeekerSeek(t *testing.T) {
+	payload := []byte("0123456789")
+	source := bytes.NewReader(payload)
+	hook := bytes.NewReader(payload)
+
+	rs, ok := newHook(source, hook).(io.ReadSeeker)
+	if !ok {
+		t.Fatal("newHook over a seekable source must return an io.ReadSeeker")
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(rs, buf); err != nil {
+		t.Fatal(err)
+	}
+	n, err := rs.Seek(2, io.SeekStart)
+	if err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("Seek returned %d, want 2", n)
+	}
+	if _, err = io.ReadFull(rs, buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf); got != "2345" {
+		t.Fatalf("read after seek = %q, want %q", got, "2345")
+	}
+	if m, _ := hook.Seek(0, io.SeekCurrent); m != 6 {
+		t.Fatalf("hook position = %d, want 6", m)
+	}
+}
+
+// TestPutObjectRetryNonSeekable verifies retry behavior around
+// retryable server errors: a non-seekable body must be sent exactly
+// once and surface the server's error, while a seekable body is
+// retried with the full body. Regression test for
+// https://github.com/minio/minio-go/issues/2078.
+func TestPutObjectRetryNonSeekable(t *testing.T) {
+	var mu sync.Mutex
+	attempts := make(map[string][]int) // object -> body bytes per attempt
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		attempts[r.URL.Path] = append(attempts[r.URL.Path], len(body))
+		first := len(attempts[r.URL.Path]) == 1
+		mu.Unlock()
+		if first {
+			// Retryable error on the first attempt for each object.
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message></Error>`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	srv, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := New(srv.Host, &Options{
+		Creds:  credentials.NewStaticV4("accesskey", "secretkey", ""),
+		Secure: false,
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := bytes.Repeat([]byte("x"), 1024)
+	size := int64(len(payload))
+
+	t.Run("non-seekable body fails fast with the server error", func(t *testing.T) {
+		_, err := client.PutObject(context.Background(), "bucket", "non-seekable",
+			bytes.NewBuffer(payload), size, PutObjectOptions{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if errResp := ToErrorResponse(err); errResp.Code != "SlowDown" {
+			t.Fatalf("expected the server's SlowDown error, got %v", err)
+		}
+		if strings.Contains(err.Error(), "ContentLength") {
+			t.Fatalf("transport error leaked instead of server error: %v", err)
+		}
+		mu.Lock()
+		got := attempts["/bucket/non-seekable"]
+		mu.Unlock()
+		if len(got) != 1 {
+			t.Fatalf("non-seekable body sent %d times %v, want exactly 1 attempt", len(got), got)
+		}
+	})
+
+	t.Run("seekable body retries with the full body", func(t *testing.T) {
+		_, err := client.PutObject(context.Background(), "bucket", "seekable",
+			bytes.NewReader(payload), size, PutObjectOptions{})
+		if err != nil {
+			t.Fatalf("expected retry to succeed, got %v", err)
+		}
+		mu.Lock()
+		got := attempts["/bucket/seekable"]
+		mu.Unlock()
+		if len(got) != 2 {
+			t.Fatalf("seekable body sent %d times %v, want 2 attempts", len(got), got)
+		}
+		for i, n := range got {
+			if n == 0 {
+				t.Fatalf("attempt %d sent an empty body", i+1)
+			}
+		}
+	})
+
+	t.Run("non-seekable body with progress hook fails fast", func(t *testing.T) {
+		_, err := client.PutObject(context.Background(), "bucket", "non-seekable-progress",
+			bytes.NewBuffer(payload), size, PutObjectOptions{Progress: bytes.NewBuffer(nil)})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if errResp := ToErrorResponse(err); errResp.Code != "SlowDown" {
+			t.Fatalf("expected the server's SlowDown error, got %v", err)
+		}
+		mu.Lock()
+		got := attempts["/bucket/non-seekable-progress"]
+		mu.Unlock()
+		if len(got) != 1 {
+			t.Fatalf("non-seekable body sent %d times %v, want exactly 1 attempt", len(got), got)
+		}
+	})
+}


### PR DESCRIPTION
## Description

Fixes #2078. `PutObject` with a non-seekable `io.Reader` (e.g. `*bytes.Buffer`) retried after a retryable server error with an empty body, exhausting all 10 attempts and returning `http: ContentLength=N with Body length 0` instead of the server's real error.

- Root cause: `newHook` wrapped every source in `hookReader`, whose `Seek` silently returned `(0, nil)` for non-seekable sources, so `executeMethod`'s non-seekable ⇒ single-attempt gate (`api.go`) never fired and each retry re-sent a drained reader.
- Fix: split the wrapper into `hookReader` (Read only) and `hookReadSeeker` (embeds `hookReader` + `Seek`); `newHook` returns the seeker variant only when the source implements `io.Seeker`, so the retry gate now sees the truth.
- Neither wrapper implements `io.Closer`, so caller-supplied readers are still shielded from the transport's body close (#2137 behavior preserved).
- Progress-hook accounting and all seekable-source behavior are unchanged; all 9 `newHook` call sites audited, none degrades.

## Motivation and Context

A non-seekable upload that hit a transient error (e.g. 503 SlowDown) burned ~10 doomed retries and surfaced a cryptic transport error that hid the actual server response, misleading users and hammering servers with empty-body requests (see grafana/mimir#10952 for a downstream workaround this makes unnecessary).

## How to test this PR?

Side-by-side repro: httptest server returns `503 SlowDown` on the first PUT per object key, then 200; harness records per-attempt `Content-Length` and received body bytes. Identical client code run against base `ccfaaed` (master) and this branch via a `replace` directive, payload 1198 bytes.

| Case | master (`ccfaaed`) — failing | this PR — fixed |
|---|---|---|
| `bytes.Buffer` (non-seekable) | 10 attempts; attempts 2–10 sent **0 body bytes** (server read `unexpected EOF`); returns `http: ContentLength=1198 with Body length 0`; the 503 SlowDown is never surfaced | **1 attempt, full body**; returns the server's `SlowDown` ErrorResponse |
| `bytes.NewReader` (seekable) | 2 attempts, both full body; succeeds | unchanged: 2 attempts, both full body; succeeds |
| `bytes.Buffer` + `SendContentMd5: true` | 2 attempts; succeeds (buffering masks the bug) | unchanged: 2 attempts; succeeds |

Tests and gates run on this branch:

- New regression tests: `go test -race -count=1 -v -run 'TestNewHookSeekability|TestHookReadSeekerSeek|TestPutObjectRetryNonSeekable' .` — PASS ×3 iterations (16 PASS lines each; the `-run` pattern also matches the two newer test functions). Covers: `newHook` seekability matrix (incl. `io.NopCloser` source and a guard that the wrapper never implements `io.Closer`), Seek + progress-hook parity (including a non-seekable progress hook, and all three Seek error paths), and the retry behavior table above (non-seekable ⇒ exactly 1 attempt + `SlowDown` code asserted; seekable ⇒ 2 attempts each carrying the full identical body — asserted as a lower bound plus cross-attempt equality, since the wire body includes aws-chunked signature framing; non-seekable with `Progress` set ⇒ 1 attempt).
- `go test -short -race -count=1 ./...` — all packages ok (root package 57s).
- `make lint` — 0 issues; `gofumpt -l` clean; `typos` clean.

### Live-server validation (AIStor and MinIO community)

Beyond the httptest mock, the fix was validated end-to-end against real servers — both licensed AIStor (ENTERPRISE-PLUS license) and MinIO community — with the SDK built from this branch driven through a fault-injecting reverse proxy in front of each server (first PUT per object key answered `503 SlowDown` without forwarding; every other request forwarded verbatim with the Host header preserved so the V4 signature stays valid), recording per-attempt `Content-Length` and body bytes on the wire.

| Target | Result |
|---|---|
| AIStor `DEVELOPMENT.2026-07-08T16-17-04Z` (licensed, Edition: AIStor) | 15/15 checks pass |
| AIStor built from master `85ddefac` on 2026-07-17 (licensed, Edition: AIStor) | 15/15 checks pass |
| MinIO community built from master `7aac2a2c` | 15/15 checks pass |

Checks per target:

- Fault-injection through the proxy: seekable reader retries with a byte-identical full body and succeeds; non-seekable reader makes **exactly 1 attempt** and surfaces the server's real `SlowDown` `ErrorResponse` (never the `ContentLength=N with Body length 0` transport error); non-seekable + `SendContentMd5` retries successfully (SDK buffers to hash, so the request body is seekable) with a full body.
- Direct happy path (no proxy): non-seekable uploads at 1 KiB (single PUT), 20 MiB (multipart), and unknown size (streaming) all succeed, with downloaded content verified by SHA-256 against the original payload in every case, including the objects stored via post-fault retries.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload retry behavior using request body seekability: non-seekable bodies are sent once and fail fast; seekable bodies are retried with an identical wire body.
  * Updated seeking so the reader only exposes `Seek` when the underlying source is seekable, and keeps hook/source offsets synchronized when the hook is also seekable.
  * Enhanced error reporting for seek failures and offset mismatches.
* **Tests**
  * Added coverage for seekability detection, hook/source synchronization behavior, seek error propagation, and `PutObject` retry semantics (including progress hooks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->