### PR TITLE
fix: Stat() returns Size 0 for RDMA GET objects

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -436,7 +436,18 @@ func (o *Object) Stat() (ObjectInfo, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
-	if o.prevErr != nil && o.prevErr != io.EOF || o.isClosed {
+	if o.prevErr != nil && o.prevErr != io.EOF {
+		return ObjectInfo{}, o.prevErr
+	}
+
+	// When the object info is already known (e.g. the RDMA GET path, whose
+	// payload is delivered out-of-band so the object is created closed, or a
+	// previously completed request) report it, even for a closed object.
+	if o.objectInfoSet {
+		return o.objectInfo, nil
+	}
+
+	if o.isClosed {
 		return ObjectInfo{}, o.prevErr
 	}
 


### PR DESCRIPTION
## Problem

The RDMA `GetObject` fast path (`api-get-object.go`, gated on `opts.RDMABuffer != nil && c.rdmaEnabled`) builds the returned `*Object` with `isClosed: true`, `objectInfoSet: true` and `objectInfo{Size: n}` — the payload is delivered out-of-band over RDMA, so there is no streaming HTTP body to read.

`Object.Stat()` short-circuits on `o.isClosed`:

```go
if o.prevErr != nil && o.prevErr != io.EOF || o.isClosed {
    return ObjectInfo{}, o.prevErr   // Size 0, nil
}
...
return o.objectInfo, nil             // never reached for RDMA
```

so `Stat().Size` is **always 0** for an RDMA GET, even though the transfer moved the full object. Callers that validate the returned size (e.g. warp `--rdma`) see a spurious `unexpected download size, got:0` on every RDMA GET.

## Fix

Return the cached `objectInfo` when `objectInfoSet` is true, before the `isClosed` check. Error-closed objects are still caught first by the `prevErr` guard, so existing semantics are preserved.

## Testing

Validated against an RDMA-capable MinIO AIStor endpoint with warp `--rdma=cpu` (256 MiB objects, coe cluster): `unexpected download size` errors went from 100% of RDMA GETs to **0** at concurrency 4 and 32; GET throughput 7.0 GiB/s (c4) / 36.2 GiB/s (c32), 0 PUT errors. `go build ./...`, `go vet`, gofmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed object status retrieval after closure.
  * Cached object information is now returned when available, including for RDMA GET operations.
  * Improved handling of closed objects without previously stored status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->