### PR TITLE
feat: expose response headers via ObjectInfo.Headers from StatObject/GetObject

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -184,12 +184,14 @@ type ObjectInfo struct {
 	// eg: x-amz-meta-*, content-encoding etc.
 	Metadata http.Header `json:"metadata" xml:"-"`
 
-	// Headers is the raw, unfiltered set of response headers from the
+	// Headers is the unfiltered set of response headers from the
 	// HEAD or GET request that produced this ObjectInfo, e.g.
-	// Content-Range for ranged requests. Set only when the object info
-	// is parsed from an HTTP object response (StatObject, GetObject);
-	// nil elsewhere, e.g. ListObjects or CopyObject results. It
-	// aliases the response headers and must be treated as read-only.
+	// Content-Range for ranged requests. RFC 2047-encoded
+	// x-amz-meta-*/x-minio-meta-* values appear MIME-decoded, matching
+	// Metadata. Set only when the object info is parsed from an HTTP
+	// object response (StatObject, GetObject); nil elsewhere, e.g. in
+	// ListObjects results, on error paths, or for RDMA-backed GetObject.
+	// It aliases the response headers and must be treated as read-only.
 	Headers http.Header `json:"-" xml:"-"`
 
 	// x-amz-meta-* headers stripped "x-amz-meta-" prefix containing the first value.

--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -184,6 +184,14 @@ type ObjectInfo struct {
 	// eg: x-amz-meta-*, content-encoding etc.
 	Metadata http.Header `json:"metadata" xml:"-"`
 
+	// Headers is the raw, unfiltered set of response headers from the
+	// HEAD or GET request that produced this ObjectInfo, e.g.
+	// Content-Range for ranged requests. Set only when the object info
+	// is parsed from an HTTP object response (StatObject, GetObject);
+	// nil elsewhere, e.g. ListObjects or CopyObject results. It
+	// aliases the response headers and must be treated as read-only.
+	Headers http.Header `json:"-" xml:"-"`
+
 	// x-amz-meta-* headers stripped "x-amz-meta-" prefix containing the first value.
 	// Only returned by MinIO servers.
 	UserMetadata StringMap `json:"userMetadata,omitempty"`

--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -192,7 +192,7 @@ type ObjectInfo struct {
 	// object response (StatObject, GetObject); nil elsewhere, e.g. in
 	// ListObjects results, on error paths, or for RDMA-backed GetObject.
 	// It aliases the response headers and must be treated as read-only.
-	Headers http.Header `json:"-" xml:"-"`
+	Headers http.Header `json:"rawHeaders,omitempty" xml:"-"`
 
 	// x-amz-meta-* headers stripped "x-amz-meta-" prefix containing the first value.
 	// Only returned by MinIO servers.

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -858,8 +858,56 @@ func testStatObjectResponseHeaders() {
 		logError(testName, function, args, startTime, "", "StatObject response headers Content-Range mismatch", fmt.Errorf("got %q, want %q", gotContentRange, wantContentRange))
 		return
 	}
-	if st.Headers.Get("Etag") == "" {
+	if st.Headers.Get("ETag") == "" {
 		logError(testName, function, args, startTime, "", "StatObject response headers missing ETag", errors.New("empty ETag header"))
+		return
+	}
+
+	gopts := minio.GetObjectOptions{}
+	err = gopts.SetRange(0, 99)
+	if err != nil {
+		logError(testName, function, args, startTime, "", "SetRange failed", err)
+		return
+	}
+	obj, err := c.GetObject(context.Background(), bucketName, objectName, gopts)
+	if err != nil {
+		logError(testName, function, args, startTime, "", "GetObject failed", err)
+		return
+	}
+	defer obj.Close()
+	// Read first: a first-op Stat issues an un-ranged StatObject by design,
+	// so the ranged GET response headers are observable only after a read.
+	buf := make([]byte, 100)
+	if _, err = io.ReadFull(obj, buf); err != nil {
+		logError(testName, function, args, startTime, "", "GetObject ranged read failed", err)
+		return
+	}
+	gst, err := obj.Stat()
+	if err != nil {
+		logError(testName, function, args, startTime, "", "GetObject Stat failed", err)
+		return
+	}
+	if got := gst.Headers.Get("Content-Range"); got != wantContentRange {
+		logError(testName, function, args, startTime, "", "GetObject response headers Content-Range mismatch", fmt.Errorf("got %q, want %q", got, wantContentRange))
+		return
+	}
+
+	sawObject := false
+	for listInfo := range c.ListObjects(context.Background(), bucketName, minio.ListObjectsOptions{}) {
+		if listInfo.Err != nil {
+			logError(testName, function, args, startTime, "", "ListObjects failed", listInfo.Err)
+			return
+		}
+		if listInfo.Key == objectName {
+			sawObject = true
+		}
+		if listInfo.Headers != nil {
+			logError(testName, function, args, startTime, "", "ListObjects ObjectInfo.Headers expected nil", fmt.Errorf("got %v", listInfo.Headers))
+			return
+		}
+	}
+	if !sawObject {
+		logError(testName, function, args, startTime, "", "ListObjects did not list the uploaded object", errors.New("uploaded object missing from listing"))
 		return
 	}
 

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -795,6 +795,77 @@ func testListObjectVersions() {
 	logSuccess(testName, function, args, startTime)
 }
 
+func testStatObjectResponseHeaders() {
+	// initialize logging params
+	startTime := time.Now()
+	testName := getFuncName()
+	function := "StatObject(bucketName, objectName, opts)"
+	args := map[string]interface{}{}
+
+	c, err := NewClient(ClientConfig{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "MinIO client object creation failed", err)
+		return
+	}
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()), "minio-go-test-")
+	args["bucketName"] = bucketName
+
+	// Make a new bucket.
+	err = c.MakeBucket(context.Background(), bucketName, minio.MakeBucketOptions{Region: "us-east-1"})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "MakeBucket failed", err)
+		return
+	}
+
+	defer cleanupBucket(bucketName, c)
+
+	bufSize := dataFileMap["datafile-33-kB"]
+	reader := getDataReader("datafile-33-kB")
+	defer reader.Close()
+
+	objectName := randString(60, rand.NewSource(time.Now().UnixNano()), "")
+	args["objectName"] = objectName
+
+	_, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize), minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "PutObject failed", err)
+		return
+	}
+
+	opts := minio.StatObjectOptions{}
+	err = opts.SetRange(0, 99)
+	if err != nil {
+		logError(testName, function, args, startTime, "", "SetRange failed", err)
+		return
+	}
+	args["range"] = "0-99"
+
+	st, err := c.StatObject(context.Background(), bucketName, objectName, opts)
+	if err != nil {
+		logError(testName, function, args, startTime, "", "StatObject failed", err)
+		return
+	}
+
+	if st.Size != 100 {
+		logError(testName, function, args, startTime, "", "StatObject ranged size mismatch", fmt.Errorf("got %d, want 100", st.Size))
+		return
+	}
+	wantContentRange := fmt.Sprintf("bytes 0-99/%d", bufSize)
+	gotContentRange := st.Headers.Get("Content-Range")
+	if gotContentRange != wantContentRange {
+		logError(testName, function, args, startTime, "", "StatObject response headers Content-Range mismatch", fmt.Errorf("got %q, want %q", gotContentRange, wantContentRange))
+		return
+	}
+	if st.Headers.Get("Etag") == "" {
+		logError(testName, function, args, startTime, "", "StatObject response headers missing ETag", errors.New("empty ETag header"))
+		return
+	}
+
+	logSuccess(testName, function, args, startTime)
+}
+
 func testStatObjectWithVersioning() {
 	// initialize logging params
 	startTime := time.Now()
@@ -15122,6 +15193,7 @@ func main() {
 		testRemoveObjects()
 		testRemoveObjectsIter()
 		testListObjectVersions()
+		testStatObjectResponseHeaders()
 		testStatObjectWithVersioning()
 		testGetObjectWithVersioning()
 		testCopyObjectWithVersioning()

--- a/utils.go
+++ b/utils.go
@@ -250,7 +250,7 @@ func extractObjMetadata(header http.Header) http.Header {
 }
 
 const (
-	// RFC 7231#section-7.1.1.1 timetamp format. e.g Tue, 29 Apr 2014 18:30:38 GMT
+	// RFC 7231#section-7.1.1.1 timestamp format. e.g Tue, 29 Apr 2014 18:30:38 GMT
 	rfc822TimeFormat                           = "Mon, 2 Jan 2006 15:04:05 GMT"
 	rfc822TimeFormatSingleDigitDay             = "Mon, _2 Jan 2006 15:04:05 GMT"
 	rfc822TimeFormatSingleDigitDayTwoDigitYear = "Mon, _2 Jan 06 15:04:05 GMT"
@@ -412,6 +412,7 @@ func ToObjectInfo(bucketName, objectName string, h http.Header) (ObjectInfo, err
 		// following function filters out a list of standard set of keys
 		// which are not part of object metadata.
 		Metadata:     metadata,
+		Headers:      h,
 		UserMetadata: userMetadata,
 		UserTags:     userTags.ToMap(),
 		UserTagCount: tagCount,

--- a/utils_test.go
+++ b/utils_test.go
@@ -544,3 +544,29 @@ func TestExtractObjMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestToObjectInfoHeaders(t *testing.T) {
+	header := http.Header{
+		"Etag":           []string{`"d41d8cd98f00b204e9800998ecf8427e"`},
+		"Content-Length": []string{"101"},
+		"Content-Type":   []string{"application/octet-stream"},
+		"Last-Modified":  []string{"Mon, 19 Aug 2024 12:00:00 GMT"},
+		"Content-Range":  []string{"bytes 0-100/2000"},
+		"X-Custom-Reply": []string{"custom-value"},
+	}
+	objInfo, err := ToObjectInfo("test-bucket", "test-object", header)
+	if err != nil {
+		t.Fatalf("ToObjectInfo() error = %v", err)
+	}
+	if got := objInfo.Headers.Get("Content-Range"); got != "bytes 0-100/2000" {
+		t.Errorf("Headers.Get(Content-Range) = %q, want %q", got, "bytes 0-100/2000")
+	}
+	if got := objInfo.Headers.Get("X-Custom-Reply"); got != "custom-value" {
+		t.Errorf("Headers.Get(X-Custom-Reply) = %q, want %q", got, "custom-value")
+	}
+	// The existing Metadata filter is unchanged: non-whitelisted response
+	// headers remain absent from Metadata and are reachable only via Headers.
+	if got := objInfo.Metadata.Get("Content-Range"); got != "" {
+		t.Errorf("Metadata.Get(Content-Range) = %q, want empty", got)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -547,12 +547,13 @@ func TestExtractObjMetadata(t *testing.T) {
 
 func TestToObjectInfoHeaders(t *testing.T) {
 	header := http.Header{
-		"Etag":           []string{`"d41d8cd98f00b204e9800998ecf8427e"`},
-		"Content-Length": []string{"101"},
-		"Content-Type":   []string{"application/octet-stream"},
-		"Last-Modified":  []string{"Mon, 19 Aug 2024 12:00:00 GMT"},
-		"Content-Range":  []string{"bytes 0-100/2000"},
-		"X-Custom-Reply": []string{"custom-value"},
+		"Etag":            []string{`"d41d8cd98f00b204e9800998ecf8427e"`},
+		"Content-Length":  []string{"101"},
+		"Content-Type":    []string{"application/octet-stream"},
+		"Last-Modified":   []string{"Mon, 19 Aug 2024 12:00:00 GMT"},
+		"Content-Range":   []string{"bytes 0-100/2000"},
+		"X-Custom-Reply":  []string{"custom-value"},
+		"X-Amz-Meta-Note": []string{"=?UTF-8?Q?d=C3=A9j=C3=A0?="},
 	}
 	objInfo, err := ToObjectInfo("test-bucket", "test-object", header)
 	if err != nil {
@@ -568,5 +569,13 @@ func TestToObjectInfoHeaders(t *testing.T) {
 	// headers remain absent from Metadata and are reachable only via Headers.
 	if got := objInfo.Metadata.Get("Content-Range"); got != "" {
 		t.Errorf("Metadata.Get(Content-Range) = %q, want empty", got)
+	}
+	// RFC 2047-encoded metadata values appear MIME-decoded via Headers,
+	// matching Metadata (the decode is applied to the shared header map).
+	if got := objInfo.Headers.Get("X-Amz-Meta-Note"); got != "déjà" {
+		t.Errorf("Headers.Get(X-Amz-Meta-Note) = %q, want %q", got, "déjà")
+	}
+	if got, want := objInfo.Headers.Get("X-Amz-Meta-Note"), objInfo.Metadata.Get("X-Amz-Meta-Note"); got != want {
+		t.Errorf("Headers meta value = %q, Metadata meta value = %q, want equal", got, want)
 	}
 }


### PR DESCRIPTION
## Description

`StatObject` parsed the HEAD response headers into `ObjectInfo` and then discarded the raw header set, so non-metadata response headers (e.g. `Content-Range` from a ranged HEAD) were unreachable. `Core.GetObject` already returned the raw `http.Header`; `StatObject` had no equivalent.

- Adds a read-only `ObjectInfo.Headers http.Header` field, populated in `ToObjectInfo` for both the HEAD (StatObject) and GET (GetObject) paths. RFC 2047-encoded `x-amz-meta-*`/`x-minio-meta-*` values appear MIME-decoded, matching `Metadata`.
- Set only when the info is parsed from an HTTP object response; `nil` elsewhere, e.g. `ListObjects` results, error paths, or RDMA-backed `GetObject`.
- Aliases the response headers — documented as read-only. No change to the existing `Metadata` whitelist behavior.

Fixes #1993

## Motivation and Context

Callers need access to non-whitelisted response headers (Content-Range, and any server-specific `X-*` reply headers) after a `StatObject`. Today the only header-bearing surface is `ObjectInfo.Metadata`, which is filtered to a fixed whitelist, so headers like `Content-Range` are silently dropped. This restores parity with the `Core.GetObject` precedent (which returns `http.Header`).

## Validation summary

The same test set (unit tests, live before/after repro, new functional test) was run against **both** backends, built from source at current master, with identical results:

| Backend | Source / build | License | Functional test | Live repro |
|---|---|---|---|---|
| MinIO community master | [minio/minio](https://github.com/minio/minio) `7aac2a2` | AGPLv3 (unlicensed community build) | PASS | `Content-Range` exposed via `ObjectInfo.Headers` |
| AIStor master | miniohq/aistor `85ddefa` (`DEVELOPMENT.2026-07-17T01-14-38Z`) | MinIO Enterprise License (`minio.license` applied via `MINIO_LICENSE`) | PASS | `Content-Range` exposed via `ObjectInfo.Headers` |

Unit tests (`go test -short -race ./...`, server-independent) pass: 382 tests in 16 packages.

## How to test this PR?

All commands run against a live server. Evidence below is a side-by-side of the unfixed SDK (`c30a92d`, current upstream master) vs. this branch.

**1. Unit tests** — `go test -short -race ./...`

```
✓ 382 passed in 16 packages   (includes new TestToObjectInfoHeaders in utils_test.go)
```

**2. Live before/after repro** — ranged `StatObject` (`Range: bytes=0-100`) against a 2000-byte object, reading `Content-Range` from each available surface:

BEFORE — SDK @ `c30a92d` (upstream master, fix NOT applied)
```
# A program that reads oi.Headers does not even compile against the unfixed SDK:
./main.go:43:67: oi.Headers undefined (type minio.ObjectInfo has no field or method Headers)

# With the oi.Headers line removed so the rest can run:
StatObject with Range: bytes=0-100 (object is 2000 bytes)
  ObjectInfo.Size                        = 101
  ObjectInfo.Metadata[Content-Range]     = ""     <- dropped (not on whitelist)
  ObjectInfo.UserMetadata[Content-Range] = ""     <- absent
                                                   <- no way to reach Content-Range
```

AFTER — SDK @ this branch, identical output against community master `7aac2a2` and licensed AIStor master `DEVELOPMENT.2026-07-17T01-14-38Z`
```
StatObject with Range: bytes=0-100 (object is 2000 bytes)
  ObjectInfo.Size                        = 101
  ObjectInfo.Metadata[Content-Range]     = ""                  <- unchanged (whitelist intact)
  ObjectInfo.UserMetadata[Content-Range] = ""                  <- unchanged
  ObjectInfo.Headers[Content-Range]      = "bytes 0-100/2000"  <- now reachable
```

**3. Functional test** — new `testStatObjectResponseHeaders` (ranged StatObject and ranged GetObject-after-read, asserts `Headers.Get("Content-Range") == "bytes 0-99/33792"` on both paths, a non-empty ETag, and that `ListObjects` entries carry nil `Headers`):

```
# MinIO community master (minio/minio 7aac2a2, built from source)
{"name":"minio-go: testStatObjectResponseHeaders","function":"StatObject(bucketName, objectName, opts)","args":{"range":"0-99",...},"status":"PASS"}

# AIStor master (miniohq/aistor 85ddefa, DEVELOPMENT.2026-07-17T01-14-38Z, MinIO Enterprise License)
{"name":"minio-go: testStatObjectResponseHeaders","function":"StatObject(bucketName, objectName, opts)","args":{"range":"0-99",...},"status":"PASS"}
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [x] Internal documentation updated (godoc on the new `ObjectInfo.Headers` field)
- [ ] Create a documentation update request [here](https://github.com/miniohq/aistor-object-store-docs/issues/new)
- [x] No internode changes / version interoperability introduced



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `ObjectInfo` now exposes the original HTTP response headers for supported object retrieval operations.
  - Range details (e.g., `Content-Range`), `ETag`, custom response headers, and MIME-decoded metadata values are included.
  - Header details are read-only and not populated for object listings or unsupported/error paths.
- **Bug Fixes**
  - Corrected a timestamp documentation typo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->