### PR TITLE
feat: make IAM credentials expiry window customizable

### DIFF
--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -63,8 +63,10 @@ type IAM struct {
 	// The zero value keeps the default behavior of refreshing once 80%
 	// of the credential lifetime has elapsed. A positive value refreshes
 	// that long before the actual expiration; a value that meets or
-	// exceeds the credential lifetime causes a refresh on every retrieval.
-	// A negative value behaves like the default.
+	// exceeds the credential lifetime places the effective expiration at
+	// or before the moment of retrieval, so the credentials are refreshed
+	// on every subsequent retrieval. A negative value behaves like the
+	// default.
 	ExpiryWindow time.Duration
 
 	// Support for container authorization token https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -106,9 +106,9 @@ func NewIAM(endpoint string) *Credentials {
 }
 
 // expiryWindow returns the configured ExpiryWindow, falling back to
-// DefaultExpiryWindow when unset.
+// DefaultExpiryWindow when unset or negative.
 func (m *IAM) expiryWindow() time.Duration {
-	if m.ExpiryWindow == 0 {
+	if m.ExpiryWindow <= 0 {
 		return DefaultExpiryWindow
 	}
 	return m.ExpiryWindow

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -202,7 +202,11 @@ func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
 
 		stsWebIdentityCreds, err := creds.RetrieveWithCredContext(cc)
 		if err == nil {
-			m.SetExpiration(creds.Expiration(), m.expiryWindow())
+			// Use the raw credential expiration, not creds.Expiration():
+			// the inner provider has already reduced its own expiration by
+			// DefaultExpiryWindow, and applying a window to the reduced
+			// value would compound the two.
+			m.SetExpiration(stsWebIdentityCreds.Expiration, m.expiryWindow())
 		}
 		return stsWebIdentityCreds, err
 

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -58,6 +58,15 @@ type IAM struct {
 	// Region configurable custom region for STS
 	Region string
 
+	// ExpiryWindow configures how long before the actual credential
+	// expiration the credentials are considered expired and refreshed.
+	// The zero value keeps the default behavior of refreshing once 80%
+	// of the credential lifetime has elapsed. A positive value refreshes
+	// that long before the actual expiration; a value that meets or
+	// exceeds the credential lifetime causes a refresh on every retrieval.
+	// A negative value behaves like the default.
+	ExpiryWindow time.Duration
+
 	// Support for container authorization token https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
 	Container struct {
 		AuthorizationToken     string
@@ -92,6 +101,15 @@ func NewIAM(endpoint string) *Credentials {
 	return New(&IAM{
 		Endpoint: endpoint,
 	})
+}
+
+// expiryWindow returns the configured ExpiryWindow, falling back to
+// DefaultExpiryWindow when unset.
+func (m *IAM) expiryWindow() time.Duration {
+	if m.ExpiryWindow == 0 {
+		return DefaultExpiryWindow
+	}
+	return m.ExpiryWindow
 }
 
 // RetrieveWithCredContext is like Retrieve with Cred Context
@@ -184,7 +202,7 @@ func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
 
 		stsWebIdentityCreds, err := creds.RetrieveWithCredContext(cc)
 		if err == nil {
-			m.SetExpiration(creds.Expiration(), DefaultExpiryWindow)
+			m.SetExpiration(creds.Expiration(), m.expiryWindow())
 		}
 		return stsWebIdentityCreds, err
 
@@ -220,8 +238,7 @@ func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
 	if err != nil {
 		return Value{}, err
 	}
-	// Expiry window is set to 10secs.
-	m.SetExpiration(roleCreds.Expiration, DefaultExpiryWindow)
+	m.SetExpiration(roleCreds.Expiration, m.expiryWindow())
 
 	return Value{
 		AccessKeyID:     roleCreds.AccessKeyID,

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -419,3 +419,120 @@ func TestIMDSv1Blocked(t *testing.T) {
 		t.Errorf("Unexpected IMDSv2 failure %s", err)
 	}
 }
+
+func TestIAMCustomExpiryWindow(t *testing.T) {
+	server := initIMDSv2Server("2014-12-16T01:51:37Z", false)
+	defer server.Close()
+
+	p := &IAM{
+		Endpoint:     server.URL,
+		ExpiryWindow: 5 * time.Minute,
+	}
+	p.CurrentTime = func() time.Time {
+		return time.Date(2014, 12, 15, 21, 0, 0, 0, time.UTC)
+	}
+
+	creds, err := p.RetrieveWithCredContext(defaultCredContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if creds.AccessKeyID != "accessKey" {
+		t.Errorf("Expected \"accessKey\", got %s", creds.AccessKeyID)
+	}
+
+	// Expiration (2014-12-16T01:51:37Z) minus the 5 minute window.
+	expectedExpiry := time.Date(2014, 12, 16, 1, 46, 37, 0, time.UTC)
+	if !p.expiration.Equal(expectedExpiry) {
+		t.Errorf("Expected expiration %v, got %v", expectedExpiry, p.expiration)
+	}
+
+	p.CurrentTime = func() time.Time {
+		return time.Date(2014, 12, 16, 1, 46, 0, 0, time.UTC)
+	}
+	if p.IsExpired() {
+		t.Error("Expected creds to not be expired just before the window.")
+	}
+
+	p.CurrentTime = func() time.Time {
+		return time.Date(2014, 12, 16, 1, 47, 0, 0, time.UTC)
+	}
+	if !p.IsExpired() {
+		t.Error("Expected creds to be expired inside the window.")
+	}
+}
+
+func TestIAMZeroExpiryWindowKeepsDefault(t *testing.T) {
+	server := initIMDSv2Server("2014-12-16T01:51:37Z", false)
+	defer server.Close()
+
+	p := &IAM{
+		Endpoint: server.URL,
+	}
+	p.CurrentTime = func() time.Time {
+		return time.Date(2014, 12, 15, 21, 0, 0, 0, time.UTC)
+	}
+
+	if _, err := p.RetrieveWithCredContext(defaultCredContext); err != nil {
+		t.Fatal(err)
+	}
+
+	// The default 80% rule refreshes before the actual expiration.
+	originalExpiration := time.Date(2014, 12, 16, 1, 51, 37, 0, time.UTC)
+	if !p.expiration.Before(originalExpiration) {
+		t.Errorf("Expected expiration before %v with the default window, got %v", originalExpiration, p.expiration)
+	}
+	if p.IsExpired() {
+		t.Error("Expected creds to not be expired right after retrieval.")
+	}
+	if p.ExpiryWindow != 0 {
+		t.Errorf("Expected ExpiryWindow to stay 0 after retrieval, got %v", p.ExpiryWindow)
+	}
+}
+
+func TestIAMExpiryWindowExceedsLifetime(t *testing.T) {
+	server := initIMDSv2Server("2014-12-16T01:51:37Z", false)
+	defer server.Close()
+
+	p := &IAM{
+		Endpoint:     server.URL,
+		ExpiryWindow: 10 * time.Hour,
+	}
+	p.CurrentTime = func() time.Time {
+		return time.Date(2014, 12, 15, 21, 0, 0, 0, time.UTC)
+	}
+
+	if _, err := p.RetrieveWithCredContext(defaultCredContext); err != nil {
+		t.Fatal(err)
+	}
+
+	// A window that exceeds the credential lifetime expires the
+	// credentials immediately, forcing a refresh on every retrieval.
+	if !p.IsExpired() {
+		t.Error("Expected creds to be expired when the window exceeds the credential lifetime.")
+	}
+}
+
+func TestIAMExplicitDefaultExpiryWindow(t *testing.T) {
+	server := initIMDSv2Server("2014-12-16T01:51:37Z", false)
+	defer server.Close()
+
+	p := &IAM{
+		Endpoint:     server.URL,
+		ExpiryWindow: DefaultExpiryWindow,
+	}
+	p.CurrentTime = func() time.Time {
+		return time.Date(2014, 12, 15, 21, 0, 0, 0, time.UTC)
+	}
+
+	if _, err := p.RetrieveWithCredContext(defaultCredContext); err != nil {
+		t.Fatal(err)
+	}
+
+	originalExpiration := time.Date(2014, 12, 16, 1, 51, 37, 0, time.UTC)
+	if !p.expiration.Before(originalExpiration) {
+		t.Errorf("Expected expiration before %v with the default window, got %v", originalExpiration, p.expiration)
+	}
+	if p.IsExpired() {
+		t.Error("Expected creds to not be expired right after retrieval.")
+	}
+}

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -536,3 +536,72 @@ func TestIAMExplicitDefaultExpiryWindow(t *testing.T) {
 		t.Error("Expected creds to not be expired right after retrieval.")
 	}
 }
+
+func TestIAMNegativeExpiryWindowBehavesLikeDefault(t *testing.T) {
+	server := initIMDSv2Server("2014-12-16T01:51:37Z", false)
+	defer server.Close()
+
+	currentTime := func() time.Time {
+		return time.Date(2014, 12, 15, 21, 0, 0, 0, time.UTC)
+	}
+
+	def := &IAM{Endpoint: server.URL}
+	def.CurrentTime = currentTime
+	if _, err := def.RetrieveWithCredContext(defaultCredContext); err != nil {
+		t.Fatal(err)
+	}
+
+	neg := &IAM{
+		Endpoint:     server.URL,
+		ExpiryWindow: -5 * time.Minute,
+	}
+	neg.CurrentTime = currentTime
+	if _, err := neg.RetrieveWithCredContext(defaultCredContext); err != nil {
+		t.Fatal(err)
+	}
+
+	if !neg.expiration.Equal(def.expiration) {
+		t.Errorf("Expected a negative window to produce the default expiration %v, got %v", def.expiration, neg.expiration)
+	}
+}
+
+func TestIAMCustomExpiryWindowWebIdentity(t *testing.T) {
+	server := initStsTestServer("2014-12-16T01:51:37Z")
+	defer server.Close()
+
+	p := &IAM{
+		Endpoint:     server.URL,
+		ExpiryWindow: 5 * time.Minute,
+	}
+	p.CurrentTime = func() time.Time {
+		return time.Date(2014, 12, 15, 21, 0, 0, 0, time.UTC)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "minio-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.Write([]byte("token"))
+	f.Close()
+
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", f.Name())
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1")
+	creds, err := p.RetrieveWithCredContext(defaultCredContext)
+	os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+	os.Unsetenv("AWS_ROLE_ARN")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if creds.AccessKeyID != "accessKey" {
+		t.Errorf("Expected \"accessKey\", got %s", creds.AccessKeyID)
+	}
+
+	// The window applies to the raw credential expiration
+	// (2014-12-16T01:51:37Z) exactly once, not to the inner provider's
+	// already-reduced expiration.
+	expectedExpiry := time.Date(2014, 12, 16, 1, 46, 37, 0, time.UTC)
+	if !p.expiration.Equal(expectedExpiry) {
+		t.Errorf("Expected expiration %v, got %v", expectedExpiry, p.expiration)
+	}
+}

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -581,15 +581,16 @@ func TestIAMCustomExpiryWindowWebIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
-	f.Write([]byte("token"))
-	f.Close()
+	if _, err := f.Write([]byte("token")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", f.Name())
 	t.Setenv("AWS_ROLE_ARN", "arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1")
 	creds, err := p.RetrieveWithCredContext(defaultCredContext)
-	os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
-	os.Unsetenv("AWS_ROLE_ARN")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Adds an exported `ExpiryWindow time.Duration` field to the `IAM` credentials provider so callers can control how long before actual expiration credentials are refreshed.

- Zero value keeps the existing default (`DefaultExpiryWindow`, the 80%-of-lifetime rule) — fully backwards compatible.
- Positive value refreshes that long before actual expiration.
- A window that meets or exceeds the credential lifetime forces a refresh on every retrieval.
- Negative value behaves like the default.
- Applied on both credential paths: web-identity (STS) and IMDS/ECS.
- The web-identity path applies the window to the **raw** STS credential expiration. Previously that path fed the inner provider's already-`DefaultExpiryWindow`-reduced expiration back into `SetExpiration`, compounding the default window (refresh at ~64% of remaining lifetime instead of the documented 80%) and skewing custom windows; it now mirrors the IMDS path.

Fixes #2136

## Motivation and Context

The refresh window was hardcoded to `DefaultExpiryWindow`, with no way to customize it. Users generating presigned URLs under AWS IAM auth hit problems near token end-of-life: AWS caps a presigned URL's lifetime to the remaining token lifetime, so URLs silently expire earlier than requested. A configurable window lets callers refresh credentials earlier and guarantee a longer minimum presigned-URL lifetime.

## How to test this PR?

`go test -race -run ExpiryWindow ./pkg/credentials/`

New tests cover: a custom window (expiry math + boundary), the zero-value default path, a window exceeding the credential lifetime, an explicitly-set default window, an arbitrary negative window (equivalent to the default), and a custom window through the web-identity (STS) path — the last one fails against the pre-fix double-application and passes with the raw-expiration fix.

### Side-by-side proof (base vs. fix)

**Before (pre-fix `iam_aws.go`, new tests present):** the capability does not exist — build fails.

```
# github.com/minio/minio-go/v7/pkg/credentials [github.com/minio/minio-go/v7/pkg/credentials.test]
pkg/credentials/iam_aws_test.go:429:3: unknown field ExpiryWindow in struct literal of type IAM
pkg/credentials/iam_aws_test.go:487:7: p.ExpiryWindow undefined (type *IAM has no field or method ExpiryWindow)
pkg/credentials/iam_aws_test.go:488:73: p.ExpiryWindow undefined (type *IAM has no field or method ExpiryWindow)
pkg/credentials/iam_aws_test.go:498:3: unknown field ExpiryWindow in struct literal of type IAM
pkg/credentials/iam_aws_test.go:521:3: unknown field ExpiryWindow in struct literal of type IAM
FAIL	github.com/minio/minio-go/v7/pkg/credentials [build failed]
```

**After (this PR):** all cases pass.

```
=== RUN   TestIAMCustomExpiryWindow
--- PASS: TestIAMCustomExpiryWindow (0.02s)
=== RUN   TestIAMZeroExpiryWindowKeepsDefault
--- PASS: TestIAMZeroExpiryWindowKeepsDefault (0.01s)
=== RUN   TestIAMExpiryWindowExceedsLifetime
--- PASS: TestIAMExpiryWindowExceedsLifetime (0.01s)
=== RUN   TestIAMExplicitDefaultExpiryWindow
--- PASS: TestIAMExplicitDefaultExpiryWindow (0.01s)
=== RUN   TestIAMNegativeExpiryWindowBehavesLikeDefault
--- PASS: TestIAMNegativeExpiryWindowBehavesLikeDefault (0.02s)
=== RUN   TestIAMCustomExpiryWindowWebIdentity
--- PASS: TestIAMCustomExpiryWindowWebIdentity (0.01s)
PASS
ok  	github.com/minio/minio-go/v7/pkg/credentials	1.145s
```

Full package (`go test -race ./pkg/credentials/`) and `go vet ./pkg/credentials/` both clean — no regressions.

## Test summary: run against BOTH AIStor master and community MinIO master

The `ExpiryWindow` behavior itself is client-side (IAM IMDS/ECS and web-identity credential refresh) and is definitively covered by the unit tests above, which drive a mock IMDS/STS endpoint. To confirm the SDK carrying this change has no regression against either server edition, the identical test matrix was run against a live **AIStor master (licensed)** server and a live **community MinIO master** server — not community only.

**Servers under test**

| Edition | Source | Build version | License |
|---|---|---|---|
| AIStor master | `miniohq/aistor` @ `aea948d17` | `DEVELOPMENT.2026-07-03T05-41-35Z` | MinIO Enterprise License (started with `MINIO_LICENSE` from the mint `minio.license`) |
| Community master | `minio/minio` @ `7aac2a2` | `DEVELOPMENT.2026-02-12T20-18-48Z` | GNU AGPLv3 |

Both single-node, `ENABLE_HTTPS=0`, `MINT_MODE=full`, `SERVER_ENDPOINT=localhost:9000`.

**Results (identical commands on each server)**

| Test set | Command | AIStor master | Community master |
|---|---|---|---|
| IAM credential unit tests (incl. 4 new `ExpiryWindow` cases), race | `go test -race -run 'ExpiryWindow\|TestIAM' ./pkg/credentials/` | ✅ 10 PASS / 0 FAIL | ✅ 10 PASS / 0 FAIL |
| SDK core live tests (`core_test.go`) | `SERVER_ENDPOINT=… go test -count=1 .` | ✅ 78 PASS / 0 FAIL | ✅ 78 PASS / 0 FAIL |
| Functional (mint) suite | `SERVER_ENDPOINT=… MINT_MODE=full ./functional_tests` | ✅ 143 PASS / 0 FAIL / 28 NA | ✅ 109 PASS / 0 FAIL / 30 NA |

`NA` = capability not applicable to a single-node, no-KMS deployment (e.g. SSE-S3 copy-part). Note: this matrix was captured before the two follow-up unit tests (negative window, web-identity custom window) were added; those are covered by the unit-test evidence above at the current head. AIStor exercises more test cases (143 vs 109 PASS) reflecting its broader feature set; **zero failures on either edition**.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [x] Internal documentation updated (godoc on the new field)
- [ ] Create a documentation update request [here](https://github.com/miniohq/aistor-object-store-docs/issues/new)
- [x] No internode changes / version interoperability introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable credential expiration windows for IAM credentials.
  * Supports custom refresh windows, with default behavior retained for zero or negative values.
  * Applies expiration handling consistently across standard and web identity credentials.
  * Credentials with windows exceeding their lifetime are refreshed immediately.

* **Tests**
  * Added coverage for custom, default, negative, oversized, and web identity expiration windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->