### PR TITLE
fix: always emit Filter or Prefix in lifecycle rule XML

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -267,10 +267,6 @@ func (f Filter) MarshalJSON() ([]byte, error) {
 // MarshalXML - produces the xml representation of the Filter struct
 // only one of Prefix, And and Tag should be present in the output.
 func (f Filter) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	if f.IsNull() {
-		return nil
-	}
-
 	if err := e.EncodeToken(start); err != nil {
 		return err
 	}
@@ -506,6 +502,50 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(newr)
+}
+
+// MarshalXML customizes marshal XML and ensures that <Filter/> is present if Prefix is empty.
+func (r Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	// If both Filter and Prefix are empty, we need to emit an empty <Filter/> element.
+	if r.RuleFilter.IsNull() {
+		type ruleWrapper struct {
+			XMLName                        xml.Name                       `xml:"Rule,omitempty"`
+			AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
+			Expiration                     Expiration                     `xml:"Expiration,omitempty"`
+			DelMarkerExpiration            DelMarkerExpiration            `xml:"DelMarkerExpiration,omitempty"`
+			AllVersionsExpiration          AllVersionsExpiration          `xml:"AllVersionsExpiration,omitempty"`
+			ID                             string                         `xml:"ID"`
+			RuleFilter                     *Filter                        `xml:"Filter,omitempty"`
+			NoncurrentVersionExpiration    NoncurrentVersionExpiration    `xml:"NoncurrentVersionExpiration,omitempty"`
+			NoncurrentVersionTransition    NoncurrentVersionTransition    `xml:"NoncurrentVersionTransition,omitempty"`
+			Prefix                         string                         `xml:"Prefix,omitempty"`
+			Status                         string                         `xml:"Status"`
+			Transition                     Transition                     `xml:"Transition,omitempty"`
+		}
+
+		w := ruleWrapper{
+			AbortIncompleteMultipartUpload: r.AbortIncompleteMultipartUpload,
+			Expiration:                     r.Expiration,
+			DelMarkerExpiration:            r.DelMarkerExpiration,
+			AllVersionsExpiration:          r.AllVersionsExpiration,
+			ID:                             r.ID,
+			NoncurrentVersionExpiration:    r.NoncurrentVersionExpiration,
+			NoncurrentVersionTransition:    r.NoncurrentVersionTransition,
+			Prefix:                         r.Prefix,
+			Status:                         r.Status,
+			Transition:                     r.Transition,
+		}
+		if r.Prefix == "" {
+			// will be explicitly marshaled as empty <Filter/>
+			w.RuleFilter = &r.RuleFilter
+		}
+
+		return e.EncodeElement(w, start)
+	}
+
+	// Default XML marshal for Rule (uses struct tags as defined).
+	type ruleAlias Rule
+	return e.EncodeElement(ruleAlias(r), start)
 }
 
 // Rule represents a single rule in lifecycle configuration

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -508,8 +508,10 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 
 // ruleWrapper mirrors Rule field-for-field, with RuleFilter as a pointer so
 // Rule.MarshalXML controls whether the Filter element is emitted; a field
-// added to Rule but not here would be silently dropped for rules without a
-// Filter.
+// added to Rule but not here — or added here but not assigned in the
+// Rule.MarshalXML literal — would be silently dropped for rules without a
+// Filter. TestRuleWrapperFieldParity guards the mirror and
+// TestRuleWrapperCopyCompleteness guards the copy.
 type ruleWrapper struct {
 	XMLName                        xml.Name                       `xml:"Rule,omitempty"`
 	AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -506,29 +506,31 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 	return json.Marshal(newr)
 }
 
+// ruleWrapper mirrors Rule field-for-field, with RuleFilter as a pointer so
+// Rule.MarshalXML controls whether the Filter element is emitted; a field
+// added to Rule but not here would be silently dropped for rules without a
+// Filter.
+type ruleWrapper struct {
+	XMLName                        xml.Name                       `xml:"Rule,omitempty"`
+	AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
+	Expiration                     Expiration                     `xml:"Expiration,omitempty"`
+	DelMarkerExpiration            DelMarkerExpiration            `xml:"DelMarkerExpiration,omitempty"`
+	AllVersionsExpiration          AllVersionsExpiration          `xml:"AllVersionsExpiration,omitempty"`
+	ID                             string                         `xml:"ID"`
+	RuleFilter                     *Filter                        `xml:"Filter,omitempty"`
+	NoncurrentVersionExpiration    NoncurrentVersionExpiration    `xml:"NoncurrentVersionExpiration,omitempty"`
+	NoncurrentVersionTransition    NoncurrentVersionTransition    `xml:"NoncurrentVersionTransition,omitempty"`
+	Prefix                         string                         `xml:"Prefix,omitempty"`
+	Status                         string                         `xml:"Status"`
+	Transition                     Transition                     `xml:"Transition,omitempty"`
+}
+
 // MarshalXML customizes XML encoding of Rule: a rule with neither Filter nor
 // Prefix set emits an empty <Filter><Prefix></Prefix></Filter>, which the S3
 // specification requires when no Prefix element is present; a rule with only
 // a top-level Prefix omits the Filter element entirely.
 func (r Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if r.RuleFilter.IsNull() {
-		// ruleWrapper must mirror Rule field-for-field; a field added to Rule
-		// but not here would be silently dropped for rules without a Filter.
-		type ruleWrapper struct {
-			XMLName                        xml.Name                       `xml:"Rule,omitempty"`
-			AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
-			Expiration                     Expiration                     `xml:"Expiration,omitempty"`
-			DelMarkerExpiration            DelMarkerExpiration            `xml:"DelMarkerExpiration,omitempty"`
-			AllVersionsExpiration          AllVersionsExpiration          `xml:"AllVersionsExpiration,omitempty"`
-			ID                             string                         `xml:"ID"`
-			RuleFilter                     *Filter                        `xml:"Filter,omitempty"`
-			NoncurrentVersionExpiration    NoncurrentVersionExpiration    `xml:"NoncurrentVersionExpiration,omitempty"`
-			NoncurrentVersionTransition    NoncurrentVersionTransition    `xml:"NoncurrentVersionTransition,omitempty"`
-			Prefix                         string                         `xml:"Prefix,omitempty"`
-			Status                         string                         `xml:"Status"`
-			Transition                     Transition                     `xml:"Transition,omitempty"`
-		}
-
 		w := ruleWrapper{
 			AbortIncompleteMultipartUpload: r.AbortIncompleteMultipartUpload,
 			Expiration:                     r.Expiration,
@@ -542,14 +544,14 @@ func (r Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 			Transition:                     r.Transition,
 		}
 		if r.Prefix == "" {
-			// marshaled as <Filter><Prefix></Prefix></Filter>
 			w.RuleFilter = &r.RuleFilter
 		}
 
 		return e.EncodeElement(w, start)
 	}
 
-	// Default XML marshal for Rule (uses struct tags as defined).
+	// ruleAlias drops Rule's methods so EncodeElement falls back to the
+	// default struct-tag encoding.
 	type ruleAlias Rule
 	return e.EncodeElement(ruleAlias(r), start)
 }

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -266,6 +266,8 @@ func (f Filter) MarshalJSON() ([]byte, error) {
 
 // MarshalXML - produces the xml representation of the Filter struct
 // only one of Prefix, And and Tag should be present in the output.
+// A zero-value Filter marshals as <Filter><Prefix></Prefix></Filter>;
+// Rule.MarshalXML decides whether the element is emitted at all.
 func (f Filter) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if err := e.EncodeToken(start); err != nil {
 		return err
@@ -504,10 +506,14 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 	return json.Marshal(newr)
 }
 
-// MarshalXML customizes marshal XML and ensures that <Filter/> is present if Prefix is empty.
+// MarshalXML customizes XML encoding of Rule: a rule with neither Filter nor
+// Prefix set emits an empty <Filter><Prefix></Prefix></Filter>, which the S3
+// specification requires when no Prefix element is present; a rule with only
+// a top-level Prefix omits the Filter element entirely.
 func (r Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	// If both Filter and Prefix are empty, we need to emit an empty <Filter/> element.
 	if r.RuleFilter.IsNull() {
+		// ruleWrapper must mirror Rule field-for-field; a field added to Rule
+		// but not here would be silently dropped for rules without a Filter.
 		type ruleWrapper struct {
 			XMLName                        xml.Name                       `xml:"Rule,omitempty"`
 			AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
@@ -536,7 +542,7 @@ func (r Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 			Transition:                     r.Transition,
 		}
 		if r.Prefix == "" {
-			// will be explicitly marshaled as empty <Filter/>
+			// marshaled as <Filter><Prefix></Prefix></Filter>
 			w.RuleFilter = &r.RuleFilter
 		}
 

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -265,9 +265,10 @@ func (f Filter) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalXML - produces the xml representation of the Filter struct
-// only one of Prefix, And and Tag should be present in the output.
+// at most one of Prefix, And, Tag, ObjectSizeGreaterThan and
+// ObjectSizeLessThan is present in the output.
 // A zero-value Filter marshals as <Filter><Prefix></Prefix></Filter>;
-// Rule.MarshalXML decides whether the element is emitted at all.
+// suppressing the element entirely is the caller's responsibility.
 func (f Filter) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if err := e.EncodeToken(start); err != nil {
 		return err
@@ -515,17 +516,18 @@ type ruleAlias Rule
 // depth-based field shadowing suppresses the deeper field, so <Filter> is
 // emitted only through this pointer: nil omits the element, a set pointer
 // emits it (empty) as the last child of <Rule>.
-// TestRuleWrapperCopyCompleteness guards both the shadowing and the
-// completeness of the embedded encoding.
 type ruleWrapper struct {
 	ruleAlias
 	RuleFilter *Filter `xml:"Filter,omitempty"`
 }
 
 // MarshalXML customizes XML encoding of Rule: a rule with neither Filter nor
-// Prefix set emits an empty <Filter><Prefix></Prefix></Filter>, which the S3
-// specification requires when no Prefix element is present; a rule with only
-// a top-level Prefix omits the Filter element entirely.
+// Prefix set emits an empty <Filter><Prefix></Prefix></Filter> as the last
+// child of <Rule> — S3 requires a Filter when no Prefix element is present;
+// the empty <Prefix> child is this library's representation of an empty
+// filter. A rule with only a top-level Prefix omits the Filter element; a
+// non-null Filter marshals through the default encoding in its declared
+// field position. MarshalJSON is unaffected and still omits a null Filter.
 func (r Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if !r.RuleFilter.IsNull() {
 		return e.EncodeElement(ruleAlias(r), start)

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -506,25 +506,20 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 	return json.Marshal(newr)
 }
 
-// ruleWrapper mirrors Rule field-for-field, with RuleFilter as a pointer so
-// Rule.MarshalXML controls whether the Filter element is emitted; a field
-// added to Rule but not here — or added here but not assigned in the
-// Rule.MarshalXML literal — would be silently dropped for rules without a
-// Filter. TestRuleWrapperFieldParity guards the mirror and
-// TestRuleWrapperCopyCompleteness guards the copy.
+// ruleAlias drops Rule's methods so EncodeElement falls back to the default
+// struct-tag encoding.
+type ruleAlias Rule
+
+// ruleWrapper embeds ruleAlias, so it needs no updating when Rule gains a
+// field. Its RuleFilter is shallower than the embedded one, and encoding/xml's
+// depth-based field shadowing suppresses the deeper field, so <Filter> is
+// emitted only through this pointer: nil omits the element, a set pointer
+// emits it (empty) as the last child of <Rule>.
+// TestRuleWrapperCopyCompleteness guards both the shadowing and the
+// completeness of the embedded encoding.
 type ruleWrapper struct {
-	XMLName                        xml.Name                       `xml:"Rule,omitempty"`
-	AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
-	Expiration                     Expiration                     `xml:"Expiration,omitempty"`
-	DelMarkerExpiration            DelMarkerExpiration            `xml:"DelMarkerExpiration,omitempty"`
-	AllVersionsExpiration          AllVersionsExpiration          `xml:"AllVersionsExpiration,omitempty"`
-	ID                             string                         `xml:"ID"`
-	RuleFilter                     *Filter                        `xml:"Filter,omitempty"`
-	NoncurrentVersionExpiration    NoncurrentVersionExpiration    `xml:"NoncurrentVersionExpiration,omitempty"`
-	NoncurrentVersionTransition    NoncurrentVersionTransition    `xml:"NoncurrentVersionTransition,omitempty"`
-	Prefix                         string                         `xml:"Prefix,omitempty"`
-	Status                         string                         `xml:"Status"`
-	Transition                     Transition                     `xml:"Transition,omitempty"`
+	ruleAlias
+	RuleFilter *Filter `xml:"Filter,omitempty"`
 }
 
 // MarshalXML customizes XML encoding of Rule: a rule with neither Filter nor
@@ -532,30 +527,15 @@ type ruleWrapper struct {
 // specification requires when no Prefix element is present; a rule with only
 // a top-level Prefix omits the Filter element entirely.
 func (r Rule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	if r.RuleFilter.IsNull() {
-		w := ruleWrapper{
-			AbortIncompleteMultipartUpload: r.AbortIncompleteMultipartUpload,
-			Expiration:                     r.Expiration,
-			DelMarkerExpiration:            r.DelMarkerExpiration,
-			AllVersionsExpiration:          r.AllVersionsExpiration,
-			ID:                             r.ID,
-			NoncurrentVersionExpiration:    r.NoncurrentVersionExpiration,
-			NoncurrentVersionTransition:    r.NoncurrentVersionTransition,
-			Prefix:                         r.Prefix,
-			Status:                         r.Status,
-			Transition:                     r.Transition,
-		}
-		if r.Prefix == "" {
-			w.RuleFilter = &r.RuleFilter
-		}
-
-		return e.EncodeElement(w, start)
+	if !r.RuleFilter.IsNull() {
+		return e.EncodeElement(ruleAlias(r), start)
 	}
 
-	// ruleAlias drops Rule's methods so EncodeElement falls back to the
-	// default struct-tag encoding.
-	type ruleAlias Rule
-	return e.EncodeElement(ruleAlias(r), start)
+	w := ruleWrapper{ruleAlias: ruleAlias(r)}
+	if r.Prefix == "" {
+		w.RuleFilter = &w.ruleAlias.RuleFilter
+	}
+	return e.EncodeElement(w, start)
 }
 
 // Rule represents a single rule in lifecycle configuration

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -528,7 +528,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-1</ID><Prefix>my_dir</Prefix><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
-			testDescription: "Ensure we always export Filter or Prefix. Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
+			testDescription: "Ensure we always export Filter or Prefix (via zero-value RuleFilter). Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
 			input: Configuration{
 				Rules: []Rule{
 					{
@@ -544,7 +544,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-2</ID><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
-			testDescription: "Ensure we always export Filter or Prefix. Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
+			testDescription: "Ensure we always export Filter or Prefix (via empty top-level Prefix). Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
 			input: Configuration{
 				Rules: []Rule{
 					{
@@ -557,15 +557,64 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			},
 			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-3</ID><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
+		{
+			testDescription: "Ensure a non-empty Filter marshals through the default path unchanged",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:     "expire-incomplete-uploads-4",
+						Status: "Enabled",
+						RuleFilter: Filter{
+							Prefix: "logs/",
+						},
+						AbortIncompleteMultipartUpload: AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-4</ID><Filter><Prefix>logs/</Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
+		{
+			testDescription: "Ensure every Rule field survives the empty-Filter marshal path",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:                             "expire-full",
+						Status:                         "Enabled",
+						AbortIncompleteMultipartUpload: AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
+						Expiration:                     Expiration{Days: 30},
+						DelMarkerExpiration:            DelMarkerExpiration{Days: 7},
+						AllVersionsExpiration:          AllVersionsExpiration{Days: 10},
+						NoncurrentVersionExpiration:    NoncurrentVersionExpiration{NoncurrentDays: 5},
+						NoncurrentVersionTransition:    NoncurrentVersionTransition{NoncurrentDays: 3, StorageClass: "GLACIER"},
+						Transition:                     Transition{Days: 60, StorageClass: "GLACIER"},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><Expiration><Days>30</Days></Expiration><DelMarkerExpiration><Days>7</Days></DelMarkerExpiration><AllVersionsExpiration><Days>10</Days></AllVersionsExpiration><ID>expire-full</ID><Filter><Prefix></Prefix></Filter><NoncurrentVersionExpiration><NoncurrentDays>5</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><StorageClass>GLACIER</StorageClass><NoncurrentDays>3</NoncurrentDays></NoncurrentVersionTransition><Status>Enabled</Status><Transition><StorageClass>GLACIER</StorageClass><Days>60</Days></Transition></Rule></LifecycleConfiguration>",
+		},
+		{
+			testDescription: "Ensure a size-only Filter marshals its size condition",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:         "expire-large",
+						Status:     "Enabled",
+						RuleFilter: Filter{ObjectSizeGreaterThan: 1048576},
+						Expiration: Expiration{Days: 30},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>expire-large</ID><Filter><ObjectSizeGreaterThan>1048576</ObjectSizeGreaterThan></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
 	}
 
 	for i, tc := range testCases {
 		xmlBytes, err := xml.Marshal(tc.input)
 		if err != nil {
-			t.Fatalf("%d: could not marshal the Configuration: %#v, %v", i+1, tc.input, err)
+			t.Fatalf("%d (%s): could not marshal the Configuration: %#v, %v", i+1, tc.testDescription, tc.input, err)
 		}
 		if string(xmlBytes) != tc.expectedXMLOut {
-			t.Fatalf("test: %s failed\nexpected: %s\ngot:      %s", tc.testDescription, tc.expectedXMLOut, string(xmlBytes))
+			t.Fatalf("%d (%s): failed\nexpected: %s\ngot:      %s", i+1, tc.testDescription, tc.expectedXMLOut, string(xmlBytes))
 		}
 	}
 }

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -505,3 +505,70 @@ func TestAllVersionsExpiration(t *testing.T) {
 		t.Fatalf("Expected %s but got %s", expected, got)
 	}
 }
+
+// TestLifecycleMarshalXML for cases where XML output needs to be well-formed
+func TestLifecycleMarshalXML(t *testing.T) {
+	testCases := []struct {
+		testDescription string
+		input           Configuration
+		expectedXMLOut  string
+	}{
+		{
+			testDescription: "Ensure Filter is missing if Prefix is present - in order to support server implementations that ignore Prefix if Filter is present",
+			input: Configuration{
+				Rules: []Rule{
+					{
+
+						ID:                             "expire-incomplete-uploads-1",
+						Status:                         "Enabled",
+						Prefix:                         "my_dir",
+						AbortIncompleteMultipartUpload: AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-1</ID><Prefix>my_dir</Prefix><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
+		{
+			testDescription: "Ensure we always export Filter or Prefix. Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:     "expire-incomplete-uploads-2",
+						Status: "Enabled",
+						RuleFilter: Filter{
+							Prefix: "",
+						},
+						AbortIncompleteMultipartUpload: AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
+					},
+				},
+			},
+			// this is wrong fixed behavior fixed in a following commit
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-2</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
+		{
+			testDescription: "Ensure we always export Filter or Prefix. Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:                             "expire-incomplete-uploads-3",
+						Status:                         "Enabled",
+						Prefix:                         "",
+						AbortIncompleteMultipartUpload: AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
+					},
+				},
+			},
+			// this is wrong fixed behavior fixed in a following commit
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-3</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
+	}
+
+	for i, tc := range testCases {
+		xmlBytes, err := xml.Marshal(tc.input)
+		if err != nil {
+			t.Fatalf("%d: could not marshal the Configuration: %#v, %v", i+1, tc.input, err)
+		}
+		if string(xmlBytes) != tc.expectedXMLOut {
+			t.Fatalf("test: %s failed\nexpected: %s\ngot:      %s", tc.testDescription, tc.expectedXMLOut, string(xmlBytes))
+		}
+	}
+}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -636,6 +636,11 @@ func TestLifecycleMarshalXML(t *testing.T) {
 // to cannot be suppressed by an omitempty tag or an isNull-style check.
 func fillNonZero(t *testing.T, v reflect.Value) {
 	t.Helper()
+	// Unexported fields cannot be set and are invisible to xml.Marshal, so
+	// they need no exercising.
+	if !v.CanSet() {
+		return
+	}
 	switch v.Kind() {
 	case reflect.String:
 		v.SetString("x")

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -530,7 +530,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-1</ID><Prefix>my_dir</Prefix><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
-			testDescription: "Ensure we always export Filter or Prefix when both are empty (a zero-value RuleFilter and an empty top-level Prefix are the same zero Rule value). Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
+			testDescription: "Ensure an empty Filter is emitted when both RuleFilter and Prefix are unset. Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
 			input: Configuration{
 				Rules: []Rule{
 					{
@@ -620,6 +620,21 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>expire-tagged</ID><Filter><Tag><Key>env</Key><Value>prod</Value></Tag></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
+			testDescription: "Ensure a rule carrying both a top-level Prefix and a non-empty Filter emits both elements through the default path",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:         "both-set",
+						Status:     "Enabled",
+						Prefix:     "abc/",
+						RuleFilter: Filter{Prefix: "data/"},
+						Expiration: Expiration{Days: 30},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>both-set</ID><Filter><Prefix>data/</Prefix></Filter><Prefix>abc/</Prefix><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
+		{
 			testDescription: "Ensure an And Filter marshals its combined conditions",
 			input: Configuration{
 				Rules: []Rule{
@@ -646,6 +661,19 @@ func TestLifecycleMarshalXML(t *testing.T) {
 	}
 }
 
+// TestFilterMarshalXMLEmpty pins the standalone contract that a zero-value
+// Filter marshals as an explicit empty element rather than nothing.
+func TestFilterMarshalXMLEmpty(t *testing.T) {
+	got, err := xml.Marshal(Filter{})
+	if err != nil {
+		t.Fatalf("could not marshal a zero-value Filter: %v", err)
+	}
+	const want = "<Filter><Prefix></Prefix></Filter>"
+	if string(got) != want {
+		t.Fatalf("zero-value Filter marshal\nexpected: %s\ngot:      %s", want, string(got))
+	}
+}
+
 // fillNonZero recursively sets v to a non-zero value so the field it belongs
 // to cannot be suppressed by an omitempty tag or an isNull-style check.
 func fillNonZero(t *testing.T, v reflect.Value) {
@@ -662,8 +690,6 @@ func fillNonZero(t *testing.T, v reflect.Value) {
 		v.SetBool(true)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v.SetInt(1)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		v.SetUint(1)
 	case reflect.Struct:
 		switch v.Type() {
 		case reflect.TypeOf(time.Time{}):
@@ -677,23 +703,17 @@ func fillNonZero(t *testing.T, v reflect.Value) {
 		for i := range v.NumField() {
 			fillNonZero(t, v.Field(i))
 		}
-	case reflect.Slice:
-		elem := reflect.New(v.Type().Elem()).Elem()
-		fillNonZero(t, elem)
-		v.Set(reflect.Append(v, elem))
 	default:
 		t.Fatalf("fillNonZero: extend for unsupported kind %v (%v)", v.Kind(), v.Type())
 	}
 }
 
 // TestRuleWrapperCopyCompleteness fills every Rule field except XMLName and
-// RuleFilter (kept null so Rule.MarshalXML takes the wrapper path) with a
-// non-zero value, then requires the wrapper-path output to match the default
-// struct-tag encoding: with Prefix set the null Filter must vanish, and with
-// Prefix empty exactly one empty Filter must be emitted, as the last child of
-// Rule. This pins encoding/xml's depth-based shadowing of the embedded
-// RuleFilter — if the wrapper's shallower pointer ever stopped shadowing it,
-// the Filter would be dropped, doubled, or misplaced here.
+// RuleFilter (kept null so the wrapper path runs), then requires the
+// wrapper-path output to match the default struct-tag encoding. This pins
+// encoding/xml's depth-based shadowing of the embedded RuleFilter: if the
+// shallower pointer ever stopped shadowing it, the Filter would be dropped,
+// doubled, or misplaced here.
 func TestRuleWrapperCopyCompleteness(t *testing.T) {
 	var r Rule
 	rv := reflect.ValueOf(&r).Elem()

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -547,7 +547,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			input: Configuration{
 				Rules: []Rule{
 					{
-						ID:     "expire-incomplete-uploads-4",
+						ID:     "expire-incomplete-uploads-3",
 						Status: "Enabled",
 						RuleFilter: Filter{
 							Prefix: "logs/",
@@ -556,7 +556,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 					},
 				},
 			},
-			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-4</ID><Filter><Prefix>logs/</Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-3</ID><Filter><Prefix>logs/</Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
 			testDescription: "Ensure every Rule field survives the empty-Filter marshal path",
@@ -590,6 +590,20 @@ func TestLifecycleMarshalXML(t *testing.T) {
 				},
 			},
 			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>expire-large</ID><Filter><ObjectSizeGreaterThan>1048576</ObjectSizeGreaterThan></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
+		{
+			testDescription: "Ensure an ObjectSizeLessThan-only Filter marshals its size condition",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:         "expire-small",
+						Status:     "Enabled",
+						RuleFilter: Filter{ObjectSizeLessThan: 1024},
+						Expiration: Expiration{Days: 30},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>expire-small</ID><Filter><ObjectSizeLessThan>1024</ObjectSizeLessThan></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
 			testDescription: "Ensure a tag-only Filter marshals its tag condition",

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -518,7 +518,6 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			input: Configuration{
 				Rules: []Rule{
 					{
-
 						ID:                             "expire-incomplete-uploads-1",
 						Status:                         "Enabled",
 						Prefix:                         "my_dir",
@@ -542,8 +541,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 					},
 				},
 			},
-			// this is wrong fixed behavior fixed in a following commit
-			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-2</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-2</ID><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
 			testDescription: "Ensure we always export Filter or Prefix. Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
@@ -557,8 +555,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 					},
 				},
 			},
-			// this is wrong fixed behavior fixed in a following commit
-			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-3</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-3</ID><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 	}
 

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -646,8 +646,13 @@ func fillNonZero(t *testing.T, v reflect.Value) {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		v.SetUint(1)
 	case reflect.Struct:
-		if v.Type() == reflect.TypeOf(time.Time{}) {
+		switch v.Type() {
+		case reflect.TypeOf(time.Time{}):
 			v.Set(reflect.ValueOf(time.Date(2026, time.July, 21, 0, 0, 0, 0, time.UTC)))
+			return
+		case reflect.TypeOf(xml.Name{}):
+			// XMLName is element metadata, not data; filling it would
+			// rename elements instead of exercising field emission.
 			return
 		}
 		for i := range v.NumField() {
@@ -697,7 +702,11 @@ func TestRuleWrapperCopyCompleteness(t *testing.T) {
 	// The default encoding emits the null Filter as
 	// <Filter><Prefix></Prefix></Filter>; the wrapper path omits the element
 	// entirely because Prefix is non-empty. Everything else must match.
-	wantStr := strings.Replace(string(want), "<Filter><Prefix></Prefix></Filter>", "", 1)
+	const nullFilter = "<Filter><Prefix></Prefix></Filter>"
+	if !strings.Contains(string(want), nullFilter) {
+		t.Fatalf("default encoding no longer emits a null Filter as %s; update this test\ngot: %s", nullFilter, string(want))
+	}
+	wantStr := strings.Replace(string(want), nullFilter, "", 1)
 	if string(got) != wantStr {
 		t.Fatalf("wrapper path dropped or altered a field\nexpected: %s\ngot:      %s", wantStr, string(got))
 	}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -628,6 +629,77 @@ func TestLifecycleMarshalXML(t *testing.T) {
 		if string(xmlBytes) != tc.expectedXMLOut {
 			t.Fatalf("%d (%s): failed\nexpected: %s\ngot:      %s", i+1, tc.testDescription, tc.expectedXMLOut, string(xmlBytes))
 		}
+	}
+}
+
+// fillNonZero recursively sets v to a non-zero value so the field it belongs
+// to cannot be suppressed by an omitempty tag or an isNull-style check.
+func fillNonZero(t *testing.T, v reflect.Value) {
+	t.Helper()
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString("x")
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(1)
+	case reflect.Struct:
+		if v.Type() == reflect.TypeOf(time.Time{}) {
+			v.Set(reflect.ValueOf(time.Date(2026, time.July, 21, 0, 0, 0, 0, time.UTC)))
+			return
+		}
+		for i := range v.NumField() {
+			fillNonZero(t, v.Field(i))
+		}
+	case reflect.Slice:
+		elem := reflect.New(v.Type().Elem()).Elem()
+		fillNonZero(t, elem)
+		v.Set(reflect.Append(v, elem))
+	default:
+		t.Fatalf("fillNonZero: extend for unsupported kind %v (%v)", v.Kind(), v.Type())
+	}
+}
+
+// TestRuleWrapperCopyCompleteness fills every Rule field except XMLName and
+// RuleFilter (kept null so Rule.MarshalXML takes the wrapper path) with a
+// non-zero value, then requires the wrapper-path output to match the default
+// struct-tag encoding. A field assignment forgotten in the ruleWrapper
+// literal inside Rule.MarshalXML would be zero-valued and omitted there,
+// which TestRuleWrapperFieldParity alone cannot catch.
+func TestRuleWrapperCopyCompleteness(t *testing.T) {
+	var r Rule
+	rv := reflect.ValueOf(&r).Elem()
+	for i := range rv.NumField() {
+		switch rv.Type().Field(i).Name {
+		case "XMLName", "RuleFilter":
+			continue
+		}
+		fillNonZero(t, rv.Field(i))
+	}
+
+	got, err := xml.Marshal(Configuration{Rules: []Rule{r}})
+	if err != nil {
+		t.Fatalf("could not marshal Rule through the wrapper path: %v", err)
+	}
+
+	type ruleAlias Rule
+	type aliasConfiguration struct {
+		XMLName xml.Name    `xml:"LifecycleConfiguration"`
+		Rules   []ruleAlias `xml:"Rule"`
+	}
+	want, err := xml.Marshal(aliasConfiguration{Rules: []ruleAlias{ruleAlias(r)}})
+	if err != nil {
+		t.Fatalf("could not marshal Rule through the default encoding: %v", err)
+	}
+
+	// The default encoding emits the null Filter as
+	// <Filter><Prefix></Prefix></Filter>; the wrapper path omits the element
+	// entirely because Prefix is non-empty. Everything else must match.
+	wantStr := strings.Replace(string(want), "<Filter><Prefix></Prefix></Filter>", "", 1)
+	if string(got) != wantStr {
+		t.Fatalf("wrapper path dropped or altered a field\nexpected: %s\ngot:      %s", wantStr, string(got))
 	}
 }
 

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -528,34 +529,17 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-1</ID><Prefix>my_dir</Prefix><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
-			testDescription: "Ensure we always export Filter or Prefix (via zero-value RuleFilter). Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
+			testDescription: "Ensure we always export Filter or Prefix when both are empty (a zero-value RuleFilter and an empty top-level Prefix are the same zero Rule value). Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
 			input: Configuration{
 				Rules: []Rule{
 					{
-						ID:     "expire-incomplete-uploads-2",
-						Status: "Enabled",
-						RuleFilter: Filter{
-							Prefix: "",
-						},
+						ID:                             "expire-incomplete-uploads-2",
+						Status:                         "Enabled",
 						AbortIncompleteMultipartUpload: AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
 					},
 				},
 			},
 			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-2</ID><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
-		},
-		{
-			testDescription: "Ensure we always export Filter or Prefix (via empty top-level Prefix). Specification explicitly mentions: 'Filter is required if the LifecycleRule does not contain a Prefix element.' (https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html)",
-			input: Configuration{
-				Rules: []Rule{
-					{
-						ID:                             "expire-incomplete-uploads-3",
-						Status:                         "Enabled",
-						Prefix:                         "",
-						AbortIncompleteMultipartUpload: AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
-					},
-				},
-			},
-			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-3</ID><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
 		{
 			testDescription: "Ensure a non-empty Filter marshals through the default path unchanged",
@@ -606,6 +590,34 @@ func TestLifecycleMarshalXML(t *testing.T) {
 			},
 			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>expire-large</ID><Filter><ObjectSizeGreaterThan>1048576</ObjectSizeGreaterThan></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
 		},
+		{
+			testDescription: "Ensure a tag-only Filter marshals its tag condition",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:         "expire-tagged",
+						Status:     "Enabled",
+						RuleFilter: Filter{Tag: Tag{Key: "env", Value: "prod"}},
+						Expiration: Expiration{Days: 30},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>expire-tagged</ID><Filter><Tag><Key>env</Key><Value>prod</Value></Tag></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
+		{
+			testDescription: "Ensure an And Filter marshals its combined conditions",
+			input: Configuration{
+				Rules: []Rule{
+					{
+						ID:         "expire-and",
+						Status:     "Enabled",
+						RuleFilter: Filter{And: And{Prefix: "docs/", Tags: []Tag{{Key: "env", Value: "prod"}}}},
+						Expiration: Expiration{Days: 30},
+					},
+				},
+			},
+			expectedXMLOut: "<LifecycleConfiguration><Rule><Expiration><Days>30</Days></Expiration><ID>expire-and</ID><Filter><And><Prefix>docs/</Prefix><Tag><Key>env</Key><Value>prod</Value></Tag></And></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+		},
 	}
 
 	for i, tc := range testCases {
@@ -615,6 +627,33 @@ func TestLifecycleMarshalXML(t *testing.T) {
 		}
 		if string(xmlBytes) != tc.expectedXMLOut {
 			t.Fatalf("%d (%s): failed\nexpected: %s\ngot:      %s", i+1, tc.testDescription, tc.expectedXMLOut, string(xmlBytes))
+		}
+	}
+}
+
+// TestRuleWrapperFieldParity asserts ruleWrapper stays a field-for-field
+// mirror of Rule, so Rule.MarshalXML cannot silently drop a field added to
+// Rule but not to the wrapper.
+func TestRuleWrapperFieldParity(t *testing.T) {
+	rt := reflect.TypeOf(Rule{})
+	wt := reflect.TypeOf(ruleWrapper{})
+	if rt.NumField() != wt.NumField() {
+		t.Fatalf("Rule has %d fields, ruleWrapper has %d", rt.NumField(), wt.NumField())
+	}
+	for i := range rt.NumField() {
+		rf, wf := rt.Field(i), wt.Field(i)
+		if rf.Name != wf.Name {
+			t.Fatalf("field %d: Rule has %q, ruleWrapper has %q", i, rf.Name, wf.Name)
+		}
+		if rXML, wXML := rf.Tag.Get("xml"), wf.Tag.Get("xml"); rXML != wXML {
+			t.Fatalf("field %s: Rule xml tag %q, ruleWrapper xml tag %q", rf.Name, rXML, wXML)
+		}
+		wantType := rf.Type
+		if rf.Name == "RuleFilter" {
+			wantType = reflect.PointerTo(rf.Type)
+		}
+		if wf.Type != wantType {
+			t.Fatalf("field %s: Rule type %v, ruleWrapper type %v (want %v)", rf.Name, rf.Type, wf.Type, wantType)
 		}
 	}
 }

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -540,7 +540,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 					},
 				},
 			},
-			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-2</ID><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule></LifecycleConfiguration>",
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><ID>expire-incomplete-uploads-2</ID><Status>Enabled</Status><Filter><Prefix></Prefix></Filter></Rule></LifecycleConfiguration>",
 		},
 		{
 			testDescription: "Ensure a non-empty Filter marshals through the default path unchanged",
@@ -575,7 +575,7 @@ func TestLifecycleMarshalXML(t *testing.T) {
 					},
 				},
 			},
-			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><Expiration><Days>30</Days></Expiration><DelMarkerExpiration><Days>7</Days></DelMarkerExpiration><AllVersionsExpiration><Days>10</Days></AllVersionsExpiration><ID>expire-full</ID><Filter><Prefix></Prefix></Filter><NoncurrentVersionExpiration><NoncurrentDays>5</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><StorageClass>GLACIER</StorageClass><NoncurrentDays>3</NoncurrentDays></NoncurrentVersionTransition><Status>Enabled</Status><Transition><StorageClass>GLACIER</StorageClass><Days>60</Days></Transition></Rule></LifecycleConfiguration>",
+			expectedXMLOut: "<LifecycleConfiguration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload><Expiration><Days>30</Days></Expiration><DelMarkerExpiration><Days>7</Days></DelMarkerExpiration><AllVersionsExpiration><Days>10</Days></AllVersionsExpiration><ID>expire-full</ID><NoncurrentVersionExpiration><NoncurrentDays>5</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><StorageClass>GLACIER</StorageClass><NoncurrentDays>3</NoncurrentDays></NoncurrentVersionTransition><Status>Enabled</Status><Transition><StorageClass>GLACIER</StorageClass><Days>60</Days></Transition><Filter><Prefix></Prefix></Filter></Rule></LifecycleConfiguration>",
 		},
 		{
 			testDescription: "Ensure a size-only Filter marshals its size condition",
@@ -689,9 +689,11 @@ func fillNonZero(t *testing.T, v reflect.Value) {
 // TestRuleWrapperCopyCompleteness fills every Rule field except XMLName and
 // RuleFilter (kept null so Rule.MarshalXML takes the wrapper path) with a
 // non-zero value, then requires the wrapper-path output to match the default
-// struct-tag encoding. A field assignment forgotten in the ruleWrapper
-// literal inside Rule.MarshalXML would be zero-valued and omitted there,
-// which TestRuleWrapperFieldParity alone cannot catch.
+// struct-tag encoding: with Prefix set the null Filter must vanish, and with
+// Prefix empty exactly one empty Filter must be emitted, as the last child of
+// Rule. This pins encoding/xml's depth-based shadowing of the embedded
+// RuleFilter — if the wrapper's shallower pointer ever stopped shadowing it,
+// the Filter would be dropped, doubled, or misplaced here.
 func TestRuleWrapperCopyCompleteness(t *testing.T) {
 	var r Rule
 	rv := reflect.ValueOf(&r).Elem()
@@ -703,57 +705,46 @@ func TestRuleWrapperCopyCompleteness(t *testing.T) {
 		fillNonZero(t, rv.Field(i))
 	}
 
-	got, err := xml.Marshal(Configuration{Rules: []Rule{r}})
-	if err != nil {
-		t.Fatalf("could not marshal Rule through the wrapper path: %v", err)
-	}
-
-	type ruleAlias Rule
 	type aliasConfiguration struct {
 		XMLName xml.Name    `xml:"LifecycleConfiguration"`
 		Rules   []ruleAlias `xml:"Rule"`
 	}
-	want, err := xml.Marshal(aliasConfiguration{Rules: []ruleAlias{ruleAlias(r)}})
-	if err != nil {
-		t.Fatalf("could not marshal Rule through the default encoding: %v", err)
-	}
-
-	// The default encoding emits the null Filter as
-	// <Filter><Prefix></Prefix></Filter>; the wrapper path omits the element
-	// entirely because Prefix is non-empty. Everything else must match.
 	const nullFilter = "<Filter><Prefix></Prefix></Filter>"
-	if !strings.Contains(string(want), nullFilter) {
-		t.Fatalf("default encoding no longer emits a null Filter as %s; update this test\ngot: %s", nullFilter, string(want))
-	}
-	wantStr := strings.Replace(string(want), nullFilter, "", 1)
-	if string(got) != wantStr {
-		t.Fatalf("wrapper path dropped or altered a field\nexpected: %s\ngot:      %s", wantStr, string(got))
-	}
-}
 
-// TestRuleWrapperFieldParity asserts ruleWrapper stays a field-for-field
-// mirror of Rule, so Rule.MarshalXML cannot silently drop a field added to
-// Rule but not to the wrapper.
-func TestRuleWrapperFieldParity(t *testing.T) {
-	rt := reflect.TypeOf(Rule{})
-	wt := reflect.TypeOf(ruleWrapper{})
-	if rt.NumField() != wt.NumField() {
-		t.Fatalf("Rule has %d fields, ruleWrapper has %d", rt.NumField(), wt.NumField())
+	marshalBoth := func(r Rule) (got, want string) {
+		gotBytes, err := xml.Marshal(Configuration{Rules: []Rule{r}})
+		if err != nil {
+			t.Fatalf("could not marshal Rule through the wrapper path: %v", err)
+		}
+		wantBytes, err := xml.Marshal(aliasConfiguration{Rules: []ruleAlias{ruleAlias(r)}})
+		if err != nil {
+			t.Fatalf("could not marshal Rule through the default encoding: %v", err)
+		}
+		if !strings.Contains(string(wantBytes), nullFilter) {
+			t.Fatalf("default encoding no longer emits a null Filter as %s; update this test\ngot: %s", nullFilter, string(wantBytes))
+		}
+		return string(gotBytes), string(wantBytes)
 	}
-	for i := range rt.NumField() {
-		rf, wf := rt.Field(i), wt.Field(i)
-		if rf.Name != wf.Name {
-			t.Fatalf("field %d: Rule has %q, ruleWrapper has %q", i, rf.Name, wf.Name)
+
+	t.Run("prefix set omits Filter", func(t *testing.T) {
+		got, want := marshalBoth(r)
+		want = strings.Replace(want, nullFilter, "", 1)
+		if got != want {
+			t.Fatalf("wrapper path dropped or altered a field\nexpected: %s\ngot:      %s", want, got)
 		}
-		if rXML, wXML := rf.Tag.Get("xml"), wf.Tag.Get("xml"); rXML != wXML {
-			t.Fatalf("field %s: Rule xml tag %q, ruleWrapper xml tag %q", rf.Name, rXML, wXML)
+	})
+
+	t.Run("prefix empty emits Filter last", func(t *testing.T) {
+		r := r
+		r.Prefix = ""
+		got, want := marshalBoth(r)
+		// The default encoding emits the null Filter in its declared field
+		// position and Prefix as an empty element is omitted; the wrapper
+		// moves the Filter to the last child of Rule.
+		want = strings.Replace(want, nullFilter, "", 1)
+		want = strings.Replace(want, "</Rule>", nullFilter+"</Rule>", 1)
+		if got != want {
+			t.Fatalf("wrapper path dropped, doubled, or misplaced a field\nexpected: %s\ngot:      %s", want, got)
 		}
-		wantType := rf.Type
-		if rf.Name == "RuleFilter" {
-			wantType = reflect.PointerTo(rf.Type)
-		}
-		if wf.Type != wantType {
-			t.Fatalf("field %s: Rule type %v, ruleWrapper type %v (want %v)", rf.Name, rf.Type, wf.Type, wantType)
-		}
-	}
+	})
 }


### PR DESCRIPTION
## Description

Fixes #2240. Supersedes and carries #2213 (its two commits are cherry-picked here with @isimluk's authorship preserved).

- Since b392776 (v7.0.98), a lifecycle rule with a zero-value `Filter` and no top-level `Prefix` serialized with **neither** `<Filter>` **nor** `<Prefix>` — schema-invalid per the AWS spec ("`Filter` is required if the `LifecycleRule` does not contain a `Prefix` element") and rejected by AWS-strict servers such as MinIO releases before RELEASE.2024-12-13.
- `Rule.MarshalXML` (new) emits `<Filter><Prefix></Prefix></Filter>` only when both `Filter` and `Prefix` are empty (as the last child of `<Rule>`); a rule with a top-level `Prefix` still omits `<Filter>` entirely, so the #2177 fix (DigitalOcean Spaces ignoring `Prefix` when `Filter` is present) is preserved.
- The wrapper uses a type alias plus struct embedding (suggested in review): the wrapper's shallower `*Filter` field shadows the embedded one under encoding/xml's depth-based field resolution, so new `Rule` fields need no wrapper maintenance.
- `Filter.MarshalXML` no longer short-circuits on an empty filter; its doc comment now states the emission contract.
- Note for downstream embedders: a zero-value `lifecycle.Filter` marshaled directly (outside `Rule`) now emits `<Filter><Prefix></Prefix></Filter>` where it previously emitted nothing.

Wire form for the issue's repro (`Rule{ID, Status, Expiration}`, no Filter/Prefix):

```
before: <Rule><Expiration><Days>30</Days></Expiration><ID>expire-30d</ID><Status>Enabled</Status></Rule>
after:  <Rule><Expiration><Days>30</Days></Expiration><ID>expire-30d</ID><Status>Enabled</Status><Filter><Prefix></Prefix></Filter></Rule>
```

## Motivation and Context

`SetBucketLifecycle` fails on MinIO `RELEASE.2024-08-03T04-33-23Z` with `The XML you provided was not well-formed or did not validate against our published schema` whenever the rule's `Filter` is omitted. Newer MinIO servers accept the malformed XML only because server-side validation was relaxed (minio/minio#20684); AWS and other strict implementations still reject it, so the client must emit conformant XML.

## How to test this PR?

Live validation against real servers — the same three `SetBucketLifecycle` calls (A: no Filter/no Prefix — the issue's repro; B: top-level Prefix only — the #2177 scenario; C: non-empty Filter) run with the pre-fix SDK (master `ccfaaed`) and with this PR, side by side:

| Scenario | pre-fix SDK → minio:RELEASE.2024-08-03T04-33-23Z | this PR → minio:RELEASE.2024-08-03T04-33-23Z | pre-fix SDK → minio:latest | this PR → minio:latest |
|---|---|---|---|---|
| A: zero Filter, no Prefix | ❌ `The XML you provided was not well-formed or did not validate against our published schema` | ✅ accepted | ✅ (lenient server) | ✅ accepted |
| B: top-level Prefix only (#2177) | ✅ | ✅ (XML byte-identical to pre-fix) | ✅ | ✅ |
| C: non-empty Filter | ✅ | ✅ (XML byte-identical to pre-fix) | ✅ | ✅ |

The embedding refactor (13c22e5) later moved the empty `<Filter>` from its declared field position to the last child of `<Rule>` (both placements are schema-valid); all three scenarios were re-run at the current head against both `minio:RELEASE.2024-08-03T04-33-23Z` and `minio:latest` — accepted and round-tripped on both.

### Validation summary — AIStor master vs. MinIO community master

The fix was additionally validated at `3c53ab6` against **current-master server builds of both distributions**, confirming it is not community-only. One harness (`SetBucketLifecycle` → `GetBucketLifecycle` round-trip over cases A/B/C above) was run **identically** against each server, each a fresh single-node instance:

| Server (master) | Build / commit | License | A: prefixless global rule | B: prefix-only | C: non-empty Filter |
|---|---|---|---|---|---|
| **AIStor** | `d724599a1` (DEVELOPMENT) | MinIO Enterprise — **licensed** (`mineos` mint license) | ✅ accepted, round-tripped | ✅ | ✅ |
| **MinIO community** | `7aac2a2` (`github.com/minio/minio` master) | GNU AGPLv3 | ✅ accepted, round-tripped | ✅ | ✅ |

All three cases were accepted with no `MalformedXML` and round-tripped cleanly on **both** servers. The prefixless global-rule case (A) — the #2240 repro — is the one the fix targets and passes on each. AIStor was exercised under a valid Enterprise license, not just community MinIO.

Unit tests:

```
go test -race -count=1 -v ./pkg/lifecycle/
```

- `TestLifecycleMarshalXML`: 8 exact-output cases — Prefix-only (Filter omitted), zero Filter/Prefix (empty `<Filter>` emitted; a zero-value `RuleFilter` and an empty top-level `Prefix` are the same zero `Rule` value), non-empty prefix filter, a fully-populated rule through the empty-Filter path (guards the marshal wrapper against silent field drops), size-only filters (`ObjectSizeGreaterThan` and `ObjectSizeLessThan`), tag-only filter, and an `And` filter.
- `TestRuleWrapperCopyCompleteness`: fills every `Rule` field except `XMLName`/`RuleFilter` via reflection and byte-compares the wrapper-path output against the default struct-tag encoding of the embedded alias, in two subtests — with `Prefix` set the null `<Filter>` must vanish, and with `Prefix` empty exactly one empty `<Filter>` must be emitted as the last child of `<Rule>` — so a dropped, doubled, or misplaced field (including a regression in encoding/xml's depth-based shadowing) fails the suite.
- `TestFilterMarshalXMLEmpty`: pins the standalone downstream-visible contract that `xml.Marshal(lifecycle.Filter{})` emits `<Filter><Prefix></Prefix></Filter>`.
- Full `pkg/lifecycle` suite passes under `-race`; `make lint` / `go vet` / `gofumpt` clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Fixes a regression (introduced by b392776 / #2177, first released in v7.0.98)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request
- [x] No internode changes / version interoperability introduced



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lifecycle XML serialization for `Filter` and `Rule`, producing correct `<Filter>`/`<Prefix>` output for zero and default values.
  * A zero-value `Filter` is now consistently represented as a `<Filter>` element containing an empty `<Prefix>`.
  * `Rule` XML now omits the `<Filter>` element when it isn’t required.

* **Tests**
  * Added table-driven tests that verify exact marshaled LifecycleConfiguration XML strings for multiple scenarios.
  * Expanded coverage to ensure rule wrapper marshaling matches the default encoding and field expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
