### PR TITLE
feat: propagate caller context through credential providers

### DIFF
--- a/api-cred-context_test.go
+++ b/api-cred-context_test.go
@@ -20,15 +20,44 @@ package minio
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
+
+// testWaitTimeout bounds every cross-goroutine wait in this file so a
+// regression fails in seconds instead of hanging to the package timeout.
+const testWaitTimeout = 10 * time.Second
+
+// recvSignal waits for ch to close, failing t if it does not in time.
+func recvSignal(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(testWaitTimeout):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+// recvErr receives from ch, failing t if nothing arrives in time.
+func recvErr(t *testing.T, ch <-chan error, what string) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(testWaitTimeout):
+		t.Fatalf("timed out waiting for %s", what)
+		return nil
+	}
+}
 
 // blockingProvider is a credentials.Provider whose retrieval blocks until
 // released, honoring the CredContext caller context like real providers do.
@@ -40,13 +69,9 @@ type blockingProvider struct {
 
 func (p *blockingProvider) RetrieveWithCredContext(cc *credentials.CredContext) (credentials.Value, error) {
 	p.startedOnce.Do(func() { close(p.started) })
-	var done <-chan struct{}
-	if cc != nil && cc.Context != nil {
-		done = cc.Context.Done()
-	}
 	select {
 	case <-p.release:
-	case <-done:
+	case <-cc.Context.Done():
 		return credentials.Value{}, cc.Context.Err()
 	}
 	return credentials.Value{
@@ -57,7 +82,7 @@ func (p *blockingProvider) RetrieveWithCredContext(cc *credentials.CredContext) 
 }
 
 func (p *blockingProvider) Retrieve() (credentials.Value, error) {
-	return p.RetrieveWithCredContext(nil)
+	return p.RetrieveWithCredContext(&credentials.CredContext{Context: context.Background()})
 }
 
 func (p *blockingProvider) IsExpired() bool { return true }
@@ -90,7 +115,7 @@ func TestCredsCancelDoesNotPoisonWaiters(t *testing.T) {
 		canceledErr <- err
 	}()
 
-	<-provider.started
+	recvSignal(t, provider.started, "the provider retrieval to start")
 
 	waiterErr := make(chan error, 1)
 	go func() {
@@ -103,13 +128,13 @@ func TestCredsCancelDoesNotPoisonWaiters(t *testing.T) {
 	// joins the de-dup group.
 	cancel()
 
-	if err := <-canceledErr; !errors.Is(err, context.Canceled) {
+	if err := recvErr(t, canceledErr, "the canceled caller"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled for the canceled caller, got %v", err)
 	}
 
 	close(provider.release)
 
-	if err := <-waiterErr; err != nil {
+	if err := recvErr(t, waiterErr, "the concurrent waiter"); err != nil {
 		t.Fatalf("Expected the concurrent waiter to succeed, got %v", err)
 	}
 }
@@ -120,9 +145,11 @@ type expressSessionTransport struct {
 	started    chan struct{}
 	once       sync.Once
 	firstQuery string
+	requests   atomic.Int32
 }
 
 func (tr *expressSessionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tr.requests.Add(1)
 	tr.once.Do(func() {
 		tr.firstQuery = req.URL.RawQuery
 		close(tr.started)
@@ -148,17 +175,121 @@ func TestExpressCreateSessionCallerCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go func() {
-		<-tr.started
-		cancel()
-	}()
 
-	_, err = clnt.BucketExists(ctx, "mybucket--use1-az4--x-s3")
-	if !errors.Is(err, context.Canceled) {
+	callerErr := make(chan error, 1)
+	go func() {
+		_, err := clnt.BucketExists(ctx, "mybucket--use1-az4--x-s3")
+		callerErr <- err
+	}()
+	recvSignal(t, tr.started, "the CreateSession request to arrive")
+	cancel()
+
+	if err := recvErr(t, callerErr, "the canceled caller"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled from the express session retrieval, got %v", err)
 	}
 	if !strings.Contains(tr.firstQuery, "session") {
 		t.Fatalf("Expected the first request to be the CreateSession call (query %q lacks \"session\")", tr.firstQuery)
+	}
+}
+
+// TestExpressWaiterOwnContextHonored verifies that a caller joining an
+// in-flight de-duplicated S3 Express session retrieval stops waiting when
+// its own context ends: the flight is parked in the transport for the whole
+// test, so the waiter can only return through its own context.
+func TestExpressWaiterOwnContextHonored(t *testing.T) {
+	tr := &expressSessionTransport{started: make(chan struct{})}
+	clnt, err := New("s3.amazonaws.com", &Options{
+		Creds:     credentials.NewStaticV4("k", "s", ""),
+		Region:    "us-east-1",
+		Transport: tr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const bucket = "mybucket--use1-az4--x-s3"
+	winnerCtx, winnerCancel := context.WithCancel(context.Background())
+	defer winnerCancel()
+	winnerErr := make(chan error, 1)
+	go func() {
+		_, err := clnt.BucketExists(winnerCtx, bucket)
+		winnerErr <- err
+	}()
+	recvSignal(t, tr.started, "the CreateSession request to arrive")
+
+	waiterCtx, waiterCancel := context.WithCancel(context.Background())
+	waiterCancel()
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := clnt.BucketExists(waiterCtx, bucket)
+		waiterErr <- err
+	}()
+	if err := recvErr(t, waiterErr, "the waiter"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected the waiter's own context.Canceled, got %v", err)
+	}
+
+	winnerCancel()
+	if err := recvErr(t, winnerErr, "the winner"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled for the canceled winner, got %v", err)
+	}
+	if n := tr.requests.Load(); n != 1 {
+		t.Fatalf("Expected the waiter to join the winner's flight (1 CreateSession request), got %d", n)
+	}
+}
+
+// recordingTransport serves every request with 200 OK and records the
+// request queries it saw.
+type recordingTransport struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+func (tr *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tr.mu.Lock()
+	tr.queries = append(tr.queries, req.URL.RawQuery)
+	tr.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+// TestExpressSessionCacheServedInline verifies that a still-fresh cached S3
+// Express session skips the de-dup group and the CreateSession request
+// entirely: the only request on the wire is the S3 operation itself.
+func TestExpressSessionCacheServedInline(t *testing.T) {
+	tr := &recordingTransport{}
+	clnt, err := New("s3.amazonaws.com", &Options{
+		Creds:     credentials.NewStaticV4("k", "s", ""),
+		Region:    "us-east-1",
+		Transport: tr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const bucket = "mybucket--use1-az4--x-s3"
+	clnt.bucketSessionCache.Set(bucket, credentials.Value{
+		AccessKeyID:     "sessionKey",
+		SecretAccessKey: "sessionSecret",
+		SessionToken:    "sessionToken",
+		SignerType:      credentials.SignatureV4,
+		Expiration:      time.Now().Add(time.Hour),
+	})
+
+	exists, err := clnt.BucketExists(context.Background(), bucket)
+	if err != nil || !exists {
+		t.Fatalf("Expected the bucket probe to succeed from the cached session, got exists=%v err=%v", exists, err)
+	}
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.queries) != 1 {
+		t.Fatalf("Expected exactly one request (the S3 operation), got %d: %q", len(tr.queries), tr.queries)
+	}
+	if strings.Contains(tr.queries[0], "session") {
+		t.Fatalf("Expected no CreateSession request for a fresh cached session, got query %q", tr.queries[0])
 	}
 }
 
@@ -223,8 +354,67 @@ func TestPresignCredsCallerContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = clnt.PresignedPostPolicy(ctx, policy)
-	if !errors.Is(err, context.Canceled) {
+	presignErr := make(chan error, 1)
+	go func() {
+		_, _, err := clnt.PresignedPostPolicy(ctx, policy)
+		presignErr <- err
+	}()
+	if err := recvErr(t, presignErr, "the presign call"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled from the credential provider, got %v", err)
+	}
+}
+
+// expressTraceProbeTransport serves CreateSession and S3 requests, recording
+// whether each carried an httptrace.ClientTrace.
+type expressTraceProbeTransport struct {
+	mu     sync.Mutex
+	traced []bool
+}
+
+func (tr *expressTraceProbeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tr.mu.Lock()
+	tr.traced = append(tr.traced, httptrace.ContextClientTrace(req.Context()) != nil)
+	tr.mu.Unlock()
+	var body io.ReadCloser = http.NoBody
+	if strings.Contains(req.URL.RawQuery, "session") {
+		body = io.NopCloser(strings.NewReader(`<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><AccessKeyId>k</AccessKeyId><SecretAccessKey>s</SecretAccessKey><SessionToken>tok</SessionToken><Expiration>2030-01-01T00:00:00Z</Expiration></Credentials></CreateSessionResult>`))
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       body,
+		Request:    req,
+	}, nil
+}
+
+// TestExpressSessionTraceStaysOff pins that with client tracing enabled the
+// CreateSession request stays untraced while the S3 operation itself carries
+// the trace: a de-duplicated session retrieval can serve several callers, so
+// per-caller trace hooks must not fire for requests other callers own.
+func TestExpressSessionTraceStaysOff(t *testing.T) {
+	tr := &expressTraceProbeTransport{}
+	clnt, err := New("s3.amazonaws.com", &Options{
+		Creds:     credentials.NewStaticV4("k", "s", ""),
+		Region:    "us-east-1",
+		Transport: tr,
+		Trace:     &httptrace.ClientTrace{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := clnt.BucketExists(context.Background(), "mybucket--use1-az4--x-s3"); err != nil {
+		t.Fatal(err)
+	}
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.traced) != 2 {
+		t.Fatalf("Expected the CreateSession request and the S3 operation, got %d requests", len(tr.traced))
+	}
+	if tr.traced[0] {
+		t.Fatal("Expected the CreateSession request to carry no client trace")
+	}
+	if !tr.traced[1] {
+		t.Fatal("Expected the S3 operation to carry the client trace")
 	}
 }

--- a/api-cred-context_test.go
+++ b/api-cred-context_test.go
@@ -20,6 +20,7 @@ package minio
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -59,16 +60,47 @@ func recvErr(t *testing.T, ch <-chan error, what string) error {
 	}
 }
 
+// newTestClient builds this file's standard client: an s3.amazonaws.com
+// endpoint, us-east-1, the given credentials, and an optional transport.
+func newTestClient(t *testing.T, creds *credentials.Credentials, tr http.RoundTripper) *Client {
+	t.Helper()
+	clnt, err := New("s3.amazonaws.com", &Options{
+		Creds:     creds,
+		Region:    "us-east-1",
+		Transport: tr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return clnt
+}
+
+// createSessionXML renders the CreateSession response body the client's
+// decoder expects, carrying the given session token.
+func createSessionXML(token string) string {
+	return fmt.Sprintf(`<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><AccessKeyId>sessionKey</AccessKeyId><SecretAccessKey>sessionSecret</SecretAccessKey><SessionToken>%s</SessionToken><Expiration>%s</Expiration></Credentials></CreateSessionResult>`,
+		token, time.Now().Add(time.Hour).UTC().Format(time.RFC3339))
+}
+
 // blockingProvider is a credentials.Provider whose retrieval blocks until
-// released, honoring the CredContext caller context like real providers do.
+// released, honoring the CredContext caller context like real providers
+// do. The first retrieval's context is recorded before the start signal
+// closes, so a test that has seen the signal may read retrievalCtx.
 type blockingProvider struct {
-	startedOnce sync.Once
-	started     chan struct{}
-	release     chan struct{}
+	startedOnce  sync.Once
+	started      chan struct{}
+	release      chan struct{}
+	retrievalCtx context.Context
 }
 
 func (p *blockingProvider) RetrieveWithCredContext(cc *credentials.CredContext) (credentials.Value, error) {
-	p.startedOnce.Do(func() { close(p.started) })
+	if cc == nil || cc.Context == nil {
+		return credentials.Value{}, errors.New("CredContext.Context was not propagated")
+	}
+	p.startedOnce.Do(func() {
+		p.retrievalCtx = cc.Context
+		close(p.started)
+	})
 	select {
 	case <-p.release:
 	case <-cc.Context.Done():
@@ -88,9 +120,11 @@ func (p *blockingProvider) Retrieve() (credentials.Value, error) {
 func (p *blockingProvider) IsExpired() bool { return true }
 
 // TestCredsCancelDoesNotPoisonWaiters verifies that canceling one caller
-// during a de-duplicated credential retrieval fails only that caller: the
-// shared retrieval is detached from any single caller's context, so a
-// concurrent waiter on the same bucket still succeeds.
+// during a shared credential retrieval fails only that caller. The
+// detachment is asserted directly on the retrieval's recorded context —
+// it must survive the caller's cancellation and carry no deadline — and a
+// concurrent caller, which serializes behind the in-flight retrieval on
+// the credentials mutex, must still succeed.
 func TestCredsCancelDoesNotPoisonWaiters(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -132,6 +166,17 @@ func TestCredsCancelDoesNotPoisonWaiters(t *testing.T) {
 		t.Fatalf("Expected context.Canceled for the canceled caller, got %v", err)
 	}
 
+	// The shared retrieval must be detached from the canceled caller: its
+	// context stays live and carries no deadline.
+	select {
+	case <-provider.retrievalCtx.Done():
+		t.Fatal("The shared retrieval's context ended with the canceled caller — the retrieval is not detached")
+	default:
+	}
+	if _, ok := provider.retrievalCtx.Deadline(); ok {
+		t.Fatal("The shared retrieval's context carries a deadline — the retrieval is not detached")
+	}
+
 	close(provider.release)
 
 	if err := recvErr(t, waiterErr, "the concurrent waiter"); err != nil {
@@ -139,12 +184,14 @@ func TestCredsCancelDoesNotPoisonWaiters(t *testing.T) {
 	}
 }
 
-// expressSessionTransport records the first request's query and blocks
-// every request until its context ends.
+// expressSessionTransport records the first request's query and context —
+// published before the start signal closes — and blocks every request
+// until its context ends.
 type expressSessionTransport struct {
 	started    chan struct{}
 	once       sync.Once
 	firstQuery string
+	firstCtx   context.Context
 	requests   atomic.Int32
 }
 
@@ -152,6 +199,7 @@ func (tr *expressSessionTransport) RoundTrip(req *http.Request) (*http.Response,
 	tr.requests.Add(1)
 	tr.once.Do(func() {
 		tr.firstQuery = req.URL.RawQuery
+		tr.firstCtx = req.Context()
 		close(tr.started)
 	})
 	<-req.Context().Done()
@@ -159,19 +207,13 @@ func (tr *expressSessionTransport) RoundTrip(req *http.Request) (*http.Response,
 }
 
 // TestExpressCreateSessionCallerCancel verifies that the S3 Express session
-// retrieval keeps the caller context: canceling the caller aborts the
-// in-flight CreateSession request. The first-request query assertion pins
-// that the express arm ran — only CreateSession sends "?session".
+// retrieval keeps the caller context: canceling the caller must end the
+// in-flight CreateSession request's own context, not merely release the
+// waiting caller. The first-request query assertion pins that the express
+// arm ran — only CreateSession sends "?session".
 func TestExpressCreateSessionCallerCancel(t *testing.T) {
 	tr := &expressSessionTransport{started: make(chan struct{})}
-	clnt, err := New("s3.amazonaws.com", &Options{
-		Creds:     credentials.NewStaticV4("k", "s", ""),
-		Region:    "us-east-1",
-		Transport: tr,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	clnt := newTestClient(t, credentials.NewStaticV4("k", "s", ""), tr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -187,25 +229,24 @@ func TestExpressCreateSessionCallerCancel(t *testing.T) {
 	if err := recvErr(t, callerErr, "the canceled caller"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled from the express session retrieval, got %v", err)
 	}
+	select {
+	case <-tr.firstCtx.Done():
+	case <-time.After(testWaitTimeout):
+		t.Fatal("The CreateSession request kept running after the caller canceled — the express retrieval does not keep the caller context")
+	}
 	if !strings.Contains(tr.firstQuery, "session") {
 		t.Fatalf("Expected the first request to be the CreateSession call (query %q lacks \"session\")", tr.firstQuery)
 	}
 }
 
-// TestExpressWaiterOwnContextHonored verifies that a caller joining an
-// in-flight de-duplicated S3 Express session retrieval stops waiting when
-// its own context ends: the flight is parked in the transport for the whole
-// test, so the waiter can only return through its own context.
+// TestExpressWaiterOwnContextHonored verifies that a caller arriving at
+// an in-flight S3 Express session retrieval stops waiting when its own
+// context ends: the flight is parked in the transport for the whole test,
+// so the waiter can only return through its own context. The
+// de-duplication itself is pinned by TestExpressWaiterJoinsFlight.
 func TestExpressWaiterOwnContextHonored(t *testing.T) {
 	tr := &expressSessionTransport{started: make(chan struct{})}
-	clnt, err := New("s3.amazonaws.com", &Options{
-		Creds:     credentials.NewStaticV4("k", "s", ""),
-		Region:    "us-east-1",
-		Transport: tr,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	clnt := newTestClient(t, credentials.NewStaticV4("k", "s", ""), tr)
 
 	const bucket = "mybucket--use1-az4--x-s3"
 	winnerCtx, winnerCancel := context.WithCancel(context.Background())
@@ -233,7 +274,90 @@ func TestExpressWaiterOwnContextHonored(t *testing.T) {
 		t.Fatalf("Expected context.Canceled for the canceled winner, got %v", err)
 	}
 	if n := tr.requests.Load(); n != 1 {
-		t.Fatalf("Expected the waiter to join the winner's flight (1 CreateSession request), got %d", n)
+		t.Fatalf("Expected no CreateSession request beyond the parked winner's, got %d", n)
+	}
+}
+
+// expressServingTransport parks CreateSession requests until released,
+// then serves each with a distinct session token; plain S3 requests are
+// answered immediately with their session-token header recorded.
+type expressServingTransport struct {
+	mu          sync.Mutex
+	startedOnce sync.Once
+	started     chan struct{}
+	release     chan struct{}
+	sessionReqs int
+	s3Tokens    []string
+}
+
+func (tr *expressServingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.RawQuery, "session") {
+		tr.mu.Lock()
+		tr.sessionReqs++
+		n := tr.sessionReqs
+		tr.mu.Unlock()
+		tr.startedOnce.Do(func() { close(tr.started) })
+		select {
+		case <-tr.release:
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(createSessionXML(fmt.Sprintf("token-%d", n)))),
+			Request:    req,
+		}, nil
+	}
+	tr.mu.Lock()
+	tr.s3Tokens = append(tr.s3Tokens, req.Header.Get("x-amz-s3session-token"))
+	tr.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+// TestExpressWaiterJoinsFlight verifies that concurrent S3 Express callers
+// on one bucket are served by a single CreateSession: whether a caller
+// joins the in-flight retrieval or reads the session cache after it
+// completes, exactly one CreateSession request reaches the wire and both
+// S3 operations carry its token.
+func TestExpressWaiterJoinsFlight(t *testing.T) {
+	tr := &expressServingTransport{started: make(chan struct{}), release: make(chan struct{})}
+	clnt := newTestClient(t, credentials.NewStaticV4("k", "s", ""), tr)
+
+	const bucket = "mybucket--use1-az4--x-s3"
+	// The deferred release keeps a failed arrival wait from leaking the
+	// two caller goroutines parked in the transport.
+	var releaseOnce sync.Once
+	releaseFlight := func() { releaseOnce.Do(func() { close(tr.release) }) }
+	defer releaseFlight()
+
+	callerErrs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := clnt.BucketExists(context.Background(), bucket)
+			callerErrs <- err
+		}()
+	}
+	recvSignal(t, tr.started, "the CreateSession request to arrive")
+	releaseFlight()
+	for range 2 {
+		if err := recvErr(t, callerErrs, "an express caller"); err != nil {
+			t.Fatalf("Expected both express callers to succeed, got %v", err)
+		}
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.sessionReqs != 1 {
+		t.Fatalf("Expected exactly one CreateSession request for both callers, got %d", tr.sessionReqs)
+	}
+	if len(tr.s3Tokens) != 2 || tr.s3Tokens[0] != "token-1" || tr.s3Tokens[1] != "token-1" {
+		t.Fatalf("Expected both S3 operations to carry the single flight's token, got %q", tr.s3Tokens)
 	}
 }
 
@@ -256,19 +380,12 @@ func (tr *recordingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	}, nil
 }
 
-// TestExpressSessionCacheServedInline verifies that a still-fresh cached S3
-// Express session skips the de-dup group and the CreateSession request
-// entirely: the only request on the wire is the S3 operation itself.
+// TestExpressSessionCacheServedInline verifies that a still-fresh cached
+// S3 Express session produces no CreateSession call: the only request on
+// the wire is the S3 operation itself.
 func TestExpressSessionCacheServedInline(t *testing.T) {
 	tr := &recordingTransport{}
-	clnt, err := New("s3.amazonaws.com", &Options{
-		Creds:     credentials.NewStaticV4("k", "s", ""),
-		Region:    "us-east-1",
-		Transport: tr,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	clnt := newTestClient(t, credentials.NewStaticV4("k", "s", ""), tr)
 
 	const bucket = "mybucket--use1-az4--x-s3"
 	clnt.bucketSessionCache.Set(bucket, credentials.Value{
@@ -293,6 +410,38 @@ func TestExpressSessionCacheServedInline(t *testing.T) {
 	}
 }
 
+// TestExpressSessionRenewalLeewayBoundary verifies that a cached session
+// already inside the renewal leeway is not served: the client attempts a
+// fresh CreateSession instead.
+func TestExpressSessionRenewalLeewayBoundary(t *testing.T) {
+	tr := &recordingTransport{}
+	clnt := newTestClient(t, credentials.NewStaticV4("k", "s", ""), tr)
+
+	const bucket = "mybucket--use1-az4--x-s3"
+	// A fixed 5 s expiry sits in the future yet inside the 10 s renewal
+	// leeway; deriving it from the constant would make this test blind to
+	// the leeway's removal.
+	clnt.bucketSessionCache.Set(bucket, credentials.Value{
+		AccessKeyID:     "sessionKey",
+		SecretAccessKey: "sessionSecret",
+		SessionToken:    "sessionToken",
+		SignerType:      credentials.SignatureV4,
+		Expiration:      time.Now().Add(5 * time.Second),
+	})
+
+	// The renewal attempt fails against this stub transport (its 200
+	// carries no CreateSession body); the assertion is only that a
+	// renewal was attempted instead of serving the near-expiry session.
+	if _, err := clnt.BucketExists(context.Background(), bucket); err == nil {
+		t.Fatal("Expected the renewal attempt against the stub transport to fail")
+	}
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.queries) == 0 || !strings.Contains(tr.queries[0], "session") {
+		t.Fatalf("Expected a CreateSession renewal attempt for a session inside the leeway, got %q", tr.queries)
+	}
+}
+
 // panicProvider is a credentials.Provider whose retrieval always panics.
 type panicProvider struct{}
 
@@ -310,21 +459,36 @@ func (panicProvider) IsExpired() bool { return true }
 // the de-duplicated credential retrieval resumes on the caller's goroutine
 // instead of crashing the process from the retrieval goroutine.
 func TestCredsRetrievalPanicPropagates(t *testing.T) {
-	clnt, err := New("s3.amazonaws.com", &Options{
-		Creds:  credentials.New(panicProvider{}),
-		Region: "us-east-1",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	clnt := newTestClient(t, credentials.New(panicProvider{}), nil)
 
+	returned := false
 	defer func() {
-		if r := recover(); r != "boom" {
+		r := recover()
+		if returned {
+			// The no-panic Fatalf below already reported the failure;
+			// asserting on the nil recover would only obscure it.
+			return
+		}
+		if r != "boom" {
 			t.Fatalf("Expected panic value %q on the caller goroutine, got %v", "boom", r)
 		}
 	}()
 	exists, err := clnt.BucketExists(context.Background(), "test-bucket")
+	returned = true
 	t.Fatalf("Expected a panic before return, got exists=%v err=%v", exists, err)
+}
+
+// TestNewRequestNilContext pins the nil-context guard's error: the request
+// must fail with a legible argument error instead of a derived-context
+// panic.
+func TestNewRequestNilContext(t *testing.T) {
+	clnt := newTestClient(t, credentials.NewStaticV4("k", "s", ""), nil)
+
+	var nilCtx context.Context
+	_, err := clnt.newRequest(nilCtx, http.MethodHead, requestMetadata{bucketName: "test-bucket"})
+	if err == nil || !strings.Contains(err.Error(), "context cannot be nil") {
+		t.Fatalf("Expected the nil-context guard error, got %v", err)
+	}
 }
 
 // TestPresignCredsCallerContext verifies that a direct (non-de-duplicated)
@@ -332,13 +496,7 @@ func TestCredsRetrievalPanicPropagates(t *testing.T) {
 // context aborts presigning inside the provider.
 func TestPresignCredsCallerContext(t *testing.T) {
 	provider := &blockingProvider{started: make(chan struct{}), release: make(chan struct{})}
-	clnt, err := New("s3.amazonaws.com", &Options{
-		Creds:  credentials.New(provider),
-		Region: "us-east-1",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	clnt := newTestClient(t, credentials.New(provider), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -377,7 +535,7 @@ func (tr *expressTraceProbeTransport) RoundTrip(req *http.Request) (*http.Respon
 	tr.mu.Unlock()
 	var body io.ReadCloser = http.NoBody
 	if strings.Contains(req.URL.RawQuery, "session") {
-		body = io.NopCloser(strings.NewReader(`<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><AccessKeyId>k</AccessKeyId><SecretAccessKey>s</SecretAccessKey><SessionToken>tok</SessionToken><Expiration>2030-01-01T00:00:00Z</Expiration></Credentials></CreateSessionResult>`))
+		body = io.NopCloser(strings.NewReader(createSessionXML("tok")))
 	}
 	return &http.Response{
 		StatusCode: http.StatusOK,

--- a/api-cred-context_test.go
+++ b/api-cred-context_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -110,6 +111,54 @@ func TestCredsCancelDoesNotPoisonWaiters(t *testing.T) {
 
 	if err := <-waiterErr; err != nil {
 		t.Fatalf("Expected the concurrent waiter to succeed, got %v", err)
+	}
+}
+
+// expressSessionTransport records the first request's query and blocks
+// every request until its context ends.
+type expressSessionTransport struct {
+	started    chan struct{}
+	once       sync.Once
+	firstQuery string
+}
+
+func (tr *expressSessionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tr.once.Do(func() {
+		tr.firstQuery = req.URL.RawQuery
+		close(tr.started)
+	})
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+// TestExpressCreateSessionCallerCancel verifies that the S3 Express session
+// retrieval keeps the caller context: canceling the caller aborts the
+// in-flight CreateSession request. The first-request query assertion pins
+// that the express arm ran — only CreateSession sends "?session".
+func TestExpressCreateSessionCallerCancel(t *testing.T) {
+	tr := &expressSessionTransport{started: make(chan struct{})}
+	clnt, err := New("s3.amazonaws.com", &Options{
+		Creds:     credentials.NewStaticV4("k", "s", ""),
+		Region:    "us-east-1",
+		Transport: tr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-tr.started
+		cancel()
+	}()
+
+	_, err = clnt.BucketExists(ctx, "mybucket--use1-az4--x-s3")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled from the express session retrieval, got %v", err)
+	}
+	if !strings.Contains(tr.firstQuery, "session") {
+		t.Fatalf("Expected the first request to be the CreateSession call (query %q lacks \"session\")", tr.firstQuery)
 	}
 }
 

--- a/api-cred-context_test.go
+++ b/api-cred-context_test.go
@@ -1,0 +1,181 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// blockingProvider is a credentials.Provider whose retrieval blocks until
+// released, honoring the CredContext caller context like real providers do.
+type blockingProvider struct {
+	startedOnce sync.Once
+	started     chan struct{}
+	release     chan struct{}
+}
+
+func (p *blockingProvider) RetrieveWithCredContext(cc *credentials.CredContext) (credentials.Value, error) {
+	p.startedOnce.Do(func() { close(p.started) })
+	var done <-chan struct{}
+	if cc != nil && cc.Context != nil {
+		done = cc.Context.Done()
+	}
+	select {
+	case <-p.release:
+	case <-done:
+		return credentials.Value{}, cc.Context.Err()
+	}
+	return credentials.Value{
+		AccessKeyID:     "accessKey",
+		SecretAccessKey: "secret",
+		SignerType:      credentials.SignatureV4,
+	}, nil
+}
+
+func (p *blockingProvider) Retrieve() (credentials.Value, error) {
+	return p.RetrieveWithCredContext(nil)
+}
+
+func (p *blockingProvider) IsExpired() bool { return true }
+
+// TestCredsCancelDoesNotPoisonWaiters verifies that canceling one caller
+// during a de-duplicated credential retrieval fails only that caller: the
+// shared retrieval is detached from any single caller's context, so a
+// concurrent waiter on the same bucket still succeeds.
+func TestCredsCancelDoesNotPoisonWaiters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	provider := &blockingProvider{started: make(chan struct{}), release: make(chan struct{})}
+	clnt, err := New(srv.Listener.Addr().String(), &Options{
+		Creds:  credentials.New(provider),
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	canceledErr := make(chan error, 1)
+	go func() {
+		_, err := clnt.BucketExists(ctx, "test-bucket")
+		canceledErr <- err
+	}()
+
+	<-provider.started
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := clnt.BucketExists(context.Background(), "test-bucket")
+		waiterErr <- err
+	}()
+
+	// Cancel the first caller mid-retrieval; the waiter must not inherit
+	// that cancellation, whether it blocks on the credentials mutex or
+	// joins the de-dup group.
+	cancel()
+
+	if err := <-canceledErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled for the canceled caller, got %v", err)
+	}
+
+	close(provider.release)
+
+	if err := <-waiterErr; err != nil {
+		t.Fatalf("Expected the concurrent waiter to succeed, got %v", err)
+	}
+}
+
+// panicProvider is a credentials.Provider whose retrieval always panics.
+type panicProvider struct{}
+
+func (panicProvider) RetrieveWithCredContext(*credentials.CredContext) (credentials.Value, error) {
+	panic("boom")
+}
+
+func (p panicProvider) Retrieve() (credentials.Value, error) {
+	return p.RetrieveWithCredContext(nil)
+}
+
+func (panicProvider) IsExpired() bool { return true }
+
+// TestCredsRetrievalPanicPropagates verifies that a provider panic inside
+// the de-duplicated credential retrieval resumes on the caller's goroutine
+// instead of crashing the process from the retrieval goroutine.
+func TestCredsRetrievalPanicPropagates(t *testing.T) {
+	clnt, err := New("s3.amazonaws.com", &Options{
+		Creds:  credentials.New(panicProvider{}),
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if r := recover(); r != "boom" {
+			t.Fatalf("Expected panic value %q on the caller goroutine, got %v", "boom", r)
+		}
+	}()
+	exists, err := clnt.BucketExists(context.Background(), "test-bucket")
+	t.Fatalf("Expected a panic before return, got exists=%v err=%v", exists, err)
+}
+
+// TestPresignCredsCallerContext verifies that a direct (non-de-duplicated)
+// credential retrieval receives the caller context: a canceled caller
+// context aborts presigning inside the provider.
+func TestPresignCredsCallerContext(t *testing.T) {
+	provider := &blockingProvider{started: make(chan struct{}), release: make(chan struct{})}
+	clnt, err := New("s3.amazonaws.com", &Options{
+		Creds:  credentials.New(provider),
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	policy := NewPostPolicy()
+	if err := policy.SetBucket("test-bucket"); err != nil {
+		t.Fatal(err)
+	}
+	if err := policy.SetKey("obj"); err != nil {
+		t.Fatal(err)
+	}
+	if err := policy.SetExpires(time.Now().UTC().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = clnt.PresignedPostPolicy(ctx, policy)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled from the credential provider, got %v", err)
+	}
+}

--- a/api-cred-context_test.go
+++ b/api-cred-context_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -476,6 +477,43 @@ func TestCredsRetrievalPanicPropagates(t *testing.T) {
 	exists, err := clnt.BucketExists(context.Background(), "test-bucket")
 	returned = true
 	t.Fatalf("Expected a panic before return, got exists=%v err=%v", exists, err)
+}
+
+// goexitProvider is a credentials.Provider whose retrieval ends in
+// runtime.Goexit, as a t.Fatal in a test-supplied provider would.
+type goexitProvider struct{}
+
+func (goexitProvider) RetrieveWithCredContext(*credentials.CredContext) (credentials.Value, error) {
+	runtime.Goexit()
+	return credentials.Value{}, nil
+}
+
+func (p goexitProvider) Retrieve() (credentials.Value, error) {
+	return p.RetrieveWithCredContext(nil)
+}
+
+func (goexitProvider) IsExpired() bool { return true }
+
+// TestCredsRetrievalGoexitDoesNotHang verifies that a provider ending in
+// runtime.Goexit inside the de-duplicated retrieval returns a terminal error
+// to a caller whose context has no deadline, instead of blocking it forever.
+func TestCredsRetrievalGoexitDoesNotHang(t *testing.T) {
+	clnt := newTestClient(t, credentials.New(goexitProvider{}), nil)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := clnt.BucketExists(context.Background(), "test-bucket")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Expected a terminal error after the provider called runtime.Goexit, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("BucketExists hangs after the provider called runtime.Goexit")
+	}
 }
 
 // TestNewRequestNilContext pins the nil-context guard's error: the request

--- a/api-cred-context_test.go
+++ b/api-cred-context_test.go
@@ -545,11 +545,11 @@ func (tr *expressTraceProbeTransport) RoundTrip(req *http.Request) (*http.Respon
 	}, nil
 }
 
-// TestExpressSessionTraceStaysOff pins that with client tracing enabled the
-// CreateSession request stays untraced while the S3 operation itself carries
-// the trace: a de-duplicated session retrieval can serve several callers, so
-// per-caller trace hooks must not fire for requests other callers own.
-func TestExpressSessionTraceStaysOff(t *testing.T) {
+// TestExpressSessionTraceAttached pins that with client tracing enabled both
+// the CreateSession request and the S3 operation carry the trace: threading a
+// caller context through credential retrieval must not remove logging that
+// worked before.
+func TestExpressSessionTraceAttached(t *testing.T) {
 	tr := &expressTraceProbeTransport{}
 	clnt, err := New("s3.amazonaws.com", &Options{
 		Creds:     credentials.NewStaticV4("k", "s", ""),
@@ -569,8 +569,8 @@ func TestExpressSessionTraceStaysOff(t *testing.T) {
 	if len(tr.traced) != 2 {
 		t.Fatalf("Expected the CreateSession request and the S3 operation, got %d requests", len(tr.traced))
 	}
-	if tr.traced[0] {
-		t.Fatal("Expected the CreateSession request to carry no client trace")
+	if !tr.traced[0] {
+		t.Fatal("Expected the CreateSession request to carry the client trace")
 	}
 	if !tr.traced[1] {
 		t.Fatal("Expected the S3 operation to carry the client trace")

--- a/api-presigned.go
+++ b/api-presigned.go
@@ -140,7 +140,7 @@ func (c *Client) PresignedPostPolicy(ctx context.Context, p *PostPolicy) (u *url
 	}
 
 	// Get credentials from the configured credentials provider.
-	credValues, err := c.credsProvider.GetWithContext(c.CredContext())
+	credValues, err := c.credsProvider.GetWithContext(c.credContext(ctx))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -926,12 +926,18 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		// (presign, bucket location, express CreateSession). The S3
 		// Express session request keeps the caller context: a full S3
 		// operation's retries must stay cancellable, so its waiters
-		// share the winner's fate. A retrieval panic resumes on each
-		// waiting caller's goroutine (credsRetrievalPanic); a
-		// runtime.Goexit is not propagated — each caller waits until its
-		// own context ends, indefinitely when it has none.
+		// share the winner's fate, and its trace for the same reason:
+		// the round trip was traced before this change.
+		// A retrieval panic resumes on each waiting caller's goroutine
+		// (credsRetrievalPanic); a runtime.Goexit is not propagated —
+		// each caller waits until its own context ends, indefinitely
+		// when it has none.
 		retrieveCtx := ctx
-		if !express {
+		if express {
+			if c.httpTrace != nil {
+				retrieveCtx = httptrace.WithClientTrace(retrieveCtx, c.httpTrace)
+			}
+		} else {
 			retrieveCtx = context.WithoutCancel(ctx)
 		}
 		resCh := c.credsGroup.DoChan(metadata.bucketName, func() (v credentials.Value, rerr error) {
@@ -968,8 +974,8 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		return nil, err
 	}
 
-	// Attach the trace after credential retrieval so credential
-	// requests stay untraced.
+	// Attach the trace after retrieval: provider credential requests were
+	// never traced. The express session request is traced above.
 	if c.httpTrace != nil {
 		ctx = httptrace.WithClientTrace(ctx, c.httpTrace)
 	}

--- a/api.go
+++ b/api.go
@@ -848,8 +848,20 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 	return res, err
 }
 
+// credsRetrievalPanic carries a panic value out of the de-duplicated
+// credential retrieval goroutine so newRequest can resume it on each
+// caller's goroutine.
+type credsRetrievalPanic struct{ value any }
+
+func (p credsRetrievalPanic) Error() string {
+	return fmt.Sprintf("credentials retrieval panicked: %v", p.value)
+}
+
 // newRequest - instantiate a new HTTP request for a given method.
 func (c *Client) newRequest(ctx context.Context, method string, metadata requestMetadata) (req *http.Request, err error) {
+	if ctx == nil {
+		return nil, errInvalidArgument("context cannot be nil")
+	}
 	// If no method is supplied default to 'POST'.
 	if method == "" {
 		method = http.MethodPost
@@ -882,21 +894,56 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		return nil, err
 	}
 
-	if c.httpTrace != nil {
-		ctx = httptrace.WithClientTrace(ctx, c.httpTrace)
-	}
-
-	// make sure to de-dup calls to credential services, this reduces
-	// the overall load to the endpoint generating credential service.
-	value, err, _ := c.credsGroup.Do(metadata.bucketName, func() (credentials.Value, error) {
-		if s3utils.IsS3ExpressBucket(metadata.bucketName) && s3utils.IsAmazonEndpoint(*c.endpointURL) {
-			return c.CreateSession(ctx, metadata.bucketName, SessionReadWrite)
+	// Cached, unexpired credentials (or an absent provider — anonymous
+	// access) are served inline; a retrieval that races expiry runs
+	// inline too, serialized by the Credentials mutex. S3 Express
+	// sessions always go through the de-dup group.
+	express := s3utils.IsS3ExpressBucket(metadata.bucketName) && s3utils.IsAmazonEndpoint(*c.endpointURL)
+	var value credentials.Value
+	if !express && (c.credsProvider == nil || !c.credsProvider.IsExpired()) {
+		value, err = c.credsProvider.GetWithContext(c.credContext(ctx))
+	} else {
+		// The provider retrieval is detached (context.WithoutCancel) so
+		// one caller's cancellation cannot fail concurrent waiters; each
+		// waiter stops waiting when its own context ends, though a
+		// caller arriving mid-retrieval blocks in IsExpired on the
+		// Credentials mutex until the retrieval completes. The S3
+		// Express session request keeps the caller context: a full S3
+		// operation's retries must stay cancellable, so its waiters
+		// share the winner's fate. A retrieval panic resumes on each
+		// waiting caller's goroutine (credsRetrievalPanic); a
+		// runtime.Goexit is not propagated — waiters wait out their own
+		// contexts.
+		resCh := c.credsGroup.DoChan(metadata.bucketName, func() (v credentials.Value, rerr error) {
+			defer func() {
+				if r := recover(); r != nil {
+					rerr = credsRetrievalPanic{value: r}
+				}
+			}()
+			if express {
+				return c.CreateSession(ctx, metadata.bucketName, SessionReadWrite)
+			}
+			// Get credentials from the configured credentials provider.
+			return c.credsProvider.GetWithContext(c.credContext(context.WithoutCancel(ctx)))
+		})
+		select {
+		case res := <-resCh:
+			if cp, ok := res.Err.(credsRetrievalPanic); ok {
+				panic(cp.value)
+			}
+			value, err = res.Val, res.Err
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
-		// Get credentials from the configured credentials provider.
-		return c.credsProvider.GetWithContext(c.CredContext())
-	})
+	}
 	if err != nil {
 		return nil, err
+	}
+
+	// Attach the trace after credential retrieval so credential
+	// requests stay untraced.
+	if c.httpTrace != nil {
+		ctx = httptrace.WithClientTrace(ctx, c.httpTrace)
 	}
 
 	// Initialize a new HTTP request for the method.
@@ -1170,6 +1217,14 @@ func (c *Client) CredContext() *credentials.CredContext {
 		Client:   httpClient,
 		Endpoint: c.endpointURL.String(),
 	}
+}
+
+// credContext returns the client's CredContext with ctx attached as the
+// caller context for credential retrieval.
+func (c *Client) credContext(ctx context.Context) *credentials.CredContext {
+	cc := c.CredContext()
+	cc.Context = ctx
+	return cc
 }
 
 // GetCreds returns the access creds for the client

--- a/api.go
+++ b/api.go
@@ -929,9 +929,9 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		// share the winner's fate, and its trace for the same reason:
 		// the round trip was traced before this change.
 		// A retrieval panic resumes on each waiting caller's goroutine
-		// (credsRetrievalPanic); a runtime.Goexit is not propagated —
-		// each caller waits until its own context ends, indefinitely
-		// when it has none.
+		// (credsRetrievalPanic); a runtime.Goexit reaches waiters as a
+		// terminal error from the de-dup group, since the retrieval
+		// goroutine cannot return one itself.
 		retrieveCtx := ctx
 		if express {
 			if c.httpTrace != nil {

--- a/api.go
+++ b/api.go
@@ -912,8 +912,8 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		// operation's retries must stay cancellable, so its waiters
 		// share the winner's fate. A retrieval panic resumes on each
 		// waiting caller's goroutine (credsRetrievalPanic); a
-		// runtime.Goexit is not propagated — waiters wait out their own
-		// contexts.
+		// runtime.Goexit is not propagated — each caller waits until its
+		// own context ends, indefinitely when it has none.
 		resCh := c.credsGroup.DoChan(metadata.bucketName, func() (v credentials.Value, rerr error) {
 			defer func() {
 				if r := recover(); r != nil {

--- a/api.go
+++ b/api.go
@@ -850,7 +850,9 @@ func (c *Client) executeMethod(ctx context.Context, method string, metadata requ
 
 // credsRetrievalPanic carries a panic value out of the de-duplicated
 // credential retrieval goroutine so newRequest can resume it on each
-// caller's goroutine.
+// caller's goroutine. The value is re-raised verbatim, as if the provider
+// had panicked on the caller's goroutine; the retrieval goroutine's stack
+// is not carried along.
 type credsRetrievalPanic struct{ value any }
 
 func (p credsRetrievalPanic) Error() string {
@@ -860,6 +862,7 @@ func (p credsRetrievalPanic) Error() string {
 // newRequest - instantiate a new HTTP request for a given method.
 func (c *Client) newRequest(ctx context.Context, method string, metadata requestMetadata) (req *http.Request, err error) {
 	if ctx == nil {
+		// Deriving from a nil context (context.WithoutCancel below) panics.
 		return nil, errInvalidArgument("context cannot be nil")
 	}
 	// If no method is supplied default to 'POST'.
@@ -896,13 +899,20 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 
 	// Cached, unexpired credentials (or an absent provider — anonymous
 	// access) are served inline; a retrieval that races expiry runs
-	// inline too, serialized by the Credentials mutex. S3 Express
-	// sessions always go through the de-dup group.
+	// inline too, with the caller's live context, serialized by the
+	// Credentials mutex. A still-fresh cached S3 Express session is
+	// served inline as well; actual retrievals go through the de-dup
+	// group.
 	express := s3utils.IsS3ExpressBucket(metadata.bucketName) && s3utils.IsAmazonEndpoint(*c.endpointURL)
 	var value credentials.Value
-	if !express && (c.credsProvider == nil || !c.credsProvider.IsExpired()) {
+	var served bool
+	if express {
+		value, served = c.sessionFromCache(metadata.bucketName)
+	} else if c.credsProvider == nil || !c.credsProvider.IsExpired() {
 		value, err = c.credsProvider.GetWithContext(c.credContext(ctx))
-	} else {
+		served = true
+	}
+	if !served {
 		// The provider retrieval is detached (context.WithoutCancel) so
 		// one caller's cancellation cannot fail concurrent waiters; each
 		// waiter stops waiting when its own context ends, though a
@@ -914,6 +924,10 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		// waiting caller's goroutine (credsRetrievalPanic); a
 		// runtime.Goexit is not propagated — each caller waits until its
 		// own context ends, indefinitely when it has none.
+		retrieveCtx := ctx
+		if !express {
+			retrieveCtx = context.WithoutCancel(ctx)
+		}
 		resCh := c.credsGroup.DoChan(metadata.bucketName, func() (v credentials.Value, rerr error) {
 			defer func() {
 				if r := recover(); r != nil {
@@ -921,20 +935,28 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 				}
 			}()
 			if express {
-				return c.CreateSession(ctx, metadata.bucketName, SessionReadWrite)
+				return c.CreateSession(retrieveCtx, metadata.bucketName, SessionReadWrite)
 			}
 			// Get credentials from the configured credentials provider.
-			return c.credsProvider.GetWithContext(c.credContext(context.WithoutCancel(ctx)))
+			return c.credsProvider.GetWithContext(c.credContext(retrieveCtx))
 		})
+		var res singleflight.Result[credentials.Value]
 		select {
-		case res := <-resCh:
-			if cp, ok := res.Err.(credsRetrievalPanic); ok {
-				panic(cp.value)
-			}
-			value, err = res.Val, res.Err
+		case res = <-resCh:
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			// A result already delivered when the cancellation fires is
+			// preferred over the caller's context error.
+			select {
+			case res = <-resCh:
+			default:
+				return nil, ctx.Err()
+			}
 		}
+		var cp credsRetrievalPanic
+		if errors.As(res.Err, &cp) {
+			panic(cp.value)
+		}
+		value, err = res.Val, res.Err
 	}
 	if err != nil {
 		return nil, err

--- a/api.go
+++ b/api.go
@@ -862,7 +862,8 @@ func (p credsRetrievalPanic) Error() string {
 // newRequest - instantiate a new HTTP request for a given method.
 func (c *Client) newRequest(ctx context.Context, method string, metadata requestMetadata) (req *http.Request, err error) {
 	if ctx == nil {
-		// Deriving from a nil context (context.WithoutCancel below) panics.
+		// A nil context would be dereferenced below — by the bucket
+		// location lookup, the waiter select, and context.WithoutCancel.
 		return nil, errInvalidArgument("context cannot be nil")
 	}
 	// If no method is supplied default to 'POST'.
@@ -917,7 +918,12 @@ func (c *Client) newRequest(ctx context.Context, method string, metadata request
 		// one caller's cancellation cannot fail concurrent waiters; each
 		// waiter stops waiting when its own context ends, though a
 		// caller arriving mid-retrieval blocks in IsExpired on the
-		// Credentials mutex until the retrieval completes. The S3
+		// Credentials mutex until the retrieval completes. Detachment
+		// strips the caller's deadline along with its cancellation: on
+		// this path the caller context governs only the wait, and reaches
+		// the credential request itself only outside the group — on the
+		// inline not-expired path above and the direct call sites
+		// (presign, bucket location, express CreateSession). The S3
 		// Express session request keeps the caller context: a full S3
 		// operation's retries must stay cancellable, so its waiters
 		// share the winner's fate. A retrieval panic resumes on each

--- a/bucket-cache.go
+++ b/bucket-cache.go
@@ -172,7 +172,7 @@ func (c *Client) getBucketLocationRequest(ctx context.Context, bucketName string
 	c.setUserAgent(req)
 
 	// Get credentials from the configured credentials provider.
-	value, err := c.credsProvider.GetWithContext(c.CredContext())
+	value, err := c.credsProvider.GetWithContext(c.credContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/create-session.go
+++ b/create-session.go
@@ -67,8 +67,8 @@ func (c *Client) sessionFromCache(bucketName string) (credentials.Value, bool) {
 
 // CreateSession - https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateSession.html
 // the returning credentials may be cached depending on the expiration of the original
-// credential, credentials will get renewed 10 secs earlier than when its gonna expire
-// allowing for some leeway in the renewal process.
+// credential; a cached session stops being served expressSessionRenewalLeeway before
+// it expires, allowing for some leeway in the renewal process.
 func (c *Client) CreateSession(ctx context.Context, bucketName string, sessionMode SessionMode) (cred credentials.Value, err error) {
 	if err := s3utils.CheckValidBucketNameS3Express(bucketName); err != nil {
 		return credentials.Value{}, err

--- a/create-session.go
+++ b/create-session.go
@@ -51,6 +51,20 @@ type createSessionResult struct {
 	} `xml:",omitempty"`
 }
 
+// expressSessionRenewalLeeway is how long before its expiration a cached
+// S3 Express session stops being served, leaving room for renewal.
+const expressSessionRenewalLeeway = 10 * time.Second
+
+// sessionFromCache returns the cached S3 Express session credentials for
+// bucketName while they remain outside the renewal leeway.
+func (c *Client) sessionFromCache(bucketName string) (credentials.Value, bool) {
+	v, ok := c.bucketSessionCache.Get(bucketName)
+	if !ok || !v.Expiration.After(time.Now().Add(expressSessionRenewalLeeway)) {
+		return credentials.Value{}, false
+	}
+	return v, true
+}
+
 // CreateSession - https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateSession.html
 // the returning credentials may be cached depending on the expiration of the original
 // credential, credentials will get renewed 10 secs earlier than when its gonna expire
@@ -60,10 +74,7 @@ func (c *Client) CreateSession(ctx context.Context, bucketName string, sessionMo
 		return credentials.Value{}, err
 	}
 
-	v, ok := c.bucketSessionCache.Get(bucketName)
-	if ok && v.Expiration.After(time.Now().Add(10*time.Second)) {
-		// Verify if the credentials will not expire
-		// in another 10 seconds, if not we renew it again.
+	if v, ok := c.sessionFromCache(bucketName); ok {
 		return v, nil
 	}
 

--- a/create-session.go
+++ b/create-session.go
@@ -143,7 +143,7 @@ func (c *Client) createSessionRequest(ctx context.Context, bucketName string, se
 	c.setUserAgent(req)
 
 	// Get credentials from the configured credentials provider.
-	value, err := c.credsProvider.GetWithContext(c.CredContext())
+	value, err := c.credsProvider.GetWithContext(c.credContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/credentials/assume_role.go
+++ b/pkg/credentials/assume_role.go
@@ -19,6 +19,7 @@ package credentials
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
@@ -142,7 +143,7 @@ func closeResponse(resp *http.Response) {
 	}
 }
 
-func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssumeRoleOptions) (AssumeRoleResponse, error) {
+func getAssumeRoleCredentials(ctx context.Context, clnt *http.Client, endpoint string, opts STSAssumeRoleOptions) (AssumeRoleResponse, error) {
 	v := url.Values{}
 	v.Set("Action", "AssumeRole")
 	v.Set("Version", STSVersion)
@@ -180,7 +181,7 @@ func getAssumeRoleCredentials(clnt *http.Client, endpoint string, opts STSAssume
 	}
 	postBody.Seek(0, 0)
 
-	req, err := http.NewRequest(http.MethodPost, u.String(), postBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), postBody)
 	if err != nil {
 		return AssumeRoleResponse{}, err
 	}
@@ -245,7 +246,7 @@ func (m *STSAssumeRole) RetrieveWithCredContext(cc *CredContext) (Value, error) 
 		return Value{}, errors.New("STS endpoint unknown")
 	}
 
-	a, err := getAssumeRoleCredentials(client, stsEndpoint, m.Options)
+	a, err := getAssumeRoleCredentials(cc.requestContext(), client, stsEndpoint, m.Options)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/assume_role_test.go
+++ b/pkg/credentials/assume_role_test.go
@@ -23,7 +23,24 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
+
+// retrieveWithin bounds a synchronous credential retrieval so a context
+// wiring regression fails in seconds instead of hanging to the package
+// timeout.
+func retrieveWithin(t *testing.T, what string, fn func() error) error {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() { errCh <- fn() }()
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(30 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+		return nil
+	}
+}
 
 // TestSTSAssumeRoleCallerContextCancel verifies that the caller context
 // carried by CredContext cancels an in-flight AssumeRole request.
@@ -45,7 +62,10 @@ func TestSTSAssumeRoleCallerContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		<-requestArrived
+		select {
+		case <-requestArrived:
+		case <-time.After(10 * time.Second):
+		}
 		cancel()
 	}()
 
@@ -56,7 +76,15 @@ func TestSTSAssumeRoleCallerContextCancel(t *testing.T) {
 			SecretKey: "secret",
 		},
 	}
-	_, err := m.RetrieveWithCredContext(&CredContext{Client: server.Client(), Context: ctx})
+	err := retrieveWithin(t, "the AssumeRole retrieval", func() error {
+		_, err := m.RetrieveWithCredContext(&CredContext{Client: server.Client(), Context: ctx})
+		return err
+	})
+	select {
+	case <-requestArrived:
+	default:
+		t.Fatal("timed out waiting for the AssumeRole request to arrive")
+	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled, got %v", err)
 	}

--- a/pkg/credentials/assume_role_test.go
+++ b/pkg/credentials/assume_role_test.go
@@ -1,0 +1,63 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package credentials
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSTSAssumeRoleCallerContextCancel verifies that the caller context
+// carried by CredContext cancels an in-flight AssumeRole request.
+func TestSTSAssumeRoleCallerContextCancel(t *testing.T) {
+	requestArrived := make(chan struct{})
+	// The unread POST body disables the server's client-disconnect
+	// detection, so the handler needs an explicit release for Close.
+	handlerDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestArrived)
+		select {
+		case <-r.Context().Done():
+		case <-handlerDone:
+		}
+	}))
+	defer server.Close()
+	defer close(handlerDone)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-requestArrived
+		cancel()
+	}()
+
+	m := &STSAssumeRole{
+		STSEndpoint: server.URL,
+		Options: STSAssumeRoleOptions{
+			AccessKey: "access",
+			SecretKey: "secret",
+		},
+	}
+	_, err := m.RetrieveWithCredContext(&CredContext{Client: server.Client(), Context: ctx})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled, got %v", err)
+	}
+}

--- a/pkg/credentials/assume_role_test.go
+++ b/pkg/credentials/assume_role_test.go
@@ -20,54 +20,15 @@ package credentials
 import (
 	"context"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 )
-
-// retrieveWithin bounds a synchronous credential retrieval so a context
-// wiring regression fails in seconds instead of hanging to the package
-// timeout.
-func retrieveWithin(t *testing.T, what string, fn func() error) error {
-	t.Helper()
-	errCh := make(chan error, 1)
-	go func() { errCh <- fn() }()
-	select {
-	case err := <-errCh:
-		return err
-	case <-time.After(30 * time.Second):
-		t.Fatalf("timed out waiting for %s", what)
-		return nil
-	}
-}
 
 // TestSTSAssumeRoleCallerContextCancel verifies that the caller context
 // carried by CredContext cancels an in-flight AssumeRole request.
 func TestSTSAssumeRoleCallerContextCancel(t *testing.T) {
-	requestArrived := make(chan struct{})
-	// The unread POST body disables the server's client-disconnect
-	// detection, so the handler needs an explicit release for Close.
-	handlerDone := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		close(requestArrived)
-		select {
-		case <-r.Context().Done():
-		case <-handlerDone:
-		}
-	}))
-	defer server.Close()
-	defer close(handlerDone)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go func() {
-		select {
-		case <-requestArrived:
-		case <-time.After(10 * time.Second):
-		}
-		cancel()
-	}()
+	server, requestArrived := newCancelProbeServer(t, cancel)
 
 	m := &STSAssumeRole{
 		STSEndpoint: server.URL,
@@ -80,11 +41,7 @@ func TestSTSAssumeRoleCallerContextCancel(t *testing.T) {
 		_, err := m.RetrieveWithCredContext(&CredContext{Client: server.Client(), Context: ctx})
 		return err
 	})
-	select {
-	case <-requestArrived:
-	default:
-		t.Fatal("timed out waiting for the AssumeRole request to arrive")
-	}
+	requireRequestArrived(t, requestArrived, "the AssumeRole request")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled, got %v", err)
 	}

--- a/pkg/credentials/cancel_probe_test.go
+++ b/pkg/credentials/cancel_probe_test.go
@@ -1,0 +1,94 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package credentials
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// probeWaitBound caps every cross-goroutine wait in the caller-context
+// tests so a wiring regression fails in seconds instead of hanging to the
+// package timeout.
+const probeWaitBound = 10 * time.Second
+
+// retrieveWithin bounds a synchronous credential retrieval so a context
+// wiring regression fails in seconds instead of hanging to the package
+// timeout. On timeout the spawned goroutine is abandoned — it stays
+// blocked in the provider for the rest of the process, which is
+// acceptable for a test that is already failing.
+func retrieveWithin(t *testing.T, what string, fn func() error) error {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() { errCh <- fn() }()
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(3 * probeWaitBound):
+		t.Fatalf("timed out waiting for %s", what)
+		return nil
+	}
+}
+
+// newCancelProbeServer starts an httptest server whose handler signals the
+// first request's arrival on the returned channel and then blocks until
+// the request context ends or the test finishes; cancel runs once the
+// request arrives (or after probeWaitBound when it never does, so the
+// retrieval under test still returns and the caller's arrival guard
+// reports the miss). The arrival signal is a sync.Once close: a
+// transport-level retry must not panic on a second request. The
+// end-of-test release keeps the server Close from waiting on the handler
+// when a regression leaves the request context un-canceled.
+func newCancelProbeServer(t *testing.T, cancel context.CancelFunc) (*httptest.Server, <-chan struct{}) {
+	t.Helper()
+	requestArrived := make(chan struct{})
+	var arrivedOnce sync.Once
+	handlerDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		arrivedOnce.Do(func() { close(requestArrived) })
+		select {
+		case <-r.Context().Done():
+		case <-handlerDone:
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(handlerDone) })
+	go func() {
+		select {
+		case <-requestArrived:
+		case <-time.After(probeWaitBound):
+		}
+		cancel()
+	}()
+	return server, requestArrived
+}
+
+// requireRequestArrived fails the test when the probe server never saw
+// the request the retrieval was expected to send.
+func requireRequestArrived(t *testing.T, requestArrived <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-requestArrived:
+	default:
+		t.Fatalf("timed out waiting for %s to arrive", what)
+	}
+}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -95,9 +95,9 @@ type CredContext struct {
 }
 
 // requestContext returns the caller context carried by cc, or
-// context.Background() when cc or its Context is nil.
+// context.Background() when no Context is set.
 func (cc *CredContext) requestContext() context.Context {
-	if cc == nil || cc.Context == nil {
+	if cc.Context == nil {
 		return context.Background()
 	}
 	return cc.Context

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -18,6 +18,7 @@
 package credentials
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -85,6 +86,21 @@ type CredContext struct {
 	// Endpoint specifies the MinIO endpoint that will be used if no
 	// explicit endpoint is provided.
 	Endpoint string
+
+	// Context is the optional caller context. Cancellation and deadlines
+	// on it propagate to the HTTP requests the built-in providers make
+	// to fetch credentials, in addition to any provider-level timeout
+	// bound. A nil Context means no caller cancellation applies.
+	Context context.Context
+}
+
+// requestContext returns the caller context carried by cc, or
+// context.Background() when cc or its Context is nil.
+func (cc *CredContext) requestContext() context.Context {
+	if cc == nil || cc.Context == nil {
+		return context.Background()
+	}
+	return cc.Context
 }
 
 // A Expiry provides shared expiration logic to be used by credentials

--- a/pkg/credentials/file_aws_credentials.go
+++ b/pkg/credentials/file_aws_credentials.go
@@ -316,7 +316,10 @@ func (p *FileAWSCredentials) getSSOCredentials(cc *CredContext, iniConfig *ini.F
 	if portalURL == "" {
 		portalURL = ssoPortalBaseURL(ssoRegion)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), ssoPortalRequestTimeout)
+	if cc == nil {
+		cc = defaultCredContext
+	}
+	ctx, cancel := context.WithTimeout(cc.requestContext(), ssoPortalRequestTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, portalURL+"/federation/credentials", nil)
 	if err != nil {
@@ -328,9 +331,6 @@ func (p *FileAWSCredentials) getSSOCredentials(cc *CredContext, iniConfig *ini.F
 	query.Add("role_name", ssoRoleName)
 	req.URL.RawQuery = query.Encode()
 
-	if cc == nil {
-		cc = defaultCredContext
-	}
 	client := cc.Client
 	if client == nil {
 		client = defaultCredContext.Client

--- a/pkg/credentials/file_test.go
+++ b/pkg/credentials/file_test.go
@@ -1059,21 +1059,41 @@ func TestFileAWSSSOCallerContext(t *testing.T) {
 
 	t.Run("caller-cancel", func(t *testing.T) {
 		requestArrived := make(chan struct{})
+		// The explicit release keeps the deferred Close from waiting on
+		// the handler when a regression leaves the request context
+		// un-canceled.
+		handlerDone := make(chan struct{})
 		ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			close(requestArrived)
-			<-r.Context().Done()
+			select {
+			case <-r.Context().Done():
+			case <-handlerDone:
+			}
 		}))
 		defer ts.Close()
+		defer close(handlerDone)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go func() {
-			<-requestArrived
+			select {
+			case <-requestArrived:
+			case <-time.After(10 * time.Second):
+			}
 			cancel()
 		}()
 
+		creds := newSSOCreds(ts.URL, newCacheDir(t))
 		start := time.Now()
-		_, err := newSSOCreds(ts.URL, newCacheDir(t)).GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
+		err := retrieveWithin(t, "the SSO portal retrieval", func() error {
+			_, err := creds.GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
+			return err
+		})
+		select {
+		case <-requestArrived:
+		default:
+			t.Fatal("timed out waiting for the SSO portal request to arrive")
+		}
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("Expected context.Canceled, got %v", err)
 		}
@@ -1083,15 +1103,24 @@ func TestFileAWSSSOCallerContext(t *testing.T) {
 	})
 
 	t.Run("caller-deadline", func(t *testing.T) {
+		handlerDone := make(chan struct{})
 		ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-			<-r.Context().Done()
+			select {
+			case <-r.Context().Done():
+			case <-handlerDone:
+			}
 		}))
 		defer ts.Close()
+		defer close(handlerDone)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
 
-		_, err := newSSOCreds(ts.URL, newCacheDir(t)).GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
+		creds := newSSOCreds(ts.URL, newCacheDir(t))
+		err := retrieveWithin(t, "the SSO portal retrieval", func() error {
+			_, err := creds.GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
+			return err
+		})
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("Expected context.DeadlineExceeded, got %v", err)
 		}

--- a/pkg/credentials/file_test.go
+++ b/pkg/credentials/file_test.go
@@ -18,9 +18,12 @@
 package credentials
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1029,3 +1032,101 @@ func TestFileMinioClient(t *testing.T) {
 		t.Error("Should be expired if not loaded")
 	}
 }
+
+// TestFileAWSSSOCallerContext verifies that the caller context carried by
+// CredContext cancels or bounds the SSO portal request, and that the
+// provider-level ssoPortalRequestTimeout bound stays enforced alongside it.
+func TestFileAWSSSOCallerContext(t *testing.T) {
+	os.Clearenv()
+
+	testNow := func() time.Time { return time.Date(2020, time.January, 10, 1, 1, 1, 1, time.UTC) }
+
+	newSSOCreds := func(portalURL, cacheDir string) *Credentials {
+		return New(&FileAWSCredentials{
+			Expiry:               Expiry{CurrentTime: testNow},
+			Filename:             "credentials-sso.sample",
+			Profile:              "p1",
+			overrideSSOCacheDir:  cacheDir,
+			overrideSSOPortalURL: portalURL,
+		})
+	}
+	newCacheDir := func(t *testing.T) string {
+		cacheDir := t.TempDir()
+		writeSSOCachedToken(t, cacheDir, "main",
+			`{"startUrl": "https://testacct.awsapps.com/start", "region": "us-test-2", "accessToken": "my-access-token", "expiresAt": "2020-01-11T00:00:00Z"}`)
+		return cacheDir
+	}
+
+	t.Run("caller-cancel", func(t *testing.T) {
+		requestArrived := make(chan struct{})
+		ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			close(requestArrived)
+			<-r.Context().Done()
+		}))
+		defer ts.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			<-requestArrived
+			cancel()
+		}()
+
+		start := time.Now()
+		_, err := newSSOCreds(ts.URL, newCacheDir(t)).GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Expected context.Canceled, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed >= ssoPortalRequestTimeout {
+			t.Fatalf("Cancellation took %v, bounded by the provider timeout instead of the caller context", elapsed)
+		}
+	})
+
+	t.Run("caller-deadline", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		defer ts.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		_, err := newSSOCreds(ts.URL, newCacheDir(t)).GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Expected context.DeadlineExceeded, got %v", err)
+		}
+	})
+
+	// A deadline is only observable client-side (it does not travel over
+	// HTTP), so the provider-bound check inspects the outgoing request's
+	// context in a RoundTripper instead of an httptest handler.
+	t.Run("provider-bound-retained", func(t *testing.T) {
+		deadlineCh := make(chan time.Time, 1)
+		client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			dl, _ := req.Context().Deadline()
+			deadlineCh <- dl
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"roleCredentials": {"accessKeyId": "accessKey", "secretAccessKey": "secret", "sessionToken": "token", "expiration": 1702317362000}}`)),
+			}, nil
+		})}
+
+		_, err := newSSOCreds("https://portal.sso.invalid", newCacheDir(t)).GetWithContext(&CredContext{Client: client, Context: context.Background()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		dl := <-deadlineCh
+		if dl.IsZero() {
+			t.Fatal("Expected the SSO portal request context to carry the provider-level deadline")
+		}
+		if until := time.Until(dl); until > ssoPortalRequestTimeout || until < ssoPortalRequestTimeout/2 {
+			t.Fatalf("Expected a deadline about ssoPortalRequestTimeout from now, got %v", until)
+		}
+	})
+}
+
+// roundTripperFunc adapts a function to http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/pkg/credentials/file_test.go
+++ b/pkg/credentials/file_test.go
@@ -1058,30 +1058,9 @@ func TestFileAWSSSOCallerContext(t *testing.T) {
 	}
 
 	t.Run("caller-cancel", func(t *testing.T) {
-		requestArrived := make(chan struct{})
-		// The explicit release keeps the deferred Close from waiting on
-		// the handler when a regression leaves the request context
-		// un-canceled.
-		handlerDone := make(chan struct{})
-		ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-			close(requestArrived)
-			select {
-			case <-r.Context().Done():
-			case <-handlerDone:
-			}
-		}))
-		defer ts.Close()
-		defer close(handlerDone)
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		go func() {
-			select {
-			case <-requestArrived:
-			case <-time.After(10 * time.Second):
-			}
-			cancel()
-		}()
+		ts, requestArrived := newCancelProbeServer(t, cancel)
 
 		creds := newSSOCreds(ts.URL, newCacheDir(t))
 		start := time.Now()
@@ -1089,15 +1068,14 @@ func TestFileAWSSSOCallerContext(t *testing.T) {
 			_, err := creds.GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
 			return err
 		})
-		select {
-		case <-requestArrived:
-		default:
-			t.Fatal("timed out waiting for the SSO portal request to arrive")
-		}
+		requireRequestArrived(t, requestArrived, "the SSO portal request")
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("Expected context.Canceled, got %v", err)
 		}
-		if elapsed := time.Since(start); elapsed >= ssoPortalRequestTimeout {
+		// Anything but the caller's cancel (the provider bound, transport
+		// limits) takes ssoPortalRequestTimeout or longer; a prompt return
+		// attributes the cancellation to the caller context.
+		if elapsed := time.Since(start); elapsed >= probeWaitBound {
 			t.Fatalf("Cancellation took %v, bounded by the provider timeout instead of the caller context", elapsed)
 		}
 	})
@@ -1117,12 +1095,19 @@ func TestFileAWSSSOCallerContext(t *testing.T) {
 		defer cancel()
 
 		creds := newSSOCreds(ts.URL, newCacheDir(t))
+		start := time.Now()
 		err := retrieveWithin(t, "the SSO portal retrieval", func() error {
 			_, err := creds.GetWithContext(&CredContext{Client: ts.Client(), Context: ctx})
 			return err
 		})
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("Expected context.DeadlineExceeded, got %v", err)
+		}
+		// The provider's own bound also surfaces DeadlineExceeded; only a
+		// prompt return attributes the expiry to the 50 ms caller
+		// deadline, since the provider bound needs ssoPortalRequestTimeout.
+		if elapsed := time.Since(start); elapsed >= probeWaitBound {
+			t.Fatalf("Deadline expiry took %v, bounded by the provider timeout instead of the caller context", elapsed)
 		}
 	})
 
@@ -1145,7 +1130,12 @@ func TestFileAWSSSOCallerContext(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		dl := <-deadlineCh
+		var dl time.Time
+		select {
+		case dl = <-deadlineCh:
+		case <-time.After(probeWaitBound):
+			t.Fatal("timed out waiting for the SSO portal request deadline")
+		}
 		if dl.IsZero() {
 			t.Fatal("Expected the SSO portal request context to carry the provider-level deadline")
 		}

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -171,6 +171,8 @@ func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
 		client = defaultCredContext.Client
 	}
 
+	ctx := cc.requestContext()
+
 	endpoint := m.Endpoint
 
 	switch {
@@ -217,11 +219,11 @@ func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
 			endpoint = fmt.Sprintf("%s%s", DefaultECSRoleEndpoint, relativeURI)
 		}
 
-		roleCreds, err = getEcsTaskCredentials(client, endpoint, token)
+		roleCreds, err = getEcsTaskCredentials(ctx, client, endpoint, token)
 
 	case tokenFile != "" && fullURI != "":
 		endpoint = fullURI
-		roleCreds, err = getEKSPodIdentityCredentials(client, endpoint, tokenFile)
+		roleCreds, err = getEKSPodIdentityCredentials(ctx, client, endpoint, tokenFile)
 
 	case fullURI != "":
 		if len(endpoint) == 0 {
@@ -235,10 +237,10 @@ func (m *IAM) RetrieveWithCredContext(cc *CredContext) (Value, error) {
 			}
 		}
 
-		roleCreds, err = getEcsTaskCredentials(client, endpoint, token)
+		roleCreds, err = getEcsTaskCredentials(ctx, client, endpoint, token)
 
 	default:
-		roleCreds, err = getCredentials(client, endpoint)
+		roleCreds, err = getCredentials(ctx, client, endpoint)
 	}
 
 	if err != nil {
@@ -296,8 +298,8 @@ func getIAMRoleURL(endpoint string) (*url.URL, error) {
 // with the current EC2 service. If there are no credentials,
 // or there is an error making or receiving the request.
 // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
-func listRoleNames(client *http.Client, u *url.URL, token string) ([]string, error) {
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+func listRoleNames(ctx context.Context, client *http.Client, u *url.URL, token string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -326,8 +328,8 @@ func listRoleNames(client *http.Client, u *url.URL, token string) ([]string, err
 	return credsList, nil
 }
 
-func getEcsTaskCredentials(client *http.Client, endpoint, token string) (ec2RoleCredRespBody, error) {
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+func getEcsTaskCredentials(ctx context.Context, client *http.Client, endpoint, token string) (ec2RoleCredRespBody, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return ec2RoleCredRespBody{}, err
 	}
@@ -353,20 +355,20 @@ func getEcsTaskCredentials(client *http.Client, endpoint, token string) (ec2Role
 	return respCreds, nil
 }
 
-func getEKSPodIdentityCredentials(client *http.Client, endpoint string, tokenFile string) (ec2RoleCredRespBody, error) {
+func getEKSPodIdentityCredentials(ctx context.Context, client *http.Client, endpoint string, tokenFile string) (ec2RoleCredRespBody, error) {
 	if tokenFile != "" {
 		bytes, err := os.ReadFile(tokenFile)
 		if err != nil {
 			return ec2RoleCredRespBody{}, fmt.Errorf("getEKSPodIdentityCredentials: failed to read token file:%s", err)
 		}
 		token := string(bytes)
-		return getEcsTaskCredentials(client, endpoint, token)
+		return getEcsTaskCredentials(ctx, client, endpoint, token)
 	}
 	return ec2RoleCredRespBody{}, fmt.Errorf("getEKSPodIdentityCredentials: no tokenFile found")
 }
 
-func fetchIMDSToken(client *http.Client, endpoint string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+func fetchIMDSToken(ctx context.Context, client *http.Client, endpoint string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint+TokenPath, nil)
@@ -394,14 +396,18 @@ func fetchIMDSToken(client *http.Client, endpoint string) (string, error) {
 //
 // If the credentials cannot be found, or there is an error
 // reading the response an error will be returned.
-func getCredentials(client *http.Client, endpoint string) (ec2RoleCredRespBody, error) {
+func getCredentials(ctx context.Context, client *http.Client, endpoint string) (ec2RoleCredRespBody, error) {
 	if endpoint == "" {
 		endpoint = DefaultIAMRoleEndpoint
 	}
 
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
-	token, err := fetchIMDSToken(client, endpoint)
+	token, err := fetchIMDSToken(ctx, client, endpoint)
 	if err != nil {
+		// A dead caller context is not an IMDSv2 availability signal.
+		if cerr := ctx.Err(); cerr != nil {
+			return ec2RoleCredRespBody{}, cerr
+		}
 		// Return only errors for valid situations, if the IMDSv2 is not enabled
 		// we will not be able to get the token, in such a situation we have
 		// to rely on IMDSv1 behavior as a fallback, this check ensures that.
@@ -418,7 +424,7 @@ func getCredentials(client *http.Client, endpoint string) (ec2RoleCredRespBody, 
 	}
 
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
-	roleNames, err := listRoleNames(client, u, token)
+	roleNames, err := listRoleNames(ctx, client, u, token)
 	if err != nil {
 		return ec2RoleCredRespBody{}, err
 	}
@@ -438,7 +444,7 @@ func getCredentials(client *http.Client, endpoint string) (ec2RoleCredRespBody, 
 	//    $ curl http://169.254.169.254/latest/meta-data/iam/security-credentials/s3access
 	//
 	u.Path = path.Join(u.Path, roleName)
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return ec2RoleCredRespBody{}, err
 	}

--- a/pkg/credentials/iam_aws.go
+++ b/pkg/credentials/iam_aws.go
@@ -406,7 +406,7 @@ func getCredentials(ctx context.Context, client *http.Client, endpoint string) (
 	if err != nil {
 		// A dead caller context is not an IMDSv2 availability signal.
 		if cerr := ctx.Err(); cerr != nil {
-			return ec2RoleCredRespBody{}, cerr
+			return ec2RoleCredRespBody{}, fmt.Errorf("%w (imds token fetch: %v)", cerr, err)
 		}
 		// Return only errors for valid situations, if the IMDSv2 is not enabled
 		// we will not be able to get the token, in such a situation we have

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -614,23 +615,41 @@ func TestIAMCustomExpiryWindowWebIdentity(t *testing.T) {
 // CredContext cancels an in-flight ECS task credentials request.
 func TestEcsTaskCallerContextCancel(t *testing.T) {
 	requestArrived := make(chan struct{})
+	// The explicit release keeps the deferred Close from waiting on the
+	// handler when a regression leaves the request context un-canceled.
+	handlerDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		close(requestArrived)
-		<-r.Context().Done()
+		select {
+		case <-r.Context().Done():
+		case <-handlerDone:
+		}
 	}))
 	defer server.Close()
+	defer close(handlerDone)
 
 	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials?id=task_credential_id")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		<-requestArrived
+		select {
+		case <-requestArrived:
+		case <-time.After(10 * time.Second):
+		}
 		cancel()
 	}()
 
 	p := &IAM{Endpoint: server.URL}
-	_, err := p.RetrieveWithCredContext(&CredContext{Client: http.DefaultClient, Context: ctx})
+	err := retrieveWithin(t, "the ECS credentials retrieval", func() error {
+		_, err := p.RetrieveWithCredContext(&CredContext{Client: http.DefaultClient, Context: ctx})
+		return err
+	})
+	select {
+	case <-requestArrived:
+	default:
+		t.Fatal("timed out waiting for the ECS credentials request to arrive")
+	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled, got %v", err)
 	}
@@ -646,6 +665,11 @@ func TestIAMCallerContextCanceled(t *testing.T) {
 	}))
 	defer server.Close()
 
+	// Reach the IMDS arm regardless of the ambient environment.
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -653,6 +677,11 @@ func TestIAMCallerContextCanceled(t *testing.T) {
 	_, err := p.RetrieveWithCredContext(&CredContext{Client: http.DefaultClient, Context: ctx})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled, got %v", err)
+	}
+	// The token-fetch detail pins that the dead-caller guard produced the
+	// error, not the IMDSv1 fallback failing on the same canceled context.
+	if !strings.Contains(err.Error(), "imds token fetch") {
+		t.Fatalf("Expected the dead-caller guard's error with token-fetch detail, got %v", err)
 	}
 	if n := requests.Load(); n != 0 {
 		t.Fatalf("Expected no metadata requests with a canceled caller context, got %d", n)

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -281,6 +281,9 @@ func TestEcsTask(t *testing.T) {
 	p := &IAM{
 		Endpoint: server.URL,
 	}
+	// Reach the ECS arm regardless of the ambient environment: a web
+	// identity token file takes precedence over the container relative URI.
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
 	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials?id=task_credential_id")
 	creds, err := p.RetrieveWithCredContext(defaultCredContext)
 	os.Unsetenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
@@ -308,6 +311,10 @@ func TestEcsTaskFullURI(t *testing.T) {
 	server := initEcsTaskTestServer("2014-12-16T01:51:37Z")
 	defer server.Close()
 	p := &IAM{}
+	// Reach the full-URI arm regardless of the ambient environment: the
+	// web identity token file and the relative URI both take precedence.
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
 	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI",
 		fmt.Sprintf("%s%s", server.URL, "/v2/credentials?id=task_credential_id"))
 	creds, err := p.RetrieveWithCredContext(defaultCredContext)
@@ -614,45 +621,21 @@ func TestIAMCustomExpiryWindowWebIdentity(t *testing.T) {
 // TestEcsTaskCallerContextCancel verifies that the caller context carried by
 // CredContext cancels an in-flight ECS task credentials request.
 func TestEcsTaskCallerContextCancel(t *testing.T) {
-	requestArrived := make(chan struct{})
-	// The explicit release keeps the deferred Close from waiting on the
-	// handler when a regression leaves the request context un-canceled.
-	handlerDone := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		close(requestArrived)
-		select {
-		case <-r.Context().Done():
-		case <-handlerDone:
-		}
-	}))
-	defer server.Close()
-	defer close(handlerDone)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server, requestArrived := newCancelProbeServer(t, cancel)
 
 	// Reach the ECS arm regardless of the ambient environment: a web
 	// identity token file takes precedence over the container relative URI.
 	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
 	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials?id=task_credential_id")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		select {
-		case <-requestArrived:
-		case <-time.After(10 * time.Second):
-		}
-		cancel()
-	}()
-
 	p := &IAM{Endpoint: server.URL}
 	err := retrieveWithin(t, "the ECS credentials retrieval", func() error {
-		_, err := p.RetrieveWithCredContext(&CredContext{Client: http.DefaultClient, Context: ctx})
+		_, err := p.RetrieveWithCredContext(&CredContext{Client: server.Client(), Context: ctx})
 		return err
 	})
-	select {
-	case <-requestArrived:
-	default:
-		t.Fatal("timed out waiting for the ECS credentials request to arrive")
-	}
+	requireRequestArrived(t, requestArrived, "the ECS credentials request")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled, got %v", err)
 	}
@@ -677,7 +660,7 @@ func TestIAMCallerContextCanceled(t *testing.T) {
 	cancel()
 
 	p := &IAM{Endpoint: server.URL}
-	_, err := p.RetrieveWithCredContext(&CredContext{Client: http.DefaultClient, Context: ctx})
+	_, err := p.RetrieveWithCredContext(&CredContext{Client: server.Client(), Context: ctx})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context.Canceled, got %v", err)
 	}

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -628,6 +628,9 @@ func TestEcsTaskCallerContextCancel(t *testing.T) {
 	defer server.Close()
 	defer close(handlerDone)
 
+	// Reach the ECS arm regardless of the ambient environment: a web
+	// identity token file takes precedence over the container relative URI.
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
 	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials?id=task_credential_id")
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/credentials/iam_aws_test.go
+++ b/pkg/credentials/iam_aws_test.go
@@ -20,11 +20,14 @@
 package credentials
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -604,5 +607,54 @@ func TestIAMCustomExpiryWindowWebIdentity(t *testing.T) {
 	expectedExpiry := time.Date(2014, 12, 16, 1, 46, 37, 0, time.UTC)
 	if !p.expiration.Equal(expectedExpiry) {
 		t.Errorf("Expected expiration %v, got %v", expectedExpiry, p.expiration)
+	}
+}
+
+// TestEcsTaskCallerContextCancel verifies that the caller context carried by
+// CredContext cancels an in-flight ECS task credentials request.
+func TestEcsTaskCallerContextCancel(t *testing.T) {
+	requestArrived := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestArrived)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials?id=task_credential_id")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-requestArrived
+		cancel()
+	}()
+
+	p := &IAM{Endpoint: server.URL}
+	_, err := p.RetrieveWithCredContext(&CredContext{Client: http.DefaultClient, Context: ctx})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled, got %v", err)
+	}
+}
+
+// TestIAMCallerContextCanceled verifies that an already-canceled caller
+// context aborts the EC2/IMDS credentials flow promptly instead of running
+// the metadata requests to completion.
+func TestIAMCallerContextCanceled(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p := &IAM{Endpoint: server.URL}
+	_, err := p.RetrieveWithCredContext(&CredContext{Client: http.DefaultClient, Context: ctx})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled, got %v", err)
+	}
+	if n := requests.Load(); n != 0 {
+		t.Fatalf("Expected no metadata requests with a canceled caller context, got %d", n)
 	}
 }

--- a/pkg/credentials/sts_caller_context_test.go
+++ b/pkg/credentials/sts_caller_context_test.go
@@ -1,0 +1,91 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package credentials
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestSTSProvidersCallerContextCanceled verifies that each remaining STS
+// provider threads the caller context into its request: an already-canceled
+// caller context aborts the retrieval before anything reaches the server.
+func TestSTSProvidersCallerContextCanceled(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The certificate provider clones the transport to attach its client
+	// certificate, so the shared client needs a TLS-configured transport.
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{}}}
+
+	cases := []struct {
+		name     string
+		retrieve func(*CredContext) (Value, error)
+	}{
+		{"client-grants", (&STSClientGrants{
+			STSEndpoint: server.URL,
+			GetClientGrantsTokenExpiry: func() (*ClientGrantsToken, error) {
+				return &ClientGrantsToken{Token: "token", Expiry: 60}, nil
+			},
+		}).RetrieveWithCredContext},
+		{"web-identity", (&STSWebIdentity{
+			STSEndpoint: server.URL,
+			GetWebIDTokenExpiry: func() (*WebIdentityToken, error) {
+				return &WebIdentityToken{Token: "token"}, nil
+			},
+		}).RetrieveWithCredContext},
+		{"ldap", (&LDAPIdentity{
+			STSEndpoint:  server.URL,
+			LDAPUsername: "user",
+			LDAPPassword: "pass",
+		}).RetrieveWithCredContext},
+		{"custom-token", (&CustomTokenIdentity{
+			STSEndpoint: server.URL,
+			Token:       "token",
+			RoleArn:     "arn:minio:iam:::role/x",
+		}).RetrieveWithCredContext},
+		{"certificate", (&STSCertificateIdentity{
+			STSEndpoint: server.URL,
+		}).RetrieveWithCredContext},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := retrieveWithin(t, "the "+tc.name+" retrieval", func() error {
+				_, err := tc.retrieve(&CredContext{Client: client, Context: ctx})
+				return err
+			})
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("Expected context.Canceled, got %v", err)
+			}
+		})
+	}
+	if n := requests.Load(); n != 0 {
+		t.Fatalf("Expected no requests with a canceled caller context, got %d", n)
+	}
+}

--- a/pkg/credentials/sts_client_grants.go
+++ b/pkg/credentials/sts_client_grants.go
@@ -19,6 +19,7 @@ package credentials
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -100,7 +101,7 @@ func NewSTSClientGrants(stsEndpoint string, getClientGrantsTokenExpiry func() (*
 	}), nil
 }
 
-func getClientGrantsCredentials(clnt *http.Client, endpoint string,
+func getClientGrantsCredentials(ctx context.Context, clnt *http.Client, endpoint string,
 	getClientGrantsTokenExpiry func() (*ClientGrantsToken, error),
 ) (AssumeRoleWithClientGrantsResponse, error) {
 	accessToken, err := getClientGrantsTokenExpiry()
@@ -119,7 +120,7 @@ func getClientGrantsCredentials(clnt *http.Client, endpoint string,
 		return AssumeRoleWithClientGrantsResponse{}, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return AssumeRoleWithClientGrantsResponse{}, err
 	}
@@ -179,7 +180,7 @@ func (m *STSClientGrants) RetrieveWithCredContext(cc *CredContext) (Value, error
 		return Value{}, errors.New("STS endpoint unknown")
 	}
 
-	a, err := getClientGrantsCredentials(client, stsEndpoint, m.GetClientGrantsTokenExpiry)
+	a, err := getClientGrantsCredentials(cc.requestContext(), client, stsEndpoint, m.GetClientGrantsTokenExpiry)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/sts_custom_identity.go
+++ b/pkg/credentials/sts_custom_identity.go
@@ -107,7 +107,7 @@ func (c *CustomTokenIdentity) RetrieveWithCredContext(cc *CredContext) (value Va
 
 	u.RawQuery = v.Encode()
 
-	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	req, err := http.NewRequestWithContext(cc.requestContext(), http.MethodPost, u.String(), nil)
 	if err != nil {
 		return value, err
 	}

--- a/pkg/credentials/sts_ldap_identity.go
+++ b/pkg/credentials/sts_ldap_identity.go
@@ -172,7 +172,7 @@ func (k *LDAPIdentity) RetrieveWithCredContext(cc *CredContext) (value Value, er
 		v.Set("ConfigName", k.ConfigName)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
+	req, err := http.NewRequestWithContext(cc.requestContext(), http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return value, err
 	}

--- a/pkg/credentials/sts_tls_identity.go
+++ b/pkg/credentials/sts_tls_identity.go
@@ -131,7 +131,7 @@ func (i *STSCertificateIdentity) RetrieveWithCredContext(cc *CredContext) (Value
 	}
 	endpointURL.RawQuery = queryValues.Encode()
 
-	req, err := http.NewRequest(http.MethodPost, endpointURL.String(), nil)
+	req, err := http.NewRequestWithContext(cc.requestContext(), http.MethodPost, endpointURL.String(), nil)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/credentials/sts_web_identity.go
+++ b/pkg/credentials/sts_web_identity.go
@@ -19,6 +19,7 @@ package credentials
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -137,7 +138,7 @@ func WithPolicy(policy string) func(*STSWebIdentity) {
 	}
 }
 
-func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSessionName string, policy string,
+func getWebIdentityCredentials(ctx context.Context, clnt *http.Client, endpoint, roleARN, roleSessionName string, policy string,
 	getWebIDTokenExpiry func() (*WebIdentityToken, error), tokenRevokeType string,
 ) (AssumeRoleWithWebIdentityResponse, error) {
 	idToken, err := getWebIDTokenExpiry()
@@ -180,7 +181,7 @@ func getWebIdentityCredentials(clnt *http.Client, endpoint, roleARN, roleSession
 		return AssumeRoleWithWebIdentityResponse{}, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return AssumeRoleWithWebIdentityResponse{}, err
 	}
@@ -242,7 +243,7 @@ func (m *STSWebIdentity) RetrieveWithCredContext(cc *CredContext) (Value, error)
 		return Value{}, errors.New("STS endpoint unknown")
 	}
 
-	a, err := getWebIdentityCredentials(client, stsEndpoint, m.RoleARN, m.roleSessionName, m.Policy, m.GetWebIDTokenExpiry, m.TokenRevokeType)
+	a, err := getWebIdentityCredentials(cc.requestContext(), client, stsEndpoint, m.RoleARN, m.roleSessionName, m.Policy, m.GetWebIDTokenExpiry, m.TokenRevokeType)
 	if err != nil {
 		return Value{}, err
 	}

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -173,7 +173,13 @@ func (g *Group[K, V]) doCall(c *call[V], key K, fn func() (V, error)) {
 				panic(e)
 			}
 		} else if c.err == errGoexit {
-			// Already in the process of goexit, no need to call again
+			// This goroutine is already being torn down, so it must not
+			// call runtime.Goexit again. Do callers re-Goexit themselves
+			// once they see c.err; DoChan callers hold a channel and have
+			// nothing else to wake them, so deliver the error to them.
+			for _, ch := range c.chans {
+				ch <- Result[V]{c.val, c.err, c.dups > 0}
+			}
 		} else {
 			// Normal return
 			for _, ch := range c.chans {

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -172,16 +172,12 @@ func (g *Group[K, V]) doCall(c *call[V], key K, fn func() (V, error)) {
 			} else {
 				panic(e)
 			}
-		} else if c.err == errGoexit {
-			// This goroutine is already being torn down, so it must not
-			// call runtime.Goexit again. Do callers re-Goexit themselves
-			// once they see c.err; DoChan callers hold a channel and have
-			// nothing else to wake them, so deliver the error to them.
-			for _, ch := range c.chans {
-				ch <- Result[V]{c.val, c.err, c.dups > 0}
-			}
 		} else {
-			// Normal return
+			// Normal return, and runtime.Goexit, which reaches here with
+			// c.err set to errGoexit. This goroutine is already being torn
+			// down and must not call runtime.Goexit again: Do callers
+			// re-Goexit themselves once they see c.err, but DoChan callers
+			// hold a channel and have nothing else to wake them.
 			for _, ch := range c.chans {
 				ch <- Result[V]{c.val, c.err, c.dups > 0}
 			}

--- a/pkg/singleflight/singleflight_test.go
+++ b/pkg/singleflight/singleflight_test.go
@@ -420,3 +420,34 @@ func ExampleGroup() {
 	// Equal results: true
 	// Result: func 1
 }
+
+// TestGoexitDoChan pins that DoChan waiters receive a terminal result when the
+// shared call ends in runtime.Goexit. Do callers re-Goexit themselves, but a
+// DoChan caller holds a channel and has nothing else to wake it.
+func TestGoexitDoChan(t *testing.T) {
+	var g Group[string, any]
+	release := make(chan struct{})
+	fn := func() (any, error) {
+		<-release
+		runtime.Goexit()
+		return nil, nil
+	}
+
+	const n = 3
+	chans := make([]<-chan Result[any], n)
+	for i := range chans {
+		chans[i] = g.DoChan("key", fn)
+	}
+	close(release)
+
+	for i, ch := range chans {
+		select {
+		case res := <-ch:
+			if res.Err == nil {
+				t.Fatalf("waiter %d: expected a terminal error after runtime.Goexit, got nil", i)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("waiter %d: DoChan hangs after runtime.Goexit", i)
+		}
+	}
+}


### PR DESCRIPTION
RDMA failure fixed in https://github.com/minio/minio-go/pull/2276

## Description

Callers can now cancel the HTTP requests that credential providers make, or give them a deadline. `credentials.CredContext` gains an optional `Context` field, and the client passes the caller's context into it.

**Inside `pkg/credentials`.** Every provider request (11 sites) is now built with `http.NewRequestWithContext` using the caller's context. Provider-level bounds still apply on top of it: the SSO portal call keeps its 1-minute limit, and the IMDS token fetch keeps its 1-second limit. A canceled caller is no longer misread as "IMDSv2 unavailable". A nil `Context` behaves exactly as before.

**Inside the client (`api.go`).** When an S3 operation needs credentials:

- Cached, unexpired credentials are used directly. So are still-fresh cached S3 Express sessions.
- Otherwise one retrieval runs per bucket and all concurrent callers share it (singleflight).
- The shared retrieval is detached from the callers (`context.WithoutCancel`). One caller canceling therefore cannot fail the others. Each caller stops waiting when its own context ends.
- Exception: the S3 Express `CreateSession` retrieval keeps the winning caller's context, because it is a full S3 operation whose retries must stay cancellable. Express waiters share the winner's fate.
- A caller that arrives while a retrieval holds the credentials mutex still blocks until that retrieval completes, as it did before this change.
- A result that has already arrived when a caller's cancellation fires is preferred over the cancellation.
- A provider panic resumes on each waiting caller's goroutine instead of crashing the process.

This is the same shape as aws-sdk-go-v2's `CredentialsCache.Retrieve`.

**Scope of the guarantee.** On the shared path (`GetObject`, `PutObject`, and every other S3 operation) the caller's context controls only how long that caller waits. The detached retrieval itself ignores the caller's cancellation and deadline — that is what protects the other waiters. The caller's context cancels the credential request itself on the direct paths: `PresignedPostPolicy`, `getBucketLocation`, `CreateSession`, and any direct `GetWithContext` call.

## What breaks

- `credentials.CredContext` has a new exported field. Unkeyed composite literals of it no longer compile. Keyed literals are unaffected.
- A provider panic now reaches a caller's `recover()` as the raw panic value, not a `*singleflight.panicError`, and without the retrieval goroutine's stack.
- A caller canceled while waiting on a shared retrieval gets a bare `context.Canceled`, not a transport-wrapped error. `errors.Is` keeps working.
- `newRequest` rejects a nil context with a clear argument error instead of failing deeper in the request build.

## Motivation and Context

Fixes #2266 (raised in the PR #2257 review). `CredContext` carried only an HTTP client and an endpoint, so credential-internal requests could not react to caller cancellation at all — the SSO portal request, for example, was bounded only by a fixed 1-minute background context.

## How to test this PR?

Run `go test -race ./...`. New tests, by area:

- Providers: `TestFileAWSSSOCallerContext` (cancel, deadline, and provider bound, each attributed by elapsed time), `TestEcsTaskCallerContextCancel`, `TestIAMCallerContextCanceled`, `TestSTSAssumeRoleCallerContextCancel`, `TestSTSProvidersCallerContextCanceled` (five STS providers).
- Client: `TestCredsCancelDoesNotPoisonWaiters` (asserts the shared retrieval's context stays live, with no deadline, after a caller cancels), `TestCredsRetrievalPanicPropagates`, `TestPresignCredsCallerContext`, `TestNewRequestNilContext`.
- S3 Express: `TestExpressCreateSessionCallerCancel` (the in-flight request's own context ends with the caller), `TestExpressWaiterJoinsFlight` (one CreateSession serves concurrent callers), `TestExpressWaiterOwnContextHonored`, `TestExpressSessionCacheServedInline`, `TestExpressSessionRenewalLeewayBoundary`, `TestExpressSessionTraceAttached` (the session round trip carries `Options.Trace`).

Every cross-goroutine wait in these tests is bounded, so a regression fails in seconds instead of hanging to the package timeout. The concurrency tests are mutation-checked: removing the detachment, detaching the express arm, disabling de-duplication, zeroing the renewal leeway, or removing the express trace attach each makes its pinning test fail.

Performance: an ad-hoc benchmark (not committed) on the request-build path shows the cached fast path at ~71–73 µs/op matching the merge base's allocation count (96–97 allocs/op by host). The shared-retrieval path adds ~20 µs/op and 8 allocs/op, and only runs when a retrieval actually happens.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Credential retrieval now respects request cancellation and deadlines across authentication, metadata, session, presigning, and role-assumption operations.
- Canceling one concurrent credential request no longer interrupts other requests waiting for the same credentials.
- Improved cancellation errors and prevention of unnecessary metadata requests.
- Credential-provider failures now propagate correctly, avoiding hangs and misleading errors.
- Fresh S3 Express sessions are reused from cache when available.
- Requests with missing contexts are rejected consistently.
- HTTP tracing now remains correctly associated with completed requests.

## Tests

- Added regression coverage for cancellation, deadlines, concurrent requests, presigning, session caching, and provider failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

