### PR TITLE
fix: add guard check for avoiding potential panic

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -76,33 +76,35 @@ func (c *Client) getBucketLocation(ctx context.Context, bucketName string) (stri
 
 // processes the getBucketLocation http response from the server.
 func processBucketLocationResponse(resp *http.Response, bucketName string) (bucketLocation string, err error) {
-	if resp != nil {
-		if resp.StatusCode != http.StatusOK {
-			err = httpRespToErrorResponse(resp, bucketName, "")
-			errResp := ToErrorResponse(err)
-			// For access denied error, it could be an anonymous
-			// request. Move forward and let the top level callers
-			// succeed if possible based on their policy.
-			switch errResp.Code {
-			case NotImplemented:
-				switch errResp.Server {
-				case "AmazonSnowball":
-					return "snowball", nil
-				case "cloudflare":
-					return "us-east-1", nil
-				}
-			case AuthorizationHeaderMalformed:
-				fallthrough
-			case InvalidRegion:
-				fallthrough
-			case AccessDenied:
-				if errResp.Region == "" {
-					return "us-east-1", nil
-				}
-				return errResp.Region, nil
+	if resp == nil {
+		return "", errInvalidArgument("Empty http response. " + reportIssue)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = httpRespToErrorResponse(resp, bucketName, "")
+		errResp := ToErrorResponse(err)
+		// For access denied error, it could be an anonymous
+		// request. Move forward and let the top level callers
+		// succeed if possible based on their policy.
+		switch errResp.Code {
+		case NotImplemented:
+			switch errResp.Server {
+			case "AmazonSnowball":
+				return "snowball", nil
+			case "cloudflare":
+				return "us-east-1", nil
 			}
-			return "", err
+		case AuthorizationHeaderMalformed:
+			fallthrough
+		case InvalidRegion:
+			fallthrough
+		case AccessDenied:
+			if errResp.Region == "" {
+				return "us-east-1", nil
+			}
+			return errResp.Region, nil
 		}
+		return "", err
 	}
 
 	// Extract location.

--- a/bucket-cache_test.go
+++ b/bucket-cache_test.go
@@ -346,4 +346,13 @@ func TestProcessBucketLocationResponse(t *testing.T) {
 			}
 		}
 	}
+
+	// Regression test: a nil response must return an error instead of
+	// panicking on a nil-dereference when accessing resp.Body.
+	t.Run("nil response", func(t *testing.T) {
+		_, err := processBucketLocationResponse(nil, "my-bucket")
+		if err == nil {
+			t.Fatal("Expected an error for nil response, but got nil")
+		}
+	})
 }


### PR DESCRIPTION
When resp was nil, the nil-check only guarded the status-code branch, so execution fell through to xmlDecoder(resp.Body, ...) and panicked.

Return early with an error instead, reusing the existing "Empty http response" pattern from httpRespToErrorResponse.

Found by PostgresPro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket-location response handling to safely return an error when no HTTP response is available.
  * Refined error processing for non-success responses, including mapping server responses and applying region fallback behavior for authorization/region/access-related errors.
  * Added a regression test to prevent nil-response crashes during bucket-location processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->