### PR TITLE
ci: add Dependabot for GitHub Actions, pin RDMA tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -24,12 +24,14 @@ jobs:
     - name: Checkout minio-go
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
+        persist-credentials: false
         path: "minio-go"
 
     - name: Checkout minio-cpp
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: minio/minio-cpp
+        persist-credentials: false
         path: "minio-cpp"
 
     - name: Checkout vcpkg
@@ -40,6 +42,7 @@ jobs:
         # runner image ships (scripts use string(JSON ... STRING_ENCODE)
         # since microsoft/vcpkg@5397c5c9f), which fails every arm64 run.
         ref: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # tag 2026.06.24
+        persist-credentials: false
         path: "vcpkg"
 
     - name: Install system dependencies

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -22,18 +22,18 @@ jobs:
 
     steps:
     - name: Checkout minio-go
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         path: "minio-go"
 
     - name: Checkout minio-cpp
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: minio/minio-cpp
         path: "minio-cpp"
 
     - name: Checkout vcpkg
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: microsoft/vcpkg
         path: "vcpkg"
@@ -62,7 +62,7 @@ jobs:
         sudo ldconfig
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: "1.25.x"
 

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -36,6 +36,10 @@ jobs:
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: microsoft/vcpkg
+        # Pinned: vcpkg master requires a newer CMake than the arm64
+        # runner image ships (scripts use string(JSON ... STRING_ENCODE)
+        # since microsoft/vcpkg@5397c5c9f), which fails every arm64 run.
+        ref: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # tag 2026.06.24
         path: "vcpkg"
 
     - name: Install system dependencies

--- a/.github/workflows/go-windows.yml
+++ b/.github/workflows/go-windows.yml
@@ -21,13 +21,13 @@ jobs:
         os: [windows-latest]
     steps:
       - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Build on ${{ matrix.os }}
         env:

--- a/.github/workflows/go-windows.yml
+++ b/.github/workflows/go-windows.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Build on ${{ matrix.os }}
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Build on ${{ matrix.os }}
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,13 +21,13 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Build on ${{ matrix.os }}
         env:

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ matrix.go-version }}

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -17,8 +17,8 @@ jobs:
         go-version: [ 1.25.x, 1.26.x ]
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true


### PR DESCRIPTION
## Description

- Pin every workflow `uses:` reference to a full commit SHA with a version anchor comment (`actions/checkout@11d5960a… # v4`, `actions/setup-go@40f1582b… # v5` — 10 sites across the four workflows).
- Add `.github/dependabot.yml` with weekly, grouped `github-actions` updates (one PR per week covering all action bumps), mirroring miniohq/aistor#3391. Dependabot reads the anchor comments and keeps the SHA pins current.
- Set `persist-credentials: false` on all six checkout steps across the four workflows. None of the jobs run authenticated git operations after checkout, so the checkout token no longer needs to land in the local git config.

## Motivation and Context

- The workflows referenced actions by mutable tags with no automated update path; this repo had no Dependabot configuration at all. Mutable tags can move to arbitrary commits, so CI runs were not reproducible against a fixed action revision.
- An audit of all four workflows found no third-party container images pulled by mutable tags to pin alongside this — the only images are the repo's own `registry.k5.min.dev/aistor/minio:edge`, which intentionally tracks edge for the functional tests. The intentionally-unpinned remainders are the `minio/minio-cpp` checkout (no `ref:` — it tracks that repo's default branch by design, like the `:edge` image) and vulncheck's `govulncheck@latest` (the scanner should always run its latest tool and vulnerability database).
- Also carries the `go-rdma.yml` vcpkg checkout pin (`cd61e1e2`, tag `2026.06.24`) so this PR's arm64 lane is green — the same commit rides on #2273; whichever merges first, the other rebases to a no-op. Dependabot has no ecosystem for repository-checkout `ref:` values, so that pin is bumped manually via its tag anchor comment.

## How to test this PR?

- `python3 -c "import yaml; yaml.safe_load(...)"` parses all five changed YAML files; `actionlint` reports no new findings (the four shellcheck findings actionlint reports in untouched `run:` scripts pre-exist this change — the set is identical at the merge base, shifted only by the inserted lines).
- CI on this PR runs with the pinned SHAs.
- After merge, Dependabot opens one grouped PR on Mondays whenever action version updates exist (visible under Insights → Dependency graph → Dependabot); security updates can still arrive as separate, ungrouped PRs. The first grouped PR will propose the pending `actions/checkout` v4→v7 and `actions/setup-go` v5→v7 major bumps as one bundle.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated (CI configuration only)
- [ ] Internal documentation updated
- [ ] Create a documentation update request
- [x] No internode changes / version interoperability introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added weekly automated maintenance checks for GitHub Actions.
  * Improved workflow security and reproducibility by pinning action versions to verified revisions.
  * Updated repository checkout steps to prevent credentials from being retained during builds.
  * Applied these safeguards consistently across Linux, Windows, RDMA, and vulnerability-check workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->