### PR TITLE
fix: honor io.Seeker contract in Object.Seek

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -548,9 +548,9 @@ func (o *Object) ReadAt(b []byte, offset int64) (n int, err error) {
 // and 2 means relative to the end.
 // Seek returns the new offset and an error, if any.
 //
-// Seeking to a negative offset is an error. Seeking to any positive
-// offset is legal, subsequent io operations succeed until the
-// underlying object is not closed.
+// Seeking to a position before the start of the object is an error.
+// Seeking to or past the end of the object is legal per the io.Seeker
+// contract; a subsequent Read reports io.EOF.
 func (o *Object) Seek(offset int64, whence int) (n int64, err error) {
 	if o == nil {
 		return 0, errInvalidArgument("Object is nil")

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -115,6 +115,12 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 					httpReader, objectInfo, _, err = c.getObject(gctx, bucketName, objectName, opts)
 					if err != nil {
 						resCh <- getResponse{Error: err}
+						// An unsatisfiable range is recoverable: the caller
+						// may Seek or ReadAt within bounds next, so keep
+						// serving requests instead of ending the stream.
+						if ToErrorResponse(err).Code == InvalidRange {
+							continue
+						}
 						return
 					}
 					etag = objectInfo.ETag
@@ -196,7 +202,10 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 				// if the object has been read or not to only initialize
 				// new ones when they haven't been already.
 				// All readAt requests are new requests.
-				if req.DidOffsetChange || !req.beenRead {
+				// A nil httpReader means the previous fetch failed and
+				// left no stream, so a new one must be established
+				// regardless of the offset bookkeeping.
+				if req.DidOffsetChange || !req.beenRead || httpReader == nil {
 					// Check whether this is snowball
 					// if yes do not use If-Match feature
 					// it doesn't work.
@@ -221,6 +230,12 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 					if err != nil {
 						resCh <- getResponse{
 							Error: err,
+						}
+						// An unsatisfiable range is recoverable: the caller
+						// may Seek or ReadAt within bounds next, so keep
+						// serving requests instead of ending the stream.
+						if ToErrorResponse(err).Code == InvalidRange {
+							continue
 						}
 						return
 					}
@@ -414,6 +429,14 @@ func (o *Object) Read(b []byte) (n int, err error) {
 	// Send and receive from the first request.
 	response, err := o.doGetRequest(readReq)
 	if err != nil && err != io.EOF {
+		// An InvalidRange response to a range generated from a non-zero
+		// read offset means the position is at or past EOF for the object
+		// as it currently exists. Offset zero sends only a caller-supplied
+		// range, whose InvalidRange must surface untranslated.
+		if o.currOffset > 0 && ToErrorResponse(err).Code == InvalidRange {
+			o.prevErr = io.EOF
+			return 0, io.EOF
+		}
 		// Save the error for future calls.
 		o.prevErr = err
 		return response.Size, err
@@ -518,6 +541,12 @@ func (o *Object) ReadAt(b []byte, offset int64) (n int, err error) {
 	// Send and receive from the first request.
 	response, err := o.doGetRequest(readAtReq)
 	if err != nil && err != io.EOF {
+		// Reading at an offset at or beyond the object size yields
+		// InvalidRange from the server: report io.EOF, matching the
+		// io.ReaderAt contract for reads past the end.
+		if ToErrorResponse(err).Code == InvalidRange {
+			return 0, io.EOF
+		}
 		// Save the error.
 		o.prevErr = err
 		return response.Size, err
@@ -549,8 +578,9 @@ func (o *Object) ReadAt(b []byte, offset int64) (n int, err error) {
 // Seek returns the new offset and an error, if any.
 //
 // Seeking to a position before the start of the object is an error.
-// Seeking to or past the end of the object is legal per the io.Seeker
-// contract; a subsequent Read reports io.EOF.
+// Seeking to the end of the object is legal; the subsequent Read reports
+// io.EOF. When the object size is known, seeking past the end returns
+// io.EOF from Seek itself and leaves the offset unchanged.
 func (o *Object) Seek(offset int64, whence int) (n int64, err error) {
 	if o == nil {
 		return 0, errInvalidArgument("Object is nil")
@@ -608,10 +638,15 @@ func (o *Object) Seek(offset int64, whence int) (n int64, err error) {
 		newOffset = o.objectInfo.Size + offset
 	}
 	// Seeking to a position before the start of the object is not allowed for
-	// any whence. Seeking to or past the end is allowed per the io.Seeker
-	// contract; the subsequent Read reports io.EOF.
+	// any whence.
 	if newOffset < 0 {
 		return 0, errInvalidArgument(fmt.Sprintf("Seeking at negative offset not allowed for %d", whence))
+	}
+	// Seeking past the end of the object is rejected with io.EOF, preserving
+	// long-standing behavior. Seeking to exactly the end is legal and the
+	// subsequent Read reports io.EOF.
+	if o.objectInfo.Size > -1 && newOffset > o.objectInfo.Size {
+		return 0, io.EOF
 	}
 	// Reset the saved error since we successfully seeked, let the Read
 	// and ReadAt decide.

--- a/api-get-object.go
+++ b/api-get-object.go
@@ -387,6 +387,13 @@ func (o *Object) Read(b []byte) (n int, err error) {
 	if o.prevErr != nil || o.isClosed {
 		return 0, o.prevErr
 	}
+	// If the current offset is at or beyond the known object size, there is
+	// nothing more to read. Return io.EOF directly instead of issuing a range
+	// request from EOF (which the server rejects as an unsatisfiable range).
+	if o.objectInfoSet && o.objectInfo.Size > -1 && o.currOffset >= o.objectInfo.Size {
+		o.prevErr = io.EOF
+		return 0, io.EOF
+	}
 
 	// Create a new request.
 	readReq := getRequest{
@@ -558,9 +565,11 @@ func (o *Object) Seek(offset int64, whence int) (n int64, err error) {
 		return 0, o.prevErr
 	}
 
-	// Negative offset is valid for whence of '2'.
-	if offset < 0 && whence != 2 {
-		return 0, errInvalidArgument(fmt.Sprintf("Negative position not allowed for %d", whence))
+	// Negative absolute offsets are invalid for SeekStart. Negative offsets
+	// for SeekCurrent/SeekEnd are valid as long as the computed position is
+	// not before the start of the object (checked after applying whence).
+	if offset < 0 && whence == 0 {
+		return 0, errInvalidArgument("Negative position not allowed for 0")
 	}
 
 	// This is the first request. So before anything else
@@ -588,31 +597,21 @@ func (o *Object) Seek(offset int64, whence int) (n int64, err error) {
 	default:
 		return 0, errInvalidArgument(fmt.Sprintf("Invalid whence %d", whence))
 	case 0:
-		if o.objectInfo.Size > -1 && offset > o.objectInfo.Size {
-			return 0, io.EOF
-		}
 		newOffset = offset
 	case 1:
-		if o.objectInfo.Size > -1 && o.currOffset+offset > o.objectInfo.Size {
-			return 0, io.EOF
-		}
 		newOffset += offset
 	case 2:
 		// If we don't know the object size return an error for io.SeekEnd
 		if o.objectInfo.Size < 0 {
 			return 0, errInvalidArgument("Whence END is not supported when the object size is unknown")
 		}
-		// Seeking to positive offset is valid for whence '2', but
-		// since we are backing a Reader we have reached 'EOF' if
-		// offset is positive.
-		if offset > 0 {
-			return 0, io.EOF
-		}
-		// Seeking to negative position not allowed for whence.
-		if o.objectInfo.Size+offset < 0 {
-			return 0, errInvalidArgument(fmt.Sprintf("Seeking at negative offset not allowed for %d", whence))
-		}
 		newOffset = o.objectInfo.Size + offset
+	}
+	// Seeking to a position before the start of the object is not allowed for
+	// any whence. Seeking to or past the end is allowed per the io.Seeker
+	// contract; the subsequent Read reports io.EOF.
+	if newOffset < 0 {
+		return 0, errInvalidArgument(fmt.Sprintf("Seeking at negative offset not allowed for %d", whence))
 	}
 	// Reset the saved error since we successfully seeked, let the Read
 	// and ReadAt decide.

--- a/api-get-object_test.go
+++ b/api-get-object_test.go
@@ -18,12 +18,17 @@
 package minio
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -148,9 +153,229 @@ func TestGetObjectReturnErrorIfServerSendsMore(t *testing.T) {
 	}
 }
 
-// TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF verifies that seeking to (or
-// past) the object size succeeds for every whence per the io.Seeker contract,
-// and that io.EOF is reported by the subsequent Read rather than by Seek. See
+// eofRangeTestServer mimics a server answering HEAD with headSize (which may
+// deliberately overstate the payload to simulate a stale cached size), plain
+// GET with the full payload, and range GET with 206 for satisfiable ranges or
+// 416 InvalidRange when the range starts at or beyond the payload size, as
+// captured in issue #2166. It counts GET requests.
+func eofRangeTestServer(t *testing.T, payload []byte, headSize int, getCount *int32) *httptest.Server {
+	t.Helper()
+	size := len(payload)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"0123456789abcdef0123456789abcdef"`)
+		w.Header().Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+		w.Header().Set("Accept-Ranges", "bytes")
+
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", strconv.Itoa(headSize))
+			return
+		}
+		atomic.AddInt32(getCount, 1)
+		rng := r.Header.Get("Range")
+		if rng == "" {
+			w.Header().Set("Content-Length", strconv.Itoa(size))
+			w.Write(payload)
+			return
+		}
+		var start, end int
+		spec := strings.TrimPrefix(rng, "bytes=")
+		if i := strings.Index(spec, "-"); i >= 0 {
+			start, _ = strconv.Atoi(spec[:i])
+			end = size - 1
+			if i+1 < len(spec) {
+				end, _ = strconv.Atoi(spec[i+1:])
+			}
+		}
+		if start >= size {
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidRange</Code><Message>The requested range 'bytes=%d--1' is not satisfiable</Message><Key>objectName</Key><BucketName>bucketName</BucketName><ActualObjectSize>%d</ActualObjectSize><RangeRequested>%s</RangeRequested></Error>`, start, size, spec)
+			return
+		}
+		if end >= size {
+			end = size - 1
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+		w.Header().Set("Content-Length", strconv.Itoa(end-start+1))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(payload[start : end+1])
+	}))
+}
+
+func TestGetObjectReadAtEOFReturnsEOF(t *testing.T) {
+	payload := []byte("0123456789")
+	var gets int32
+	srv := eofRangeTestServer(t, payload, len(payload), &gets)
+	defer srv.Close()
+
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seek to the object size, then Read: io.EOF without any GET request.
+	obj, err := clnt.GetObject(context.Background(), "bucketName", "objectName", GetObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n64, err := obj.Seek(int64(len(payload)), io.SeekStart)
+	if err != nil || n64 != int64(len(payload)) {
+		t.Fatalf("Seek(size, SeekStart): expected (%d, nil), got (%d, %v)", len(payload), n64, err)
+	}
+	buf := make([]byte, 4)
+	if _, err = obj.Read(buf); err != io.EOF {
+		t.Fatalf("Read at object size: expected io.EOF, got %v", err)
+	}
+	if got := atomic.LoadInt32(&gets); got != 0 {
+		t.Fatalf("Read at object size issued %d GET request(s), expected 0", got)
+	}
+
+	// The object must stay usable: seek back and read real data.
+	if _, err = obj.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek(0, SeekStart) after EOF read: expected success, got %v", err)
+	}
+	n, err := obj.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read after re-seek: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("Read after re-seek: expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+	obj.Close()
+
+	// ReadAt in chunks up to and past the end: the object size is never
+	// known client-side on the ReadAt path, so the at-EOF request is issued
+	// and the server's 416 InvalidRange must surface as io.EOF.
+	obj, err = clnt.GetObject(context.Background(), "bucketName", "objectName", GetObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Close()
+	n, err = obj.ReadAt(buf, 0)
+	if err != nil && err != io.EOF {
+		t.Fatalf("ReadAt(0): expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("ReadAt(0): expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+	if _, err = obj.ReadAt(buf, int64(len(payload))); err != io.EOF {
+		t.Fatalf("ReadAt(size): expected io.EOF, got %v", err)
+	}
+
+	// The at-EOF ReadAt must not end the stream: an in-range ReadAt on the
+	// same object still returns data.
+	n, err = obj.ReadAt(buf, 0)
+	if err != nil && err != io.EOF {
+		t.Fatalf("ReadAt(0) after at-EOF ReadAt: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("ReadAt(0) after at-EOF ReadAt: expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+
+	// A metadata request between a failed fetch and the next read clears the
+	// re-establish flag; the read must still not use the dead reader.
+	if _, err = obj.ReadAt(buf, int64(len(payload))); err != io.EOF {
+		t.Fatalf("ReadAt(size) second time: expected io.EOF, got %v", err)
+	}
+	if _, err = obj.Stat(); err != nil {
+		t.Fatalf("Stat after at-EOF ReadAt: expected success, got %v", err)
+	}
+	n, err = obj.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read after Stat following at-EOF ReadAt: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("Read after Stat following at-EOF ReadAt: expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+}
+
+// TestGetObjectReadUserRangeInvalidRangeSurfaces pins that a caller-supplied
+// unsatisfiable range - the only range a read at offset zero ever sends - is
+// caller misuse, not EOF, and keeps surfacing the server's InvalidRange.
+func TestGetObjectReadUserRangeInvalidRangeSurfaces(t *testing.T) {
+	payload := []byte("0123456789")
+	var gets int32
+	srv := eofRangeTestServer(t, payload, len(payload), &gets)
+	defer srv.Close()
+
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := GetObjectOptions{}
+	if err := opts.SetRange(int64(len(payload)+1), int64(len(payload)+10)); err != nil {
+		t.Fatal(err)
+	}
+	obj, err := clnt.GetObject(context.Background(), "bucketName", "objectName", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Close()
+	_, err = obj.Read(make([]byte, 4))
+	if err == io.EOF {
+		t.Fatal("Read with caller-set unsatisfiable range: expected InvalidRange to surface, got io.EOF")
+	}
+	if code := ToErrorResponse(err).Code; code != InvalidRange {
+		t.Fatalf("Read with caller-set unsatisfiable range: expected code %q, got %v", InvalidRange, err)
+	}
+}
+
+// TestGetObjectReadStaleSizeReturnsEOF covers the read path where the
+// advertised size is stale-high (object shrunk after Stat): the local at-EOF
+// guard cannot fire, the offset-generated range draws a 416 from the server,
+// and the error must translate to io.EOF.
+func TestGetObjectReadStaleSizeReturnsEOF(t *testing.T) {
+	payload := []byte("0123456789")
+	var gets int32
+	srv := eofRangeTestServer(t, payload, 2*len(payload), &gets)
+	defer srv.Close()
+
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, err := clnt.GetObject(context.Background(), "bucketName", "objectName", GetObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Close()
+	// Seek runs Stat, which reports the stale doubled size, so seeking past
+	// the real payload end succeeds and the local at-EOF guard cannot fire.
+	if _, err = obj.Seek(int64(len(payload)+5), io.SeekStart); err != nil {
+		t.Fatalf("Seek past real size with stale Stat size: expected success, got %v", err)
+	}
+	if _, err = obj.Read(make([]byte, 4)); err != io.EOF {
+		t.Fatalf("Read past real object end: expected io.EOF, got %v", err)
+	}
+	if got := atomic.LoadInt32(&gets); got != 1 {
+		t.Fatalf("stale-size read issued %d GET request(s), expected exactly 1", got)
+	}
+
+	// The translated EOF must be recoverable: seek back and read real data.
+	if _, err = obj.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek(0, SeekStart) after translated EOF: expected success, got %v", err)
+	}
+	buf := make([]byte, 4)
+	n, err := obj.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read after re-seek: expected data, got %v", err)
+	}
+	if n != len(buf) || !bytes.Equal(buf, payload[:n]) {
+		t.Fatalf("Read after re-seek: expected %q, got %q", payload[:len(buf)], buf[:n])
+	}
+}
+
+// TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF verifies that seeking to
+// exactly the object size succeeds for every whence, and that io.EOF is
+// reported by the subsequent Read rather than by Seek. See
 // https://github.com/minio/minio-go/issues/2155 and #2166.
 func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 	o := &Object{
@@ -193,38 +418,62 @@ func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
 		t.Fatalf("expected read at object end to return io.EOF, got %v", err)
 	}
+}
 
-	n, err = o.Seek(12, io.SeekStart)
-	if err != nil {
-		t.Fatalf("expected seeking past object size to succeed, got %v", err)
-	}
-	if n != 12 {
-		t.Fatalf("expected offset 12, got %d", n)
-	}
-	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
-		t.Fatalf("expected read past object size to return io.EOF, got %v", err)
-	}
-
-	n, err = o.Seek(3, io.SeekCurrent)
-	if err != nil {
-		t.Fatalf("expected seeking current past object size to succeed, got %v", err)
-	}
-	if n != 15 {
-		t.Fatalf("expected offset 15, got %d", n)
-	}
-	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
-		t.Fatalf("expected read past object size to return io.EOF, got %v", err)
+// TestObjectSeekPastObjectSizeReturnsEOF verifies that seeking past the object
+// size is rejected by Seek with io.EOF for every whence, leaving the offset
+// unchanged, and that the object stays usable afterwards.
+func TestObjectSeekPastObjectSizeReturnsEOF(t *testing.T) {
+	o := &Object{
+		mutex:         &sync.Mutex{},
+		objectInfo:    ObjectInfo{Size: 10},
+		objectInfoSet: true,
+		isStarted:     true,
 	}
 
-	n, err = o.Seek(2, io.SeekEnd)
-	if err != nil {
-		t.Fatalf("expected seeking past object end to succeed, got %v", err)
+	n, err := o.Seek(11, io.SeekStart)
+	if err != io.EOF {
+		t.Fatalf("expected seeking past object size to return io.EOF, got %v", err)
 	}
-	if n != 12 {
-		t.Fatalf("expected offset 12, got %d", n)
+	if n != 0 {
+		t.Fatalf("expected returned offset 0, got %d", n)
+	}
+	if o.currOffset != 0 {
+		t.Fatalf("expected offset to stay 0 after failed seek, got %d", o.currOffset)
+	}
+
+	o.currOffset = 9
+	n, err = o.Seek(2, io.SeekCurrent)
+	if err != io.EOF {
+		t.Fatalf("expected seeking current past object size to return io.EOF, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected returned offset 0, got %d", n)
+	}
+	if o.currOffset != 9 {
+		t.Fatalf("expected offset to stay 9 after failed seek, got %d", o.currOffset)
+	}
+
+	n, err = o.Seek(1, io.SeekEnd)
+	if err != io.EOF {
+		t.Fatalf("expected seeking past object end to return io.EOF, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected returned offset 0, got %d", n)
+	}
+	if o.currOffset != 9 {
+		t.Fatalf("expected offset to stay 9 after failed seek, got %d", o.currOffset)
+	}
+
+	n, err = o.Seek(10, io.SeekStart)
+	if err != nil {
+		t.Fatalf("expected seeking to object size to succeed after failed seek, got %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("expected offset 10, got %d", n)
 	}
 	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
-		t.Fatalf("expected read past object end to return io.EOF, got %v", err)
+		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
 	}
 }
 
@@ -287,5 +536,87 @@ func TestObjectSeekInvalidWhence(t *testing.T) {
 
 	if _, err := o.Seek(0, 3); err == nil {
 		t.Fatal("expected error for invalid whence")
+	}
+}
+
+// TestObjectSeekWithSetRange documents the current interplay between
+// GetObjectOptions.SetRange and Object.Seek: a Seek issued before any Read
+// stats the object without the range header, so Seek offsets and the
+// end-of-object boundary refer to the full object, and a Read after a Seek
+// requests a fresh range starting at the seek offset, discarding the range
+// supplied by the caller. See https://github.com/minio/minio-go/pull/2267 for
+// a proposed change to the related Stat behavior.
+func TestObjectSeekWithSetRange(t *testing.T) {
+	content := []byte("0123456789")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+			return
+		}
+		body := content
+		if rng := r.Header.Get("Range"); rng != "" {
+			var start, end int
+			if n, _ := fmt.Sscanf(rng, "bytes=%d-%d", &start, &end); n == 2 {
+				body = content[start:min(end+1, len(content))]
+			} else if n, _ := fmt.Sscanf(rng, "bytes=%d-", &start); n == 1 {
+				body = content[start:]
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+len(body)-1, len(content)))
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.WriteHeader(http.StatusPartialContent)
+		} else {
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		}
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := GetObjectOptions{}
+	if err = opts.SetRange(2, 8); err != nil {
+		t.Fatal(err)
+	}
+	obj, err := clnt.GetObject(context.Background(), "bucketName", "objectName", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seek relative to the end resolves against the full object size, not the
+	// requested range.
+	n, err := obj.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("expected seeking to object end to succeed, got %v", err)
+	}
+	if n != int64(len(content)) {
+		t.Fatalf("expected offset %d, got %d", len(content), n)
+	}
+	if _, err = obj.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read at object end to return io.EOF, got %v", err)
+	}
+
+	// The past-end boundary also refers to the full object size.
+	if _, err = obj.Seek(int64(len(content))+1, io.SeekStart); err != io.EOF {
+		t.Fatalf("expected seeking past object end to return io.EOF, got %v", err)
+	}
+
+	// A Read after a Seek fetches from the seek offset, not from the range
+	// supplied by the caller.
+	if _, err = obj.Seek(4, io.SeekStart); err != nil {
+		t.Fatalf("expected seeking within the object to succeed, got %v", err)
+	}
+	buf := make([]byte, 3)
+	rn, err := obj.Read(buf)
+	if err != nil {
+		t.Fatalf("expected read after seek to succeed, got %v", err)
+	}
+	if rn != 3 || string(buf) != "456" {
+		t.Fatalf("expected to read %q, got %q (%d bytes)", "456", string(buf[:rn]), rn)
 	}
 }

--- a/api-get-object_test.go
+++ b/api-get-object_test.go
@@ -171,7 +171,6 @@ func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
 	}
 
-	o.prevErr = nil
 	o.currOffset = 9
 	n, err = o.Seek(1, io.SeekCurrent)
 	if err != nil {
@@ -184,7 +183,6 @@ func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
 	}
 
-	o.prevErr = nil
 	n, err = o.Seek(0, io.SeekEnd)
 	if err != nil {
 		t.Fatalf("expected seeking to object end to succeed, got %v", err)
@@ -195,10 +193,43 @@ func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
 	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
 		t.Fatalf("expected read at object end to return io.EOF, got %v", err)
 	}
+
+	n, err = o.Seek(12, io.SeekStart)
+	if err != nil {
+		t.Fatalf("expected seeking past object size to succeed, got %v", err)
+	}
+	if n != 12 {
+		t.Fatalf("expected offset 12, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read past object size to return io.EOF, got %v", err)
+	}
+
+	n, err = o.Seek(3, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("expected seeking current past object size to succeed, got %v", err)
+	}
+	if n != 15 {
+		t.Fatalf("expected offset 15, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read past object size to return io.EOF, got %v", err)
+	}
+
+	n, err = o.Seek(2, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("expected seeking past object end to succeed, got %v", err)
+	}
+	if n != 12 {
+		t.Fatalf("expected offset 12, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read past object end to return io.EOF, got %v", err)
+	}
 }
 
 // TestObjectSeekCurrentNegativeOffset verifies that a negative offset with
-// io.SeekCurrent is honoured when the resulting absolute position is within the
+// io.SeekCurrent is honored when the resulting absolute position is within the
 // object, and rejected only when it would move before the start of the object.
 // Regression test for https://github.com/minio/minio-go/issues/2155.
 func TestObjectSeekCurrentNegativeOffset(t *testing.T) {
@@ -221,5 +252,40 @@ func TestObjectSeekCurrentNegativeOffset(t *testing.T) {
 	_, err = o.Seek(-10, io.SeekCurrent)
 	if err == nil {
 		t.Fatal("expected error when SeekCurrent would move before start of object")
+	}
+
+	_, err = o.Seek(-1, io.SeekStart)
+	if err == nil {
+		t.Fatal("expected error when SeekStart is given a negative offset")
+	}
+}
+
+// TestObjectSeekEndUnknownSize verifies that io.SeekEnd is rejected when the
+// object size is unknown.
+func TestObjectSeekEndUnknownSize(t *testing.T) {
+	o := &Object{
+		mutex:         &sync.Mutex{},
+		objectInfo:    ObjectInfo{Size: -1},
+		objectInfoSet: true,
+		isStarted:     true,
+	}
+
+	if _, err := o.Seek(0, io.SeekEnd); err == nil {
+		t.Fatal("expected error when seeking from end with unknown object size")
+	}
+}
+
+// TestObjectSeekInvalidWhence verifies that an unsupported whence value is
+// rejected.
+func TestObjectSeekInvalidWhence(t *testing.T) {
+	o := &Object{
+		mutex:         &sync.Mutex{},
+		objectInfo:    ObjectInfo{Size: 10},
+		objectInfoSet: true,
+		isStarted:     true,
+	}
+
+	if _, err := o.Seek(0, 3); err == nil {
+		t.Fatal("expected error for invalid whence")
 	}
 }

--- a/api-get-object_test.go
+++ b/api-get-object_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 )
 
@@ -144,5 +145,81 @@ func TestGetObjectReturnErrorIfServerSendsMore(t *testing.T) {
 	// We expect an error when reading back.
 	if _, err = io.ReadAll(obj); err != io.ErrUnexpectedEOF {
 		t.Fatalf("Expected %v, got %v", io.ErrUnexpectedEOF, err)
+	}
+}
+
+// TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF verifies that seeking to (or
+// past) the object size succeeds for every whence per the io.Seeker contract,
+// and that io.EOF is reported by the subsequent Read rather than by Seek. See
+// https://github.com/minio/minio-go/issues/2155 and #2166.
+func TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF(t *testing.T) {
+	o := &Object{
+		mutex:         &sync.Mutex{},
+		objectInfo:    ObjectInfo{Size: 10},
+		objectInfoSet: true,
+		isStarted:     true,
+	}
+
+	n, err := o.Seek(10, io.SeekStart)
+	if err != nil {
+		t.Fatalf("expected seeking to object size to succeed, got %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("expected offset 10, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
+	}
+
+	o.prevErr = nil
+	o.currOffset = 9
+	n, err = o.Seek(1, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("expected seeking current to object size to succeed, got %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("expected offset 10, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read at object size to return io.EOF, got %v", err)
+	}
+
+	o.prevErr = nil
+	n, err = o.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("expected seeking to object end to succeed, got %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("expected offset 10, got %d", n)
+	}
+	if _, err = o.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected read at object end to return io.EOF, got %v", err)
+	}
+}
+
+// TestObjectSeekCurrentNegativeOffset verifies that a negative offset with
+// io.SeekCurrent is honoured when the resulting absolute position is within the
+// object, and rejected only when it would move before the start of the object.
+// Regression test for https://github.com/minio/minio-go/issues/2155.
+func TestObjectSeekCurrentNegativeOffset(t *testing.T) {
+	o := &Object{
+		mutex:         &sync.Mutex{},
+		objectInfo:    ObjectInfo{Size: 10},
+		objectInfoSet: true,
+		isStarted:     true,
+		currOffset:    5,
+	}
+
+	n, err := o.Seek(-2, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("expected SeekCurrent with negative offset to succeed, got %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected offset 3, got %d", n)
+	}
+
+	_, err = o.Seek(-10, io.SeekCurrent)
+	if err == nil {
+		t.Fatal("expected error when SeekCurrent would move before start of object")
 	}
 }

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -5379,7 +5379,7 @@ func testGetObjectReadSeekFunctional() {
 	}
 
 	if st.Size != int64(bufSize) {
-		logError(testName, function, args, startTime, "", "Number of bytes does not match, expected "+string(int64(bufSize))+", got "+string(st.Size), err)
+		logError(testName, function, args, startTime, "", "Number of bytes does not match, expected "+strconv.Itoa(bufSize)+", got "+strconv.FormatInt(st.Size, 10), err)
 		return
 	}
 
@@ -5428,7 +5428,7 @@ func testGetObjectReadSeekFunctional() {
 		// Move larger than possible: seek past end now succeeds.
 		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
 		// Provide negative offset with CUR_SEEK: valid since the resulting
-		// absolute position stays within the object.
+		// absolute position is not negative.
 		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
 		// Test with whence SEEK_END and with positive offset: seek past end
 		// now succeeds.
@@ -5464,6 +5464,15 @@ func testGetObjectReadSeekFunctional() {
 		// Compare only if shouldCmp is activated
 		if testCase.shouldCmp {
 			cmpData(r, testCase.start, testCase.end)
+		}
+		// A successful seek to or past the object end must defer io.EOF to the
+		// subsequent read.
+		if !testCase.shouldCmp && testCase.pos >= int64(bufSize) {
+			readN, readErr := r.Read(make([]byte, 1))
+			if readN != 0 || readErr != io.EOF {
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to/past object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
+				return
+			}
 		}
 	}
 	logSuccess(testName, function, args, startTime)
@@ -6530,7 +6539,7 @@ func testSSECEncryptedGetObjectReadSeekFunctional() {
 	}
 
 	if st.Size != int64(bufSize) {
-		logError(testName, function, args, startTime, "", "Number of bytes does not match, expected "+string(int64(bufSize))+", got "+string(st.Size), err)
+		logError(testName, function, args, startTime, "", "Number of bytes does not match, expected "+strconv.Itoa(bufSize)+", got "+strconv.FormatInt(st.Size, 10), err)
 		return
 	}
 
@@ -6576,7 +6585,7 @@ func testSSECEncryptedGetObjectReadSeekFunctional() {
 		// Move larger than possible: seek past end now succeeds.
 		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
 		// Provide negative offset with CUR_SEEK: valid since the resulting
-		// absolute position stays within the object.
+		// absolute position is not negative.
 		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
 		// Test with whence SEEK_END and with positive offset: seek past end
 		// now succeeds.
@@ -6621,6 +6630,15 @@ func testSSECEncryptedGetObjectReadSeekFunctional() {
 		// Compare only if shouldCmp is activated
 		if testCase.shouldCmp {
 			cmpData(r, testCase.start, testCase.end)
+		}
+		// A successful seek to or past the object end must defer io.EOF to the
+		// subsequent read.
+		if !testCase.shouldCmp && testCase.pos >= int64(bufSize) {
+			readN, readErr := r.Read(make([]byte, 1))
+			if readN != 0 || readErr != io.EOF {
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to/past object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
+				return
+			}
 		}
 	}
 
@@ -6699,7 +6717,7 @@ func testSSES3EncryptedGetObjectReadSeekFunctional() {
 	}
 
 	if st.Size != int64(bufSize) {
-		logError(testName, function, args, startTime, "", "Number of bytes does not match, expected "+string(int64(bufSize))+", got "+string(st.Size), err)
+		logError(testName, function, args, startTime, "", "Number of bytes does not match, expected "+strconv.Itoa(bufSize)+", got "+strconv.FormatInt(st.Size, 10), err)
 		return
 	}
 
@@ -6745,7 +6763,7 @@ func testSSES3EncryptedGetObjectReadSeekFunctional() {
 		// Move larger than possible: seek past end now succeeds.
 		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
 		// Provide negative offset with CUR_SEEK: valid since the resulting
-		// absolute position stays within the object.
+		// absolute position is not negative.
 		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
 		// Test with whence SEEK_END and with positive offset: seek past end
 		// now succeeds.
@@ -6790,6 +6808,15 @@ func testSSES3EncryptedGetObjectReadSeekFunctional() {
 		// Compare only if shouldCmp is activated
 		if testCase.shouldCmp {
 			cmpData(r, testCase.start, testCase.end)
+		}
+		// A successful seek to or past the object end must defer io.EOF to the
+		// subsequent read.
+		if !testCase.shouldCmp && testCase.pos >= int64(bufSize) {
+			readN, readErr := r.Read(make([]byte, 1))
+			if readN != 0 || readErr != io.EOF {
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to/past object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
+				return
+			}
 		}
 	}
 
@@ -8865,7 +8892,7 @@ func testGetObjectReadSeekFunctionalV2() {
 	}
 
 	if st.Size != int64(bufSize) {
-		logError(testName, function, args, startTime, "", "Number of bytes in stat does not match, expected "+string(int64(bufSize))+" got "+string(st.Size), err)
+		logError(testName, function, args, startTime, "", "Number of bytes in stat does not match, expected "+strconv.Itoa(bufSize)+" got "+strconv.FormatInt(st.Size, 10), err)
 		return
 	}
 
@@ -8876,7 +8903,7 @@ func testGetObjectReadSeekFunctionalV2() {
 		return
 	}
 	if n != offset {
-		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+string(offset)+" got "+string(n), err)
+		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(offset, 10)+" got "+strconv.FormatInt(n, 10), err)
 		return
 	}
 	n, err = r.Seek(0, 1)
@@ -8885,7 +8912,7 @@ func testGetObjectReadSeekFunctionalV2() {
 		return
 	}
 	if n != offset {
-		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+string(offset)+" got "+string(n), err)
+		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(offset, 10)+" got "+strconv.FormatInt(n, 10), err)
 		return
 	}
 	// Seeking past the object end with SEEK_END now succeeds per the
@@ -8899,8 +8926,9 @@ func testGetObjectReadSeekFunctionalV2() {
 		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(st.Size+offset, 10)+" got "+strconv.FormatInt(n, 10), err)
 		return
 	}
-	if _, err = r.Read(make([]byte, 1)); err != io.EOF {
-		logError(testName, function, args, startTime, "", "Read after seeking past object end should return EOF", err)
+	readN, readErr := r.Read(make([]byte, 1))
+	if readN != 0 || readErr != io.EOF {
+		logError(testName, function, args, startTime, "", "Read after seeking past object end should return zero bytes and EOF", readErr)
 		return
 	}
 	n, err = r.Seek(-offset, 2)
@@ -8909,7 +8937,7 @@ func testGetObjectReadSeekFunctionalV2() {
 		return
 	}
 	if n != st.Size-offset {
-		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+string(st.Size-offset)+" got "+string(n), err)
+		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(st.Size-offset, 10)+" got "+strconv.FormatInt(n, 10), err)
 		return
 	}
 
@@ -8932,7 +8960,7 @@ func testGetObjectReadSeekFunctionalV2() {
 		return
 	}
 	if n != (offset - 1) {
-		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+string(offset-1)+" got "+string(n), err)
+		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(offset-1, 10)+" got "+strconv.FormatInt(n, 10), err)
 		return
 	}
 

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -5418,28 +5418,37 @@ func testGetObjectReadSeekFunctional() {
 		{0, 0, 0, nil, true, 0, 0},
 		// Start from offset 2048, fetch data and compare
 		{2048, 0, 2048, nil, true, 2048, bufSize},
-		// Start from offset larger than possible: seek now succeeds per the
-		// io.Seeker contract; a subsequent read reports io.EOF.
-		{int64(bufSize) + 1024, 0, int64(bufSize) + 1024, nil, false, 0, 0},
+		// Start from offset larger than possible: Seek rejects it with io.EOF
+		// and keeps the offset unchanged.
+		{int64(bufSize) + 1024, 0, 0, io.EOF, false, 0, 0},
 		// Move to offset 0 without comparing
 		{0, 0, 0, nil, false, 0, 0},
 		// Move one step forward and compare
 		{1, 1, 1, nil, true, 1, bufSize},
-		// Move larger than possible: seek past end now succeeds.
-		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
+		// Move larger than possible: Seek returns io.EOF.
+		{int64(bufSize), 1, 0, io.EOF, false, 0, 0},
 		// Provide negative offset with CUR_SEEK: valid since the resulting
-		// absolute position is not negative.
-		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
-		// Test with whence SEEK_END and with positive offset: seek past end
-		// now succeeds.
-		{1024, 2, int64(bufSize) + 1024, nil, false, 0, 0},
+		// absolute position is within the object.
+		{int64(-1), 1, int64(bufSize) - 1, nil, false, 0, 0},
+		// Test with whence SEEK_END and with positive offset: Seek returns
+		// io.EOF.
+		{1024, 2, 0, io.EOF, false, 0, 0},
 		// Test with whence SEEK_END and with negative offset
 		{-1024, 2, int64(bufSize) - 1024, nil, true, bufSize - 1024, bufSize},
 		// Test with whence SEEK_END and with large negative offset
 		{-int64(bufSize) * 2, 2, 0, seekErr, true, 0, 0},
+		// Seek to exactly the object end; the subsequent read reports io.EOF.
+		{0, 2, int64(bufSize), nil, false, 0, 0},
 	}
 
 	for i, testCase := range testCases {
+		// Snapshot the cursor so rejected seeks can be asserted side-effect
+		// free.
+		prevPos, err := r.Seek(0, io.SeekCurrent)
+		if err != nil {
+			logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, reading the current position failed", i+1), err)
+			return
+		}
 		// Perform seek operation
 		n, err := r.Seek(testCase.offset, testCase.whence)
 		// We expect an error
@@ -5454,6 +5463,12 @@ func testGetObjectReadSeekFunctional() {
 		}
 		// If we expect an error go to the next loop
 		if testCase.err != nil {
+			// A rejected seek must leave the cursor unchanged.
+			curPos, cerr := r.Seek(0, io.SeekCurrent)
+			if cerr != nil || curPos != prevPos {
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, cursor after rejected seek: expected %d, got %d", i+1, prevPos, curPos), cerr)
+				return
+			}
 			continue
 		}
 		// Check the returned seek pos
@@ -5465,12 +5480,12 @@ func testGetObjectReadSeekFunctional() {
 		if testCase.shouldCmp {
 			cmpData(r, testCase.start, testCase.end)
 		}
-		// A successful seek to or past the object end must defer io.EOF to the
+		// A successful seek to the object end must defer io.EOF to the
 		// subsequent read.
-		if !testCase.shouldCmp && testCase.pos >= int64(bufSize) {
+		if !testCase.shouldCmp && testCase.err == nil && testCase.pos >= int64(bufSize) {
 			readN, readErr := r.Read(make([]byte, 1))
 			if readN != 0 || readErr != io.EOF {
-				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to/past object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
 				return
 			}
 		}
@@ -6575,30 +6590,39 @@ func testSSECEncryptedGetObjectReadSeekFunctional() {
 		{0, 0, 0, nil, true, 0, 0},
 		// Start from offset 2048, fetch data and compare
 		{2048, 0, 2048, nil, true, 2048, bufSize},
-		// Start from offset larger than possible: seek now succeeds per the
-		// io.Seeker contract; a subsequent read reports io.EOF.
-		{int64(bufSize) + 1024, 0, int64(bufSize) + 1024, nil, false, 0, 0},
+		// Start from offset larger than possible: Seek rejects it with io.EOF
+		// and keeps the offset unchanged.
+		{int64(bufSize) + 1024, 0, 0, io.EOF, false, 0, 0},
 		// Move to offset 0 without comparing
 		{0, 0, 0, nil, false, 0, 0},
 		// Move one step forward and compare
 		{1, 1, 1, nil, true, 1, bufSize},
-		// Move larger than possible: seek past end now succeeds.
-		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
+		// Move larger than possible: Seek returns io.EOF.
+		{int64(bufSize), 1, 0, io.EOF, false, 0, 0},
 		// Provide negative offset with CUR_SEEK: valid since the resulting
-		// absolute position is not negative.
-		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
-		// Test with whence SEEK_END and with positive offset: seek past end
-		// now succeeds.
-		{1024, 2, int64(bufSize) + 1024, nil, false, 0, 0},
+		// absolute position is within the object.
+		{int64(-1), 1, int64(bufSize) - 1, nil, false, 0, 0},
+		// Test with whence SEEK_END and with positive offset: Seek returns
+		// io.EOF.
+		{1024, 2, 0, io.EOF, false, 0, 0},
 		// Test with whence SEEK_END and with negative offset
 		{-1024, 2, int64(bufSize) - 1024, nil, true, bufSize - 1024, bufSize},
 		// Test with whence SEEK_END and with large negative offset
 		{-int64(bufSize) * 2, 2, 0, fmt.Errorf("Seeking at negative offset not allowed for 2"), false, 0, 0},
 		// Test with invalid whence
 		{0, 3, 0, fmt.Errorf("Invalid whence 3"), false, 0, 0},
+		// Seek to exactly the object end; the subsequent read reports io.EOF.
+		{0, 2, int64(bufSize), nil, false, 0, 0},
 	}
 
 	for i, testCase := range testCases {
+		// Snapshot the cursor so rejected seeks can be asserted side-effect
+		// free.
+		prevPos, err := r.Seek(0, io.SeekCurrent)
+		if err != nil {
+			logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, reading the current position failed", i+1), err)
+			return
+		}
 		// Perform seek operation
 		n, err := r.Seek(testCase.offset, testCase.whence)
 		if err != nil && testCase.err == nil {
@@ -6620,6 +6644,12 @@ func testSSECEncryptedGetObjectReadSeekFunctional() {
 					fmt.Sprintf("Test %d, unexpected err value: expected: %s, found: %s", i+1, testCase.err, err), err)
 				return
 			}
+			// A rejected seek must leave the cursor unchanged.
+			curPos, cerr := r.Seek(0, io.SeekCurrent)
+			if cerr != nil || curPos != prevPos {
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, cursor after rejected seek: expected %d, got %d", i+1, prevPos, curPos), cerr)
+				return
+			}
 		}
 		// Check the returned seek pos
 		if n != testCase.pos {
@@ -6631,12 +6661,12 @@ func testSSECEncryptedGetObjectReadSeekFunctional() {
 		if testCase.shouldCmp {
 			cmpData(r, testCase.start, testCase.end)
 		}
-		// A successful seek to or past the object end must defer io.EOF to the
+		// A successful seek to the object end must defer io.EOF to the
 		// subsequent read.
-		if !testCase.shouldCmp && testCase.pos >= int64(bufSize) {
+		if !testCase.shouldCmp && testCase.err == nil && testCase.pos >= int64(bufSize) {
 			readN, readErr := r.Read(make([]byte, 1))
 			if readN != 0 || readErr != io.EOF {
-				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to/past object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
 				return
 			}
 		}
@@ -6753,30 +6783,39 @@ func testSSES3EncryptedGetObjectReadSeekFunctional() {
 		{0, 0, 0, nil, true, 0, 0},
 		// Start from offset 2048, fetch data and compare
 		{2048, 0, 2048, nil, true, 2048, bufSize},
-		// Start from offset larger than possible: seek now succeeds per the
-		// io.Seeker contract; a subsequent read reports io.EOF.
-		{int64(bufSize) + 1024, 0, int64(bufSize) + 1024, nil, false, 0, 0},
+		// Start from offset larger than possible: Seek rejects it with io.EOF
+		// and keeps the offset unchanged.
+		{int64(bufSize) + 1024, 0, 0, io.EOF, false, 0, 0},
 		// Move to offset 0 without comparing
 		{0, 0, 0, nil, false, 0, 0},
 		// Move one step forward and compare
 		{1, 1, 1, nil, true, 1, bufSize},
-		// Move larger than possible: seek past end now succeeds.
-		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
+		// Move larger than possible: Seek returns io.EOF.
+		{int64(bufSize), 1, 0, io.EOF, false, 0, 0},
 		// Provide negative offset with CUR_SEEK: valid since the resulting
-		// absolute position is not negative.
-		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
-		// Test with whence SEEK_END and with positive offset: seek past end
-		// now succeeds.
-		{1024, 2, int64(bufSize) + 1024, nil, false, 0, 0},
+		// absolute position is within the object.
+		{int64(-1), 1, int64(bufSize) - 1, nil, false, 0, 0},
+		// Test with whence SEEK_END and with positive offset: Seek returns
+		// io.EOF.
+		{1024, 2, 0, io.EOF, false, 0, 0},
 		// Test with whence SEEK_END and with negative offset
 		{-1024, 2, int64(bufSize) - 1024, nil, true, bufSize - 1024, bufSize},
 		// Test with whence SEEK_END and with large negative offset
 		{-int64(bufSize) * 2, 2, 0, fmt.Errorf("Seeking at negative offset not allowed for 2"), false, 0, 0},
 		// Test with invalid whence
 		{0, 3, 0, fmt.Errorf("Invalid whence 3"), false, 0, 0},
+		// Seek to exactly the object end; the subsequent read reports io.EOF.
+		{0, 2, int64(bufSize), nil, false, 0, 0},
 	}
 
 	for i, testCase := range testCases {
+		// Snapshot the cursor so rejected seeks can be asserted side-effect
+		// free.
+		prevPos, err := r.Seek(0, io.SeekCurrent)
+		if err != nil {
+			logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, reading the current position failed", i+1), err)
+			return
+		}
 		// Perform seek operation
 		n, err := r.Seek(testCase.offset, testCase.whence)
 		if err != nil && testCase.err == nil {
@@ -6798,6 +6837,12 @@ func testSSES3EncryptedGetObjectReadSeekFunctional() {
 					fmt.Sprintf("Test %d, unexpected err value: expected: %s, found: %s", i+1, testCase.err, err), err)
 				return
 			}
+			// A rejected seek must leave the cursor unchanged.
+			curPos, cerr := r.Seek(0, io.SeekCurrent)
+			if cerr != nil || curPos != prevPos {
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, cursor after rejected seek: expected %d, got %d", i+1, prevPos, curPos), cerr)
+				return
+			}
 		}
 		// Check the returned seek pos
 		if n != testCase.pos {
@@ -6809,12 +6854,12 @@ func testSSES3EncryptedGetObjectReadSeekFunctional() {
 		if testCase.shouldCmp {
 			cmpData(r, testCase.start, testCase.end)
 		}
-		// A successful seek to or past the object end must defer io.EOF to the
+		// A successful seek to the object end must defer io.EOF to the
 		// subsequent read.
-		if !testCase.shouldCmp && testCase.pos >= int64(bufSize) {
+		if !testCase.shouldCmp && testCase.err == nil && testCase.pos >= int64(bufSize) {
 			readN, readErr := r.Read(make([]byte, 1))
 			if readN != 0 || readErr != io.EOF {
-				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to/past object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
+				logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, read after seek to object end expected zero bytes and io.EOF, got %d bytes and %v", i+1, readN, readErr), readErr)
 				return
 			}
 		}
@@ -8915,20 +8960,41 @@ func testGetObjectReadSeekFunctionalV2() {
 		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(offset, 10)+" got "+strconv.FormatInt(n, 10), err)
 		return
 	}
-	// Seeking past the object end with SEEK_END now succeeds per the
-	// io.Seeker contract; the subsequent read reports io.EOF.
+	// Seeking past the object end with SEEK_END is rejected with io.EOF and
+	// leaves the offset unchanged.
 	n, err = r.Seek(offset, 2)
+	if err != io.EOF {
+		logError(testName, function, args, startTime, "", "Seek past object end should return io.EOF", err)
+		return
+	}
+	if n != 0 {
+		logError(testName, function, args, startTime, "", "Seek past object end should return offset 0, got "+strconv.FormatInt(n, 10), err)
+		return
+	}
+	// A rejected seek must leave the cursor unchanged.
+	n, err = r.Seek(0, 1)
 	if err != nil {
 		logError(testName, function, args, startTime, "", "Seek failed", err)
 		return
 	}
-	if n != st.Size+offset {
-		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(st.Size+offset, 10)+" got "+strconv.FormatInt(n, 10), err)
+	if n != offset {
+		logError(testName, function, args, startTime, "", "Cursor moved after rejected seek, expected "+strconv.FormatInt(offset, 10)+" got "+strconv.FormatInt(n, 10), err)
+		return
+	}
+	// Seeking to exactly the object end succeeds; the subsequent read reports
+	// io.EOF.
+	n, err = r.Seek(0, 2)
+	if err != nil {
+		logError(testName, function, args, startTime, "", "Seek failed", err)
+		return
+	}
+	if n != st.Size {
+		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(st.Size, 10)+" got "+strconv.FormatInt(n, 10), err)
 		return
 	}
 	readN, readErr := r.Read(make([]byte, 1))
 	if readN != 0 || readErr != io.EOF {
-		logError(testName, function, args, startTime, "", "Read after seeking past object end should return zero bytes and EOF", readErr)
+		logError(testName, function, args, startTime, "", "Read after seeking to object end should return zero bytes and EOF", readErr)
 		return
 	}
 	n, err = r.Seek(-offset, 2)

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -5418,18 +5418,21 @@ func testGetObjectReadSeekFunctional() {
 		{0, 0, 0, nil, true, 0, 0},
 		// Start from offset 2048, fetch data and compare
 		{2048, 0, 2048, nil, true, 2048, bufSize},
-		// Start from offset larger than possible
-		{int64(bufSize) + 1024, 0, 0, seekErr, false, 0, 0},
+		// Start from offset larger than possible: seek now succeeds per the
+		// io.Seeker contract; a subsequent read reports io.EOF.
+		{int64(bufSize) + 1024, 0, int64(bufSize) + 1024, nil, false, 0, 0},
 		// Move to offset 0 without comparing
 		{0, 0, 0, nil, false, 0, 0},
 		// Move one step forward and compare
 		{1, 1, 1, nil, true, 1, bufSize},
-		// Move larger than possible
-		{int64(bufSize), 1, 0, seekErr, false, 0, 0},
-		// Provide negative offset with CUR_SEEK
-		{int64(-1), 1, 0, seekErr, false, 0, 0},
-		// Test with whence SEEK_END and with positive offset
-		{1024, 2, int64(bufSize) - 1024, io.EOF, true, 0, 0},
+		// Move larger than possible: seek past end now succeeds.
+		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
+		// Provide negative offset with CUR_SEEK: valid since the resulting
+		// absolute position stays within the object.
+		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
+		// Test with whence SEEK_END and with positive offset: seek past end
+		// now succeeds.
+		{1024, 2, int64(bufSize) + 1024, nil, false, 0, 0},
 		// Test with whence SEEK_END and with negative offset
 		{-1024, 2, int64(bufSize) - 1024, nil, true, bufSize - 1024, bufSize},
 		// Test with whence SEEK_END and with large negative offset
@@ -5441,12 +5444,12 @@ func testGetObjectReadSeekFunctional() {
 		n, err := r.Seek(testCase.offset, testCase.whence)
 		// We expect an error
 		if testCase.err == seekErr && err == nil {
-			logError(testName, function, args, startTime, "", "Test "+string(i+1)+", unexpected err value: expected: "+testCase.err.Error()+", found: "+err.Error(), err)
+			logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, unexpected err value: expected: %v, found: %v", i+1, testCase.err, err), err)
 			return
 		}
 		// We expect a specific error
 		if testCase.err != seekErr && testCase.err != err {
-			logError(testName, function, args, startTime, "", "Test "+string(i+1)+", unexpected err value: expected: "+testCase.err.Error()+", found: "+err.Error(), err)
+			logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, unexpected err value: expected: %v, found: %v", i+1, testCase.err, err), err)
 			return
 		}
 		// If we expect an error go to the next loop
@@ -5455,7 +5458,7 @@ func testGetObjectReadSeekFunctional() {
 		}
 		// Check the returned seek pos
 		if n != testCase.pos {
-			logError(testName, function, args, startTime, "", "Test "+string(i+1)+", number of bytes seeked does not match, expected "+string(testCase.pos)+", got "+string(n), err)
+			logError(testName, function, args, startTime, "", fmt.Sprintf("Test %d, number of bytes seeked does not match, expected %d, got %d", i+1, testCase.pos, n), err)
 			return
 		}
 		// Compare only if shouldCmp is activated
@@ -6563,18 +6566,21 @@ func testSSECEncryptedGetObjectReadSeekFunctional() {
 		{0, 0, 0, nil, true, 0, 0},
 		// Start from offset 2048, fetch data and compare
 		{2048, 0, 2048, nil, true, 2048, bufSize},
-		// Start from offset larger than possible
-		{int64(bufSize) + 1024, 0, 0, io.EOF, false, 0, 0},
+		// Start from offset larger than possible: seek now succeeds per the
+		// io.Seeker contract; a subsequent read reports io.EOF.
+		{int64(bufSize) + 1024, 0, int64(bufSize) + 1024, nil, false, 0, 0},
 		// Move to offset 0 without comparing
 		{0, 0, 0, nil, false, 0, 0},
 		// Move one step forward and compare
 		{1, 1, 1, nil, true, 1, bufSize},
-		// Move larger than possible
-		{int64(bufSize), 1, 0, io.EOF, false, 0, 0},
-		// Provide negative offset with CUR_SEEK
-		{int64(-1), 1, 0, fmt.Errorf("Negative position not allowed for 1"), false, 0, 0},
-		// Test with whence SEEK_END and with positive offset
-		{1024, 2, 0, io.EOF, false, 0, 0},
+		// Move larger than possible: seek past end now succeeds.
+		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
+		// Provide negative offset with CUR_SEEK: valid since the resulting
+		// absolute position stays within the object.
+		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
+		// Test with whence SEEK_END and with positive offset: seek past end
+		// now succeeds.
+		{1024, 2, int64(bufSize) + 1024, nil, false, 0, 0},
 		// Test with whence SEEK_END and with negative offset
 		{-1024, 2, int64(bufSize) - 1024, nil, true, bufSize - 1024, bufSize},
 		// Test with whence SEEK_END and with large negative offset
@@ -6729,18 +6735,21 @@ func testSSES3EncryptedGetObjectReadSeekFunctional() {
 		{0, 0, 0, nil, true, 0, 0},
 		// Start from offset 2048, fetch data and compare
 		{2048, 0, 2048, nil, true, 2048, bufSize},
-		// Start from offset larger than possible
-		{int64(bufSize) + 1024, 0, 0, io.EOF, false, 0, 0},
+		// Start from offset larger than possible: seek now succeeds per the
+		// io.Seeker contract; a subsequent read reports io.EOF.
+		{int64(bufSize) + 1024, 0, int64(bufSize) + 1024, nil, false, 0, 0},
 		// Move to offset 0 without comparing
 		{0, 0, 0, nil, false, 0, 0},
 		// Move one step forward and compare
 		{1, 1, 1, nil, true, 1, bufSize},
-		// Move larger than possible
-		{int64(bufSize), 1, 0, io.EOF, false, 0, 0},
-		// Provide negative offset with CUR_SEEK
-		{int64(-1), 1, 0, fmt.Errorf("Negative position not allowed for 1"), false, 0, 0},
-		// Test with whence SEEK_END and with positive offset
-		{1024, 2, 0, io.EOF, false, 0, 0},
+		// Move larger than possible: seek past end now succeeds.
+		{int64(bufSize), 1, int64(bufSize) * 2, nil, false, 0, 0},
+		// Provide negative offset with CUR_SEEK: valid since the resulting
+		// absolute position stays within the object.
+		{int64(-1), 1, int64(bufSize)*2 - 1, nil, false, 0, 0},
+		// Test with whence SEEK_END and with positive offset: seek past end
+		// now succeeds.
+		{1024, 2, int64(bufSize) + 1024, nil, false, 0, 0},
 		// Test with whence SEEK_END and with negative offset
 		{-1024, 2, int64(bufSize) - 1024, nil, true, bufSize - 1024, bufSize},
 		// Test with whence SEEK_END and with large negative offset
@@ -8879,9 +8888,19 @@ func testGetObjectReadSeekFunctionalV2() {
 		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+string(offset)+" got "+string(n), err)
 		return
 	}
-	_, err = r.Seek(offset, 2)
-	if err == nil {
-		logError(testName, function, args, startTime, "", "Seek on positive offset for whence '2' should error out", err)
+	// Seeking past the object end with SEEK_END now succeeds per the
+	// io.Seeker contract; the subsequent read reports io.EOF.
+	n, err = r.Seek(offset, 2)
+	if err != nil {
+		logError(testName, function, args, startTime, "", "Seek failed", err)
+		return
+	}
+	if n != st.Size+offset {
+		logError(testName, function, args, startTime, "", "Number of seeked bytes does not match, expected "+strconv.FormatInt(st.Size+offset, 10)+" got "+strconv.FormatInt(n, 10), err)
+		return
+	}
+	if _, err = r.Read(make([]byte, 1)); err != io.EOF {
+		logError(testName, function, args, startTime, "", "Read after seeking past object end should return EOF", err)
 		return
 	}
 	n, err = r.Seek(-offset, 2)


### PR DESCRIPTION
## Description

`Object` did not behave like a standard Go reader/seeker at the end-of-object boundary (#2155, #2166):

- Negative offsets were rejected for `io.SeekCurrent` even when the resulting absolute position was still within the object.
- Seeking to exactly `offset == size` succeeded, but the subsequent `Read` issued an unsatisfiable range request (`bytes=N--1`) that the server rejects with 416 `InvalidRange`, instead of returning a clean `io.EOF` — and the saved error permanently poisoned the object for every subsequent `Seek`/`Read`.

This PR (now also carrying the read-side fixes from #2255, which it supersedes):

**Seek semantics**

- Allows negative offsets for `SeekCurrent`/`SeekEnd` as long as the computed absolute position is `>= 0`; positions before the start of the object are rejected for any whence, as are negative absolute offsets for `SeekStart`.
- Allows seeking to exactly the end of the object; the subsequent `Read` reports `io.EOF` (the `Read` path short-circuits at a known EOF instead of issuing an unsatisfiable range request).
- Keeps the long-standing rejection of seeks **past** the end: `Seek` returns `(0, io.EOF)` and leaves the offset unchanged. Per review feedback, the `io.Seeker` contract's "may be allowed" wording permits rejecting past-end seeks, and the existing behavior is kept for compatibility.
- Rewrites the `Seek` doc comment to document the actual behavior instead of attributing it to the `io.Seeker` contract.

**Read/ReadAt EOF robustness** (from #2255)

- `Object.Read`: returns `io.EOF` locally — no request issued — when the current offset is already known to be at or past `objectInfo.Size`.
- `Object.Read` / `Object.ReadAt`: translate a server 416 `InvalidRange` into `io.EOF`. `Read` stores `prevErr = io.EOF` (recoverable via `Seek`); `ReadAt` stores nothing. On `Read` the translation applies only to ranges the SDK generated from a non-zero read offset — a caller-supplied `GetObjectOptions` range on the first read keeps surfacing `InvalidRange` untranslated.
- The request goroutine survives an `InvalidRange` fetch error instead of ending the stream, so a translated `io.EOF` is genuinely recoverable: `Seek` back and read, or issue another in-range `ReadAt`, on the same object (previously any fetch error ended the stream and later calls returned `context canceled`).

**Tests**

- Adds `TestObjectSeekWithSetRange` pinning the current `SetRange`+`Seek` interplay: a `Seek` issued before any `Read` stats the object without the range header, so seek offsets and the end-of-object boundary refer to the full object, and a `Read` after a `Seek` requests a fresh range from the seek offset, discarding the caller's range (cross-ref #2267, which proposes changing the related `Stat` behavior).
- The three functional seek tables and the V2 flow assert that a rejected seek leaves the cursor unchanged (probed via `Seek(0, io.SeekCurrent)`) and that a `Read` after seeking to exactly the end returns zero bytes and `io.EOF`.

## Motivation and Context

Fixes #2155
Fixes #2166
Supersedes #2255 and the approved-but-abandoned #2228.

## How to test this PR?

Unit tests in `api-get-object_test.go`:

```
go test -race -run 'TestObjectSeek|TestGetObjectRead' -v .
```

- Seek: `TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF`, `TestObjectSeekPastObjectSizeReturnsEOF`, `TestObjectSeekCurrentNegativeOffset`, `TestObjectSeekEndUnknownSize`, `TestObjectSeekInvalidWhence`, `TestObjectSeekWithSetRange`
- Read/ReadAt: `TestGetObjectReadAtEOFReturnsEOF`, `TestGetObjectReadUserRangeInvalidRangeSurfaces`, `TestGetObjectReadStaleSizeReturnsEOF`

Plus the extended `functional_tests.go` seek coverage (three seek tables + V2 flow).

### Proof of validity — pre-fix vs fix (unit tests run against both trees)

| Test | Pre-fix (`ccfaaed`) | Fix (this PR) |
| --- | --- | --- |
| `TestObjectSeekAtObjectSizeAllowsSubsequentReadEOF` | ❌ FAIL — `Read` after seeking to `size` issues an unsatisfiable range request (surfaces as a panic in the unit harness) | ✅ PASS |
| `TestObjectSeekPastObjectSizeReturnsEOF` | ❌ FAIL — past-end rejection itself is unchanged, but the final recovery step (`Seek(size)` then `Read`) hits the same at-EOF `Read` defect | ✅ PASS |
| `TestObjectSeekCurrentNegativeOffset` | ❌ FAIL — `expected SeekCurrent with negative offset to succeed, got Negative position not allowed for 1` | ✅ PASS |
| `TestObjectSeekEndUnknownSize`, `TestObjectSeekInvalidWhence`, `TestObjectSeekWithSetRange` | ✅ PASS (pin behavior that is intentionally unchanged) | ✅ PASS |

### Validation (2026-07-21, this exact tree)

| Check | Result |
| --- | --- |
| `go vet ./...`, `gofumpt -d`, `make lint` (golangci-lint) | ✅ clean |
| Unit: `go test -race -run 'TestObjectSeek\|TestGetObject' .` | ✅ 13/13 PASS |
| Functional against a live server: `testGetObjectReadSeekFunctional`, `testSSECEncryptedGetObjectReadSeekFunctional`, `testSSES3EncryptedGetObjectReadSeekFunctional`, `testGetObjectReadSeekFunctionalV2` | ✅ 4/4 PASS × 3 iterations |

Functional runs used the same server setup as this repo's CI (`registry.k5.min.dev/aistor/minio:edge` with TLS certs and `MINIO_KMS_SECRET_KEY`), so the SSE-C and SSE-S3 seek variants executed rather than being skipped.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/miniohq/aistor-object-store-docs/issues/new)
- [x] No internode changes / version interoperability introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object reading when requests reach or pass the end of an object.
  * Reads and `ReadAt` now consistently return `io.EOF` for end-of-object conditions.
  * Prevented unnecessary network requests after seeking to the object’s end.
  * Improved recovery after invalid range responses so subsequent reads can continue.
  * Updated seeking behavior for positions before, at, and beyond the object boundaries.
  * Expanded coverage for seeking, range handling, stale size information, and EOF behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->