### PR TITLE
fix: trim whitespace from bucket location

### DIFF
--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
@@ -114,7 +115,7 @@ func processBucketLocationResponse(resp *http.Response, bucketName string) (buck
 		return "", err
 	}
 
-	location := locationConstraint
+	location := strings.TrimSpace(locationConstraint)
 	// Location is empty will be 'us-east-1'.
 	if location == "" {
 		location = "us-east-1"

--- a/bucket-cache_test.go
+++ b/bucket-cache_test.go
@@ -309,6 +309,8 @@ func TestProcessBucketLocationResponse(t *testing.T) {
 	}{
 		{"my-bucket", "", true, APIErrors[0], "us-east-1", nil, true},
 		{"my-bucket", "", false, APIError{}, "us-east-1", nil, true},
+		{"my-bucket", "\n  \n", false, APIError{}, "us-east-1", nil, true},
+		{"my-bucket", " \neu-central-1\t", false, APIError{}, "eu-central-1", nil, true},
 		{"my-bucket", "EU", false, APIError{}, "eu-west-1", nil, true},
 		{"my-bucket", "eu-central-1", false, APIError{}, "eu-central-1", nil, true},
 		{"my-bucket", "us-east-1", false, APIError{}, "us-east-1", nil, true},


### PR DESCRIPTION
## Description

Trim whitespace from decoded `LocationConstraint` values before applying existing empty-region and EU normalization. This prevents whitespace-only responses from being cached and inserted into SigV4 `Authorization` headers.

## Testing

- `go test -run '^TestProcessBucketLocationResponse$' -count=1 .`
- `go test -short -race ./...`
- `go test -race -v ./...` against TLS-enabled AIStor edge
- Full functional suite against TLS-enabled AIStor edge
- `make lint`
- `make examples`
- `go build ./...`
- `govulncheck ./...` with Go 1.26.5

Fixes #2271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket location handling by removing surrounding whitespace from responses.
  * Ensured blank or whitespace-only locations correctly use the default region.

* **Tests**
  * Added coverage for blank locations and regional values containing extra whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->