### PR TITLE
fix: return delete-marker ObjectInfo from StatObject alongside the error

### DIFF
--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -24,22 +24,27 @@ jobs:
     - name: Checkout minio-go
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         path: "minio-go"
 
     - name: Checkout minio-cpp
       uses: actions/checkout@v4
       with:
         repository: minio/minio-cpp
+        persist-credentials: false
         path: "minio-cpp"
 
     - name: Checkout vcpkg
       uses: actions/checkout@v4
       with:
         repository: microsoft/vcpkg
-        # Pinned: vcpkg master requires a newer CMake than the arm64
-        # runner image ships (scripts use string(JSON ... STRING_ENCODE)
-        # since microsoft/vcpkg@5397c5c9f), which fails every arm64 run.
+        # Pinned: vcpkg master needs CMake >= 4.3 (scripts use
+        # string(JSON ... STRING_ENCODE) since microsoft/vcpkg@5397c5c9f).
+        # vcpkg bootstraps its own CMake 4.4 on linux-amd64 but not on
+        # linux-arm64, which falls back to apt's CMake 3.28 and fails
+        # every arm64 run. Unpin once vcpkg supplies an arm64 CMake.
         ref: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # tag 2026.06.24
+        persist-credentials: false
         path: "vcpkg"
 
     - name: Install system dependencies

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -36,6 +36,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: microsoft/vcpkg
+        # Pinned: vcpkg master requires a newer CMake than the arm64
+        # runner image ships (scripts use string(JSON ... STRING_ENCODE)
+        # since microsoft/vcpkg@5397c5c9f), which fails every arm64 run.
+        ref: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # tag 2026.06.24
         path: "vcpkg"
 
     - name: Install system dependencies

--- a/api-stat.go
+++ b/api-stat.go
@@ -57,7 +57,11 @@ func (c *Client) BucketExists(ctx context.Context, bucketName string) (bool, err
 }
 
 // StatObject verifies if object exists, you have permission to access it
-// and returns information about the object.
+// and returns information about the object. When the returned error is
+// non-nil but a response was received, the ObjectInfo still carries the
+// VersionID and IsDeleteMarker values parsed from the response headers,
+// plus ReplicationReady on every error path except the versioned
+// delete-marker 405.
 func (c *Client) StatObject(ctx context.Context, bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
@@ -92,8 +96,9 @@ func (c *Client) StatObject(ctx context.Context, bucketName, objectName string, 
 	})
 	defer closeResponse(resp)
 	if err != nil {
-		// Surface the version, delete-marker, and replication-ready
-		// fields carried in the response headers alongside the error.
+		// executeMethod returns a non-nil error for every non-success
+		// status. When a response exists, its headers still carry the
+		// version and delete-marker fields — surface them with the error.
 		if resp == nil {
 			return ObjectInfo{}, err
 		}
@@ -115,7 +120,7 @@ func (c *Client) StatObject(ctx context.Context, bucketName, objectName string, 
 		return ObjectInfo{
 			VersionID:        resp.Header.Get(amzVersionID),
 			IsDeleteMarker:   deleteMarker,
-			ReplicationReady: replicationReady,
+			ReplicationReady: replicationReady, // whether delete marker can be replicated
 		}, err
 	}
 

--- a/api-stat.go
+++ b/api-stat.go
@@ -61,7 +61,8 @@ func (c *Client) BucketExists(ctx context.Context, bucketName string) (bool, err
 // non-nil but a response was received, the ObjectInfo still carries the
 // VersionID and IsDeleteMarker values parsed from the response headers,
 // plus ReplicationReady on every error path except the versioned
-// delete-marker 405.
+// delete-marker 405 (an asymmetry preserved from the pre-v7.0.93
+// behavior, which populated ReplicationReady on the generic branch only).
 func (c *Client) StatObject(ctx context.Context, bucketName, objectName string, opts StatObjectOptions) (ObjectInfo, error) {
 	// Input validation.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {

--- a/api-stat.go
+++ b/api-stat.go
@@ -92,32 +92,31 @@ func (c *Client) StatObject(ctx context.Context, bucketName, objectName string, 
 	})
 	defer closeResponse(resp)
 	if err != nil {
-		return ObjectInfo{}, err
-	}
-
-	if resp != nil {
+		// Surface the version, delete-marker, and replication-ready
+		// fields carried in the response headers alongside the error.
+		if resp == nil {
+			return ObjectInfo{}, err
+		}
 		deleteMarker := resp.Header.Get(amzDeleteMarker) == "true"
 		replicationReady := resp.Header.Get(minioTgtReplicationReady) == "true"
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-			if resp.StatusCode == http.StatusMethodNotAllowed && opts.VersionID != "" && deleteMarker {
-				errResp := ErrorResponse{
-					StatusCode: resp.StatusCode,
-					Code:       MethodNotAllowed,
-					Message:    s3ErrorResponseMap[MethodNotAllowed],
-					BucketName: bucketName,
-					Key:        objectName,
-				}
-				return ObjectInfo{
-					VersionID:      resp.Header.Get(amzVersionID),
-					IsDeleteMarker: deleteMarker,
-				}, errResp
+		if resp.StatusCode == http.StatusMethodNotAllowed && opts.VersionID != "" && deleteMarker {
+			errResp := ErrorResponse{
+				StatusCode: resp.StatusCode,
+				Code:       MethodNotAllowed,
+				Message:    s3ErrorResponseMap[MethodNotAllowed],
+				BucketName: bucketName,
+				Key:        objectName,
 			}
 			return ObjectInfo{
-				VersionID:        resp.Header.Get(amzVersionID),
-				IsDeleteMarker:   deleteMarker,
-				ReplicationReady: replicationReady, // whether delete marker can be replicated
-			}, httpRespToErrorResponse(resp, bucketName, objectName)
+				VersionID:      resp.Header.Get(amzVersionID),
+				IsDeleteMarker: deleteMarker,
+			}, errResp
 		}
+		return ObjectInfo{
+			VersionID:        resp.Header.Get(amzVersionID),
+			IsDeleteMarker:   deleteMarker,
+			ReplicationReady: replicationReady,
+		}, err
 	}
 
 	return ToObjectInfo(bucketName, objectName, resp.Header)

--- a/api-stat_test.go
+++ b/api-stat_test.go
@@ -205,3 +205,20 @@ func TestStatObjectErrorHeaders(t *testing.T) {
 		t.Error("expected ReplicationReady to be true")
 	}
 }
+
+// Tests that the delete-marker branch is gated on the 405 status: a
+// non-405 error carrying the same delete-marker and version shape must
+// still take the generic path.
+func TestStatObjectDeleteMarkerNon405(t *testing.T) {
+	clnt := newTestStatClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(amzDeleteMarker, "true")
+		w.Header().Set(amzVersionID, "test-version-id")
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, err := clnt.StatObject(context.Background(), "bucket-name", "object-name",
+		StatObjectOptions{VersionID: "test-version-id"})
+	if errResp := ToErrorResponse(err); errResp.Code != NoSuchKey {
+		t.Errorf("error code = %q, want %q", errResp.Code, NoSuchKey)
+	}
+}

--- a/api-stat_test.go
+++ b/api-stat_test.go
@@ -21,35 +21,40 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
-// Tests that StatObject returns the delete-marker ObjectInfo fields
-// (VersionID, IsDeleteMarker) and the MethodNotAllowed error code when a
-// versioned HEAD hits a delete marker (HTTP 405).
-func TestStatObjectDeleteMarker(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set(amzDeleteMarker, "true")
-		w.Header().Set(amzVersionID, "test-version-id")
-		w.WriteHeader(http.StatusMethodNotAllowed)
-	}))
-	defer srv.Close()
+// newTestStatClient returns a Client pointed at an httptest server that
+// serves handler; the server is closed via t.Cleanup.
+func newTestStatClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
 
-	u, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clnt, err := New(u.Host, &Options{
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
 		Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
 		Region: "us-east-1",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	return clnt
+}
+
+// Tests that StatObject returns the delete-marker ObjectInfo fields
+// (VersionID and IsDeleteMarker — ReplicationReady is deliberately not
+// merged into this return) and the MethodNotAllowed error code when a
+// versioned HEAD hits a delete marker (HTTP 405).
+func TestStatObjectDeleteMarker(t *testing.T) {
+	clnt := newTestStatClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(amzDeleteMarker, "true")
+		w.Header().Set(amzVersionID, "test-version-id")
+		w.Header().Set(minioTgtReplicationReady, "true")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
 
 	objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name",
 		StatObjectOptions{VersionID: "test-version-id"})
@@ -63,11 +68,18 @@ func TestStatObjectDeleteMarker(t *testing.T) {
 	if errResp.StatusCode != http.StatusMethodNotAllowed {
 		t.Errorf("error status = %d, want %d", errResp.StatusCode, http.StatusMethodNotAllowed)
 	}
+	if errResp.BucketName != "bucket-name" || errResp.Key != "object-name" {
+		t.Errorf("error bucket/key = %q/%q, want %q/%q",
+			errResp.BucketName, errResp.Key, "bucket-name", "object-name")
+	}
 	if !objInfo.IsDeleteMarker {
 		t.Error("expected IsDeleteMarker to be true")
 	}
 	if objInfo.VersionID != "test-version-id" {
 		t.Errorf("VersionID = %q, want %q", objInfo.VersionID, "test-version-id")
+	}
+	if objInfo.ReplicationReady {
+		t.Error("expected ReplicationReady to stay false on the delete-marker return")
 	}
 }
 
@@ -75,6 +87,7 @@ func TestStatObjectDeleteMarker(t *testing.T) {
 // shape (the x-amz-delete-marker header, or a version-targeted stat)
 // falls through to the generic error path with the raw status code.
 func TestStatObjectMethodNotAllowedGeneric(t *testing.T) {
+	const wantCode = "405 Method Not Allowed"
 	tests := []struct {
 		name         string
 		deleteMarker bool
@@ -85,35 +98,21 @@ func TestStatObjectMethodNotAllowedGeneric(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			clnt := newTestStatClient(t, func(w http.ResponseWriter, _ *http.Request) {
 				if tt.deleteMarker {
 					w.Header().Set(amzDeleteMarker, "true")
 				}
 				w.Header().Set(amzVersionID, "test-version-id")
 				w.WriteHeader(http.StatusMethodNotAllowed)
-			}))
-			defer srv.Close()
-
-			u, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			clnt, err := New(u.Host, &Options{
-				Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
-				Region: "us-east-1",
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name",
 				StatObjectOptions{VersionID: tt.versionID})
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
-			if errResp := ToErrorResponse(err); errResp.Code != "405 Method Not Allowed" {
-				t.Errorf("error code = %q, want %q", errResp.Code, "405 Method Not Allowed")
+			if errResp := ToErrorResponse(err); errResp.Code != wantCode {
+				t.Errorf("error code = %q, want %q", errResp.Code, wantCode)
 			}
 			if objInfo.IsDeleteMarker != tt.deleteMarker {
 				t.Errorf("IsDeleteMarker = %v, want %v", objInfo.IsDeleteMarker, tt.deleteMarker)
@@ -130,26 +129,12 @@ func TestStatObjectMethodNotAllowedGeneric(t *testing.T) {
 func TestStatObjectNoContentSuccess(t *testing.T) {
 	for _, status := range []int{http.StatusAccepted, http.StatusNoContent} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			clnt := newTestStatClient(t, func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Last-Modified", "Thu, 30 Jul 2026 00:00:00 GMT")
 				w.Header().Set("ETag", `"deadbeef"`)
 				w.Header().Set(amzVersionID, "test-version-id")
 				w.WriteHeader(status)
-			}))
-			defer srv.Close()
-
-			u, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			clnt, err := New(u.Host, &Options{
-				Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
-				Region: "us-east-1",
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name", StatObjectOptions{})
 			if err != nil {
@@ -187,7 +172,7 @@ func TestStatObjectNoResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unreachable endpoint, got nil")
 	}
-	if objInfo.IsDeleteMarker || objInfo.VersionID != "" || objInfo.ETag != "" {
+	if !reflect.DeepEqual(objInfo, ObjectInfo{}) {
 		t.Errorf("expected zero ObjectInfo, got %+v", objInfo)
 	}
 }
@@ -196,26 +181,12 @@ func TestStatObjectNoResponse(t *testing.T) {
 // headers on a generic error response, e.g. HEAD on an object whose
 // latest version is a delete marker (HTTP 404).
 func TestStatObjectErrorHeaders(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	clnt := newTestStatClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set(amzDeleteMarker, "true")
 		w.Header().Set(amzVersionID, "test-version-id")
 		w.Header().Set(minioTgtReplicationReady, "true")
 		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	u, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clnt, err := New(u.Host, &Options{
-		Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
-		Region: "us-east-1",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name", StatObjectOptions{})
 	if err == nil {

--- a/api-stat_test.go
+++ b/api-stat_test.go
@@ -1,0 +1,236 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// Tests that StatObject returns the delete-marker ObjectInfo fields
+// (VersionID, IsDeleteMarker) and the MethodNotAllowed error code when a
+// versioned HEAD hits a delete marker (HTTP 405).
+func TestStatObjectDeleteMarker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(amzDeleteMarker, "true")
+		w.Header().Set(amzVersionID, "test-version-id")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clnt, err := New(u.Host, &Options{
+		Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name",
+		StatObjectOptions{VersionID: "test-version-id"})
+	if err == nil {
+		t.Fatal("expected error for delete marker, got nil")
+	}
+	errResp := ToErrorResponse(err)
+	if errResp.Code != MethodNotAllowed {
+		t.Errorf("error code = %q, want %q", errResp.Code, MethodNotAllowed)
+	}
+	if errResp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("error status = %d, want %d", errResp.StatusCode, http.StatusMethodNotAllowed)
+	}
+	if !objInfo.IsDeleteMarker {
+		t.Error("expected IsDeleteMarker to be true")
+	}
+	if objInfo.VersionID != "test-version-id" {
+		t.Errorf("VersionID = %q, want %q", objInfo.VersionID, "test-version-id")
+	}
+}
+
+// Tests that a 405 response missing either half of the delete-marker
+// shape (the x-amz-delete-marker header, or a version-targeted stat)
+// falls through to the generic error path with the raw status code.
+func TestStatObjectMethodNotAllowedGeneric(t *testing.T) {
+	tests := []struct {
+		name         string
+		deleteMarker bool
+		versionID    string
+	}{
+		{"no delete-marker header", false, "test-version-id"},
+		{"no version id", true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.deleteMarker {
+					w.Header().Set(amzDeleteMarker, "true")
+				}
+				w.Header().Set(amzVersionID, "test-version-id")
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}))
+			defer srv.Close()
+
+			u, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			clnt, err := New(u.Host, &Options{
+				Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
+				Region: "us-east-1",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name",
+				StatObjectOptions{VersionID: tt.versionID})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if errResp := ToErrorResponse(err); errResp.Code != "405 Method Not Allowed" {
+				t.Errorf("error code = %q, want %q", errResp.Code, "405 Method Not Allowed")
+			}
+			if objInfo.IsDeleteMarker != tt.deleteMarker {
+				t.Errorf("IsDeleteMarker = %v, want %v", objInfo.IsDeleteMarker, tt.deleteMarker)
+			}
+			if objInfo.VersionID != "test-version-id" {
+				t.Errorf("VersionID = %q, want %q", objInfo.VersionID, "test-version-id")
+			}
+		})
+	}
+}
+
+// Tests that 202 and 204 responses, which executeMethod treats as
+// success, are parsed like a 200 instead of being converted into errors.
+func TestStatObjectNoContentSuccess(t *testing.T) {
+	for _, status := range []int{http.StatusAccepted, http.StatusNoContent} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Last-Modified", "Thu, 30 Jul 2026 00:00:00 GMT")
+				w.Header().Set("ETag", `"deadbeef"`)
+				w.Header().Set(amzVersionID, "test-version-id")
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			u, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			clnt, err := New(u.Host, &Options{
+				Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
+				Region: "us-east-1",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name", StatObjectOptions{})
+			if err != nil {
+				t.Fatalf("expected nil error for %d, got %v", status, err)
+			}
+			if objInfo.ETag != "deadbeef" {
+				t.Errorf("ETag = %q, want %q", objInfo.ETag, "deadbeef")
+			}
+			if objInfo.VersionID != "test-version-id" {
+				t.Errorf("VersionID = %q, want %q", objInfo.VersionID, "test-version-id")
+			}
+		})
+	}
+}
+
+// Tests that StatObject returns a zero ObjectInfo when the request fails
+// before any response is received.
+func TestStatObjectNoResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	addr := srv.Listener.Addr().String()
+	srv.Close()
+
+	clnt, err := New(addr, &Options{
+		Creds:      credentials.NewStaticV4("foo", "foo12345", ""),
+		Region:     "us-east-1",
+		MaxRetries: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name", StatObjectOptions{})
+	if err == nil {
+		t.Fatal("expected error for unreachable endpoint, got nil")
+	}
+	if objInfo.IsDeleteMarker || objInfo.VersionID != "" || objInfo.ETag != "" {
+		t.Errorf("expected zero ObjectInfo, got %+v", objInfo)
+	}
+}
+
+// Tests that StatObject surfaces the delete-marker and replication-ready
+// headers on a generic error response, e.g. HEAD on an object whose
+// latest version is a delete marker (HTTP 404).
+func TestStatObjectErrorHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(amzDeleteMarker, "true")
+		w.Header().Set(amzVersionID, "test-version-id")
+		w.Header().Set(minioTgtReplicationReady, "true")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clnt, err := New(u.Host, &Options{
+		Creds:  credentials.NewStaticV4("foo", "foo12345", ""),
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name", StatObjectOptions{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errResp := ToErrorResponse(err); errResp.Code != NoSuchKey {
+		t.Errorf("error code = %q, want %q", errResp.Code, NoSuchKey)
+	}
+	if !objInfo.IsDeleteMarker {
+		t.Error("expected IsDeleteMarker to be true")
+	}
+	if objInfo.VersionID != "test-version-id" {
+		t.Errorf("VersionID = %q, want %q", objInfo.VersionID, "test-version-id")
+	}
+	if !objInfo.ReplicationReady {
+		t.Error("expected ReplicationReady to be true")
+	}
+}

--- a/api-stat_test.go
+++ b/api-stat_test.go
@@ -179,16 +179,21 @@ func TestStatObjectNoResponse(t *testing.T) {
 
 // Tests that StatObject surfaces the delete-marker and replication-ready
 // headers on a generic error response, e.g. HEAD on an object whose
-// latest version is a delete marker (HTTP 404).
+// latest version is a delete marker (HTTP 404) — and that the
+// IsReplicationReadyForDeleteMarker option puts the matching check
+// header on the request.
 func TestStatObjectErrorHeaders(t *testing.T) {
-	clnt := newTestStatClient(t, func(w http.ResponseWriter, _ *http.Request) {
+	var gotReplicationReadyCheck string
+	clnt := newTestStatClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotReplicationReadyCheck = r.Header.Get(isMinioTgtReplicationReady)
 		w.Header().Set(amzDeleteMarker, "true")
 		w.Header().Set(amzVersionID, "test-version-id")
 		w.Header().Set(minioTgtReplicationReady, "true")
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name", StatObjectOptions{})
+	objInfo, err := clnt.StatObject(context.Background(), "bucket-name", "object-name",
+		StatObjectOptions{Internal: AdvancedGetOptions{IsReplicationReadyForDeleteMarker: true}})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -203,6 +208,10 @@ func TestStatObjectErrorHeaders(t *testing.T) {
 	}
 	if !objInfo.ReplicationReady {
 		t.Error("expected ReplicationReady to be true")
+	}
+	if gotReplicationReadyCheck != "true" {
+		t.Errorf("request header %s = %q, want %q",
+			isMinioTgtReplicationReady, gotReplicationReadyCheck, "true")
 	}
 }
 


### PR DESCRIPTION
## Description

`StatObject` stopped returning delete-marker information. This PR restores it.

**What broke.** PR #2115, first released in v7.0.93, changed `executeMethod` to return a non-nil error for every response outside its success set. That set was 200/204/206; #2252 later added 202. `StatObject` returns early with a zero `ObjectInfo` whenever the error is non-nil, so its delete-marker block never runs. That block is what handled the 405 and 404 responses that carry delete-marker headers.

**What this PR does.** It moves that logic into the `err != nil` branch and removes the old block. `StatObject` now behaves as it did before v7.0.93:

- Stat of a delete marker — a HEAD with a `VersionID`, answered `405` with `x-amz-delete-marker: true` — returns `ObjectInfo{VersionID, IsDeleteMarker}` together with a `MethodNotAllowed` `ErrorResponse`. The SDK synthesizes that error exactly as before v7.0.93: it does not merge in the fields parsed from the server, and it does not merge in `ReplicationReady`. Tests pin both omissions.
- Every other error response returns the `ObjectInfo` built from the headers (`VersionID`, `IsDeleteMarker`, `ReplicationReady`) together with the error that `executeMethod` already parsed.
- When there is no response at all (`resp == nil`), `StatObject` returns a zero `ObjectInfo` with the error, as before.

**One behavior change beyond the restore.** `executeMethod` treats 202 and 204 as success, so a HEAD that returns either is now parsed like a 200. The old block turned them into errors. No known S3 server returns 202 or 204 for a HEAD.

The PR changes two files: `api-stat.go` and `api-stat_test.go`.

It also carried two `go-rdma.yml` CI fixes for a while — a vcpkg checkout pin and `persist-credentials: false` — because a broken arm64 job was blocking CI here. #2276 and #2279 have since landed the same fixes upstream, so this branch now takes the upstream version of that file and no longer changes it.

Fixes #2260

## Is this a breaking change?

No. This is a regression fix.

- **The API surface does not change.** `StatObject`'s signature, `ObjectInfo`'s fields, and every exported identifier are untouched. Existing callers compile unchanged.
- **The error contract holds.** The error path still returns a non-nil error of the same type, built by `httpRespToErrorResponse` inside `executeMethod`, so `minio.ToErrorResponse(err)` keeps working.
- **The behavior change restores the documented contract.** Returning `VersionID`, `IsDeleteMarker`, and `ReplicationReady` alongside the error is what `StatObject` did before v7.0.93, and losing them is what #2260 reports. #2115 made the change unintentionally; this PR undoes it. The only caller this affects is one that relied on `ObjectInfo` being zero whenever the error is non-nil. The docs never promised that, and the new doc comment now states the contract.
- **The 202/204 change is real but inert in practice.** Those statuses now parse like a 200 instead of becoming errors. No known S3 server returns them for a HEAD, and treating a success status as success is the more correct behavior.
- **Nothing else ships with it.** The only other change is the new unit tests in `api-stat_test.go`.

## Motivation and Context

Callers detect delete markers from `StatObject` errors. That behavior arrived in #1379 and #1397. Since v7.0.93 those callers have silently lost `VersionID`, `IsDeleteMarker`, and `ReplicationReady` — and, on 405 responses, the `MethodNotAllowed` error code as well.

## How to test this PR?

Run `go test -race -run TestStatObject .`. `api-stat_test.go` adds five regression tests. The first four fail on master and pass on this branch:

- `TestStatObjectDeleteMarker` — 405 with delete-marker headers returns a populated `ObjectInfo`, the `MethodNotAllowed` code, and status 405.
- `TestStatObjectMethodNotAllowedGeneric` — a 405 that is missing either half of the delete-marker shape (no marker header, or a stat that does not target a version) takes the generic path and reports the raw status code.
- `TestStatObjectNoContentSuccess` — 202 and 204 parse like a 200: nil error, fields taken from the headers.
- `TestStatObjectErrorHeaders` — a 404 carrying delete-marker and replication headers keeps all three fields alongside `NoSuchKey`.
- `TestStatObjectNoResponse` — an unreachable endpoint returns a zero `ObjectInfo` with the error.

`go test -short -race ./...` passes on this branch: 482 tests across 16 packages, run at merge commit `34e8078`, which merges the current `master`.

The same fix logic was validated live on 2026-07-17 against MinIO community master and AIStor master. The steps: create a versioned bucket, delete an object, then stat both the marker version and the latest version. On both servers the unfixed client loses the fields, and the fixed client returns `MethodNotAllowed` or `NoSuchKey` with the information populated. The repro test also passes on v7.0.92, which brackets the regression to #2115.

One detail worth knowing: `StatObject` sends a HEAD request, and Go's HTTP client never exposes a body for a HEAD response. `httpRespToErrorResponse` therefore always falls through to its `default:` arm and reports `Code` as the raw status line. The lost error code affects every server, not only servers that return an empty 405 body, and the synthesized `ErrorResponse` is the only source of `MethodNotAllowed` on this path. The unit tests pin this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Fixes a regression (introduced by #2115, commit 7a9dff0)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request
- [x] No internode changes / version interoperability introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved object metadata reporting when status requests encounter errors.
  - Preserved version and delete-marker details for relevant responses.
  - Added safer handling for missing responses and common HTTP error cases.
- **Tests**
  - Added regression coverage for delete markers, successful responses, failures, and error metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
