### PR TITLE
fix: return io.EOF when reading at or beyond object size

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -388,6 +388,14 @@ func (o *Object) Read(b []byte) (n int, err error) {
 		return 0, o.prevErr
 	}
 
+	// If the current offset is at or beyond the known object size, we are
+	// already at EOF - return io.EOF locally instead of issuing a range
+	// request the server would reject as unsatisfiable.
+	if o.objectInfoSet && o.objectInfo.Size > -1 && o.currOffset >= o.objectInfo.Size {
+		o.prevErr = io.EOF
+		return 0, io.EOF
+	}
+
 	// Create a new request.
 	readReq := getRequest{
 		isReadOp: true,
@@ -407,6 +415,13 @@ func (o *Object) Read(b []byte) (n int, err error) {
 	// Send and receive from the first request.
 	response, err := o.doGetRequest(readReq)
 	if err != nil && err != io.EOF {
+		// An InvalidRange response means the requested start is not
+		// satisfiable for the object as it currently exists: the read
+		// position is at or past EOF.
+		if ToErrorResponse(err).Code == InvalidRange {
+			o.prevErr = io.EOF
+			return 0, io.EOF
+		}
 		// Save the error for future calls.
 		o.prevErr = err
 		return response.Size, err
@@ -511,6 +526,12 @@ func (o *Object) ReadAt(b []byte, offset int64) (n int, err error) {
 	// Send and receive from the first request.
 	response, err := o.doGetRequest(readAtReq)
 	if err != nil && err != io.EOF {
+		// Reading at an offset at or beyond the object size yields
+		// InvalidRange from the server: report io.EOF, matching the
+		// io.ReaderAt contract for reads past the end.
+		if ToErrorResponse(err).Code == InvalidRange {
+			return 0, io.EOF
+		}
 		// Save the error.
 		o.prevErr = err
 		return response.Size, err

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -115,6 +115,12 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 					httpReader, objectInfo, _, err = c.getObject(gctx, bucketName, objectName, opts)
 					if err != nil {
 						resCh <- getResponse{Error: err}
+						// An unsatisfiable range is recoverable: the caller
+						// may Seek or ReadAt within bounds next, so keep
+						// serving requests instead of ending the stream.
+						if ToErrorResponse(err).Code == InvalidRange {
+							continue
+						}
 						return
 					}
 					etag = objectInfo.ETag
@@ -196,7 +202,10 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 				// if the object has been read or not to only initialize
 				// new ones when they haven't been already.
 				// All readAt requests are new requests.
-				if req.DidOffsetChange || !req.beenRead {
+				// A nil httpReader means the previous fetch failed and
+				// left no stream, so a new one must be established
+				// regardless of the offset bookkeeping.
+				if req.DidOffsetChange || !req.beenRead || httpReader == nil {
 					// Check whether this is snowball
 					// if yes do not use If-Match feature
 					// it doesn't work.
@@ -221,6 +230,12 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 					if err != nil {
 						resCh <- getResponse{
 							Error: err,
+						}
+						// An unsatisfiable range is recoverable: the caller
+						// may Seek or ReadAt within bounds next, so keep
+						// serving requests instead of ending the stream.
+						if ToErrorResponse(err).Code == InvalidRange {
+							continue
 						}
 						return
 					}
@@ -415,10 +430,11 @@ func (o *Object) Read(b []byte) (n int, err error) {
 	// Send and receive from the first request.
 	response, err := o.doGetRequest(readReq)
 	if err != nil && err != io.EOF {
-		// An InvalidRange response means the requested start is not
-		// satisfiable for the object as it currently exists: the read
-		// position is at or past EOF.
-		if ToErrorResponse(err).Code == InvalidRange {
+		// An InvalidRange response to a range generated from a non-zero
+		// read offset means the position is at or past EOF for the object
+		// as it currently exists. Offset zero sends only a caller-supplied
+		// range, whose InvalidRange must surface untranslated.
+		if o.currOffset > 0 && ToErrorResponse(err).Code == InvalidRange {
 			o.prevErr = io.EOF
 			return 0, io.EOF
 		}

--- a/api-get-object_test.go
+++ b/api-get-object_test.go
@@ -18,11 +18,17 @@
 package minio
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -115,6 +121,162 @@ func TestGetObjectReturnErrorIfServerTruncatesResponseDouble(t *testing.T) {
 	// We expect an error when reading back.
 	if _, err = io.ReadAll(obj); err != io.ErrUnexpectedEOF {
 		t.Fatalf("Expected %v, got %v", io.ErrUnexpectedEOF, err)
+	}
+}
+
+func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
+	o := &Object{
+		mutex:         &sync.Mutex{},
+		objectInfo:    ObjectInfo{Size: 10},
+		objectInfoSet: true,
+		isStarted:     true,
+	}
+
+	n, err := o.Seek(10, io.SeekStart)
+	if err != nil {
+		t.Fatalf("expected seeking to object size to succeed, got %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("expected offset 10, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
+	}
+
+	o.prevErr = nil
+	o.currOffset = 9
+	n, err = o.Seek(1, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("expected seeking current to object size to succeed, got %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("expected offset 10, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
+	}
+
+	o.prevErr = nil
+	n, err = o.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("expected seeking to object end to succeed, got %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("expected offset 10, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read at object end to return io.EOF, got %v", err)
+	}
+}
+
+// eofRangeTestServer mimics a server answering HEAD with the object size,
+// plain GET with the full payload, and range GET with 206 for satisfiable
+// ranges or 416 InvalidRange when the range starts at or beyond the size,
+// as captured in issue #2166. It counts GET requests.
+func eofRangeTestServer(t *testing.T, payload []byte, getCount *int32) *httptest.Server {
+	t.Helper()
+	size := len(payload)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"0123456789abcdef0123456789abcdef"`)
+		w.Header().Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+		w.Header().Set("Accept-Ranges", "bytes")
+
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", strconv.Itoa(size))
+			return
+		}
+		atomic.AddInt32(getCount, 1)
+		rng := r.Header.Get("Range")
+		if rng == "" {
+			w.Header().Set("Content-Length", strconv.Itoa(size))
+			w.Write(payload)
+			return
+		}
+		var start, end int
+		spec := strings.TrimPrefix(rng, "bytes=")
+		if i := strings.Index(spec, "-"); i >= 0 {
+			start, _ = strconv.Atoi(spec[:i])
+			end = size - 1
+			if i+1 < len(spec) {
+				end, _ = strconv.Atoi(spec[i+1:])
+			}
+		}
+		if start >= size {
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidRange</Code><Message>The requested range 'bytes=%d--1' is not satisfiable</Message><Key>objectName</Key><BucketName>bucketName</BucketName><ActualObjectSize>%d</ActualObjectSize><RangeRequested>%s</RangeRequested></Error>`, start, size, spec)
+			return
+		}
+		if end >= size {
+			end = size - 1
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+		w.Header().Set("Content-Length", strconv.Itoa(end-start+1))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(payload[start : end+1])
+	}))
+}
+
+func TestGetObjectReadAtEOFReturnsEOF(t *testing.T) {
+	payload := []byte("0123456789")
+	var gets int32
+	srv := eofRangeTestServer(t, payload, &gets)
+	defer srv.Close()
+
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seek to the object size, then Read: io.EOF without any GET request.
+	obj, err := clnt.GetObject(context.Background(), "bucketName", "objectName", GetObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n64, err := obj.Seek(int64(len(payload)), io.SeekStart)
+	if err != nil || n64 != int64(len(payload)) {
+		t.Fatalf("Seek(size, SeekStart): expected (%d, nil), got (%d, %v)", len(payload), n64, err)
+	}
+	buf := make([]byte, 4)
+	if _, err = obj.Read(buf); err != io.EOF {
+		t.Fatalf("Read at object size: expected io.EOF, got %v", err)
+	}
+	if got := atomic.LoadInt32(&gets); got != 0 {
+		t.Fatalf("Read at object size issued %d GET request(s), expected 0", got)
+	}
+
+	// The object must stay usable: seek back and read real data.
+	if _, err = obj.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek(0, SeekStart) after EOF read: expected success, got %v", err)
+	}
+	n, err := obj.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read after re-seek: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("Read after re-seek: expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+	obj.Close()
+
+	// ReadAt in chunks up to and past the end: the object size is never
+	// known client-side on the ReadAt path, so the at-EOF request is issued
+	// and the server's 416 InvalidRange must surface as io.EOF.
+	obj, err = clnt.GetObject(context.Background(), "bucketName", "objectName", GetObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Close()
+	n, err = obj.ReadAt(buf, 0)
+	if err != nil && err != io.EOF {
+		t.Fatalf("ReadAt(0): expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("ReadAt(0): expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+	if _, err = obj.ReadAt(buf, int64(len(payload))); err != io.EOF {
+		t.Fatalf("ReadAt(size): expected io.EOF, got %v", err)
 	}
 }
 

--- a/api-get-object_test.go
+++ b/api-get-object_test.go
@@ -143,7 +143,6 @@ func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
 	}
 
-	o.prevErr = nil
 	o.currOffset = 9
 	n, err = o.Seek(1, io.SeekCurrent)
 	if err != nil {
@@ -156,7 +155,6 @@ func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
 	}
 
-	o.prevErr = nil
 	n, err = o.Seek(0, io.SeekEnd)
 	if err != nil {
 		t.Fatalf("expected seeking to object end to succeed, got %v", err)
@@ -169,11 +167,12 @@ func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 	}
 }
 
-// eofRangeTestServer mimics a server answering HEAD with the object size,
-// plain GET with the full payload, and range GET with 206 for satisfiable
-// ranges or 416 InvalidRange when the range starts at or beyond the size,
-// as captured in issue #2166. It counts GET requests.
-func eofRangeTestServer(t *testing.T, payload []byte, getCount *int32) *httptest.Server {
+// eofRangeTestServer mimics a server answering HEAD with headSize (which may
+// deliberately overstate the payload to simulate a stale cached size), plain
+// GET with the full payload, and range GET with 206 for satisfiable ranges or
+// 416 InvalidRange when the range starts at or beyond the payload size, as
+// captured in issue #2166. It counts GET requests.
+func eofRangeTestServer(t *testing.T, payload []byte, headSize int, getCount *int32) *httptest.Server {
 	t.Helper()
 	size := len(payload)
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +181,7 @@ func eofRangeTestServer(t *testing.T, payload []byte, getCount *int32) *httptest
 		w.Header().Set("Accept-Ranges", "bytes")
 
 		if r.Method == http.MethodHead {
-			w.Header().Set("Content-Length", strconv.Itoa(size))
+			w.Header().Set("Content-Length", strconv.Itoa(headSize))
 			return
 		}
 		atomic.AddInt32(getCount, 1)
@@ -220,7 +219,7 @@ func eofRangeTestServer(t *testing.T, payload []byte, getCount *int32) *httptest
 func TestGetObjectReadAtEOFReturnsEOF(t *testing.T) {
 	payload := []byte("0123456789")
 	var gets int32
-	srv := eofRangeTestServer(t, payload, &gets)
+	srv := eofRangeTestServer(t, payload, len(payload), &gets)
 	defer srv.Close()
 
 	clnt, err := New(srv.Listener.Addr().String(), &Options{
@@ -277,6 +276,114 @@ func TestGetObjectReadAtEOFReturnsEOF(t *testing.T) {
 	}
 	if _, err = obj.ReadAt(buf, int64(len(payload))); err != io.EOF {
 		t.Fatalf("ReadAt(size): expected io.EOF, got %v", err)
+	}
+
+	// The at-EOF ReadAt must not end the stream: an in-range ReadAt on the
+	// same object still returns data.
+	n, err = obj.ReadAt(buf, 0)
+	if err != nil && err != io.EOF {
+		t.Fatalf("ReadAt(0) after at-EOF ReadAt: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("ReadAt(0) after at-EOF ReadAt: expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+
+	// A metadata request between a failed fetch and the next read clears the
+	// re-establish flag; the read must still not use the dead reader.
+	if _, err = obj.ReadAt(buf, int64(len(payload))); err != io.EOF {
+		t.Fatalf("ReadAt(size) second time: expected io.EOF, got %v", err)
+	}
+	if _, err = obj.Stat(); err != nil {
+		t.Fatalf("Stat after at-EOF ReadAt: expected success, got %v", err)
+	}
+	n, err = obj.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read after Stat following at-EOF ReadAt: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("Read after Stat following at-EOF ReadAt: expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+}
+
+// TestGetObjectReadUserRangeInvalidRangeSurfaces pins that a caller-supplied
+// unsatisfiable range - the only range a read at offset zero ever sends - is
+// caller misuse, not EOF, and keeps surfacing the server's InvalidRange.
+func TestGetObjectReadUserRangeInvalidRangeSurfaces(t *testing.T) {
+	payload := []byte("0123456789")
+	var gets int32
+	srv := eofRangeTestServer(t, payload, len(payload), &gets)
+	defer srv.Close()
+
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := GetObjectOptions{}
+	if err := opts.SetRange(int64(len(payload)+1), int64(len(payload)+10)); err != nil {
+		t.Fatal(err)
+	}
+	obj, err := clnt.GetObject(context.Background(), "bucketName", "objectName", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Close()
+	_, err = obj.Read(make([]byte, 4))
+	if err == io.EOF {
+		t.Fatal("Read with caller-set unsatisfiable range: expected InvalidRange to surface, got io.EOF")
+	}
+	if code := ToErrorResponse(err).Code; code != InvalidRange {
+		t.Fatalf("Read with caller-set unsatisfiable range: expected code %q, got %v", InvalidRange, err)
+	}
+}
+
+// TestGetObjectReadStaleSizeReturnsEOF covers the read path where the
+// advertised size is stale-high (object shrunk after Stat): the local at-EOF
+// guard cannot fire, the offset-generated range draws a 416 from the server,
+// and the error must translate to io.EOF.
+func TestGetObjectReadStaleSizeReturnsEOF(t *testing.T) {
+	payload := []byte("0123456789")
+	var gets int32
+	srv := eofRangeTestServer(t, payload, 2*len(payload), &gets)
+	defer srv.Close()
+
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, err := clnt.GetObject(context.Background(), "bucketName", "objectName", GetObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Close()
+	// Seek runs Stat, which reports the stale doubled size, so seeking past
+	// the real payload end succeeds and the local at-EOF guard cannot fire.
+	if _, err = obj.Seek(int64(len(payload)+5), io.SeekStart); err != nil {
+		t.Fatalf("Seek past real size with stale Stat size: expected success, got %v", err)
+	}
+	if _, err = obj.Read(make([]byte, 4)); err != io.EOF {
+		t.Fatalf("Read past real object end: expected io.EOF, got %v", err)
+	}
+	if got := atomic.LoadInt32(&gets); got != 1 {
+		t.Fatalf("stale-size read issued %d GET request(s), expected exactly 1", got)
+	}
+
+	// The translated EOF must be recoverable: seek back and read real data.
+	if _, err = obj.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek(0, SeekStart) after translated EOF: expected success, got %v", err)
+	}
+	buf := make([]byte, 4)
+	n, err := obj.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read after re-seek: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("Read after re-seek: expected %q, got %q", payload[:len(buf)], buf[:n])
 	}
 }
 


### PR DESCRIPTION
## Description

Reading a `minio.Object` at or beyond its known size surfaced the server's 416 `InvalidRange` error instead of `io.EOF`, and the saved error permanently poisoned the object for every subsequent `Seek`/`Read`.

- `Object.Read`: return `io.EOF` locally — no request issued — when the current offset is already known to be at or past `objectInfo.Size`
- `Object.Read` / `Object.ReadAt`: translate a server 416 `InvalidRange` into `io.EOF`; `Read` stores `prevErr = io.EOF` (recoverable via `Seek`), `ReadAt` stores nothing, mirroring the pre-existing at-EOF guard. On `Read` the translation applies only to ranges the SDK generated from a non-zero read offset — a caller-supplied `GetObjectOptions` range on the first read keeps surfacing `InvalidRange` untranslated
- The request goroutine survives an `InvalidRange` fetch error instead of ending the stream, so a translated `io.EOF` is genuinely recoverable: `Seek` back and read, or issue another in-range `ReadAt`, on the same object (previously any fetch error ended the stream and later calls returned `context canceled`)
- `Seek` boundary semantics deliberately untouched (that is #2155 scope), so the `functional_tests.go` seek tables are unaffected

## Motivation and Context

Fixes #2166. `Seek(size, io.SeekStart)` — or `Seek(0, io.SeekEnd)` — followed by `Read` sent `Range: bytes=<size>-`, which the server correctly rejects per RFC 9110; `os.File` returns `(0, io.EOF)` for the same sequence. Covers the read-side portion of the closed #2226/#2228.

## How to test this PR?

Regression tests added in this PR: `go test -race -run 'TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF|TestGetObjectReadAtEOFReturnsEOF|TestGetObjectReadUserRangeInvalidRangeSurfaces|TestGetObjectReadStaleSizeReturnsEOF' .` — the second replays the issue's wire capture (HEAD 200, then ranged GET answered 416) against an httptest server, asserting zero GETs are issued for the at-EOF read and the object remains usable afterward — including after a genuine round-trip 416 (`ReadAt` past the end, or a stale-high cached size); the third pins that a caller-supplied unsatisfiable range still surfaces `InvalidRange`; the fourth drives the server-416 translation via a stale-high `HEAD` size and asserts the object stays usable. Full suite `go test -short -race ./...` and `make lint` both pass.

### Server coverage summary

The fix depends on server-side 416 `InvalidRange` behavior for at-EOF range reads, so the end-to-end probe was run against **both server lines**, not just community. One probe program (PutObject 6306 bytes, then the sequences below with a 16-byte buffer) was built against pre-fix `master` (`ccfaaed`) and against this branch (`c63505d`) and run against each server in the same session:

| Server line | Build | License | Result |
|---|---|---|---|
| **AIStor master** | `miniohq/aistor@d724599a1` (2026-07-13), go1.26.5 | MinIO Enterprise License (applied via `MINIO_LICENSE`) | Identical to table below — fix confirmed |
| **MinIO community master** | `minio/minio@7aac2a2` (2026-02-12), go1.25.6 | GNU AGPLv3 | Identical to table below — fix confirmed |
| MinIO community release | `quay.io/minio/minio:latest`, `RELEASE.2025-09-07T16-13-09Z` | GNU AGPLv3 | Identical to table below — fix confirmed |

All three servers returned the **same** `InvalidRange` wire behavior and the **same** before/after probe results, so the fix is not specific to one server variant.

### End-to-end probe (identical on all three servers above)

Pre-fix `master` (`ccfaaed`) vs this branch, same server, same session:

| Probe | pre-fix (`master` @ `ccfaaed`) | this branch |
|---|---|---|
| `Seek(size, SeekStart)` | `(6306, nil)` | `(6306, nil)` |
| `Read` after seek-to-size | `(0, The requested range 'bytes=6306--1' is not satisfiable)` | `(0, EOF)` |
| `Seek(0, SeekStart)` after that error | `(0, The requested range 'bytes=6306--1' is not satisfiable)` — object permanently poisoned | `(0, nil)` |
| `Read` after re-seek to 0 | `(0, The requested range 'bytes=6306--1' is not satisfiable)` | `(16, nil)` — data readable again |
| `Seek(0, SeekEnd)` then `Read` | `(0, The requested range 'bytes=6306--1' is not satisfiable)` | `(0, EOF)` |
| First-op `ReadAt(buf, size)` | `(0, The requested range 'bytes=6306-6321' is not satisfiable)` | `(0, EOF)` |
| `Stat()` then `ReadAt(buf, size)` | `(0, EOF)` | `(0, EOF)` — unchanged |
| `ReadAll` then `Read` at EOF | `6306 bytes, nil` / `(0, EOF)` | `6306 bytes, nil` / `(0, EOF)` — unchanged |

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-of-file handling for object reads and ranged reads.
  * Reads at or beyond a known object size now return `EOF` consistently without unnecessary requests.
  * Recoverable range errors no longer terminate ongoing read or seek operations.
  * Objects with outdated size information can still be re-read successfully after reaching EOF.

* **Tests**
  * Added coverage for EOF behavior, invalid ranges, seeking, and stale object sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->