### PR TITLE
fix: declare aws-chunked content encoding on streaming uploads

### DIFF
--- a/pkg/signer/request-signature-streaming-unsigned-trailer.go
+++ b/pkg/signer/request-signature-streaming-unsigned-trailer.go
@@ -61,10 +61,10 @@ func getUSStreamLength(dataLen, chunkSize int64, trailers http.Header) int64 {
 	return streamLen
 }
 
-// prepareStreamingRequest - prepares a request with appropriate
-// headers before computing the seed signature.
+// prepareUSStreamingRequest - prepares a request with the headers
+// required for an unsigned aws-chunked streaming upload.
 func prepareUSStreamingRequest(req *http.Request, sessionToken string, dataLen int64, timestamp time.Time) {
-	req.TransferEncoding = []string{"aws-chunked"}
+	setAwsChunkedContentEncoding(req)
 	if sessionToken != "" {
 		req.Header.Set("X-Amz-Security-Token", sessionToken)
 	}

--- a/pkg/signer/request-signature-streaming.go
+++ b/pkg/signer/request-signature-streaming.go
@@ -132,8 +132,8 @@ func prepareStreamingRequest(req *http.Request, sessionToken string, dataLen int
 		for k := range req.Trailer {
 			req.Header.Add("X-Amz-Trailer", strings.ToLower(k))
 		}
-		req.TransferEncoding = []string{"aws-chunked"}
 	}
+	setAwsChunkedContentEncoding(req)
 
 	if sessionToken != "" {
 		req.Header.Set("X-Amz-Security-Token", sessionToken)

--- a/pkg/signer/request-signature-streaming_test.go
+++ b/pkg/signer/request-signature-streaming_test.go
@@ -24,6 +24,9 @@ import (
 	"hash"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,7 +71,7 @@ func TestGetSeedSignature(t *testing.T) {
 	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", "us-east-1", int64(dataLen), reqTime, newSHA256Hasher())
 	actualSeedSignature := req.Body.(*StreamingReader).seedSignature
 
-	expectedSeedSignature := "38cab3af09aa15ddf29e26e36236f60fb6bfb6243a20797ae9a8183674526079"
+	expectedSeedSignature := "007480502de61457e955731b0f5d191f7e6f54a8a0f6cc7974a5ebd887965686"
 	if actualSeedSignature != expectedSeedSignature {
 		t.Errorf("Expected %s but received %s", expectedSeedSignature, actualSeedSignature)
 	}
@@ -117,7 +120,7 @@ func TestSetStreamingAuthorization(t *testing.T) {
 	reqTime, _ := time.Parse(iso8601DateFormat, "20130524T000000Z")
 	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", location, dataLen, reqTime, newSHA256Hasher())
 
-	expectedAuthorization := "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-storage-class,Signature=38cab3af09aa15ddf29e26e36236f60fb6bfb6243a20797ae9a8183674526079"
+	expectedAuthorization := "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=content-encoding;host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-storage-class,Signature=007480502de61457e955731b0f5d191f7e6f54a8a0f6cc7974a5ebd887965686"
 
 	actualAuthorization := req.Header.Get("Authorization")
 	if actualAuthorization != expectedAuthorization {
@@ -177,4 +180,181 @@ func TestStreamingReader(t *testing.T) {
 		t.Errorf("Expected no error but received %v  %d", err, len(b))
 	}
 	req.Body.Close()
+}
+
+func TestStreamingSignV4ContentEncoding(t *testing.T) {
+	accessKeyID := "AKIAIOSFODNN7EXAMPLE"
+	secretAccessKeyID := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	reqTime, err := time.Parse(iso8601DateFormat, "20130524T000000Z")
+	if err != nil {
+		t.Fatalf("Failed to parse time - %v", err)
+	}
+
+	testCases := []struct {
+		name            string
+		contentEncoding string
+		trailer         http.Header
+		expected        string
+	}{
+		{"no trailer", "", nil, "aws-chunked"},
+		{"with trailer", "", http.Header{"X-Amz-Checksum-Crc32c": []string{""}}, "aws-chunked"},
+		{"user encoding preserved", "gzip", nil, "aws-chunked,gzip"},
+		{"already aws-chunked", "aws-chunked", nil, "aws-chunked"},
+		{"already aws-chunked mixed case", "AWS-CHUNKED", nil, "AWS-CHUNKED"},
+		{"token after user encoding", "gzip, aws-chunked", nil, "gzip, aws-chunked"},
+		{"whitespace only", " ", nil, "aws-chunked"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dataLen := int64(payloadChunkSize)
+			body := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), int(dataLen))))
+			req := NewRequest(http.MethodPut, "/examplebucket/chunkObject.txt", body)
+			if testCase.contentEncoding != "" {
+				req.Header.Set("Content-Encoding", testCase.contentEncoding)
+			}
+			req.Trailer = testCase.trailer
+
+			req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", "us-east-1", dataLen, reqTime, newSHA256Hasher())
+
+			if gotEncoding := req.Header.Get("Content-Encoding"); gotEncoding != testCase.expected {
+				t.Errorf("Content-Encoding = %q, want %q", gotEncoding, testCase.expected)
+			}
+			auth := req.Header.Get("Authorization")
+			_, after, found := strings.Cut(auth, "SignedHeaders=")
+			if !found {
+				t.Fatalf("SignedHeaders missing from Authorization: %s", auth)
+			}
+			signedHeaders, _, _ := strings.Cut(after, ",")
+			if !slices.Contains(strings.Split(signedHeaders, ";"), "content-encoding") {
+				t.Errorf("content-encoding missing from SignedHeaders %q", signedHeaders)
+			}
+			if err := req.Body.Close(); err != nil {
+				t.Errorf("Failed to close request body - %v", err)
+			}
+		})
+	}
+}
+
+func TestStreamingSignV4ContentEncodingOnWire(t *testing.T) {
+	accessKeyID := "AKIAIOSFODNN7EXAMPLE"
+	secretAccessKeyID := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	reqTime, err := time.Parse(iso8601DateFormat, "20130524T000000Z")
+	if err != nil {
+		t.Fatalf("Failed to parse time - %v", err)
+	}
+
+	type wireHeaders struct {
+		contentEncoding  string
+		transferEncoding []string
+	}
+	received := make(chan wireHeaders, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		received <- wireHeaders{r.Header.Get("Content-Encoding"), r.TransferEncoding}
+	}))
+	defer srv.Close()
+
+	dataLen := int64(payloadChunkSize)
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/examplebucket/chunkObject.txt", bytes.NewReader(bytes.Repeat([]byte("a"), int(dataLen))))
+	if err != nil {
+		t.Fatalf("Failed to create request - %v", err)
+	}
+	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", "us-east-1", dataLen, reqTime, newSHA256Hasher())
+
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Request failed - %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Failed to close response body - %v", err)
+	}
+
+	got := <-received
+	if got.contentEncoding != "aws-chunked" {
+		t.Errorf("server received Content-Encoding = %q, want %q", got.contentEncoding, "aws-chunked")
+	}
+	if len(got.transferEncoding) != 0 {
+		t.Errorf("server received Transfer-Encoding = %v, want none", got.transferEncoding)
+	}
+}
+
+func TestStreamingUnsignedV4ContentEncoding(t *testing.T) {
+	reqTime, err := time.Parse(iso8601DateFormat, "20130524T000000Z")
+	if err != nil {
+		t.Fatalf("Failed to parse time - %v", err)
+	}
+	dataLen := int64(payloadChunkSize)
+	body := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), int(dataLen))))
+	req := NewRequest(http.MethodPut, "/examplebucket/chunkObject.txt", body)
+	req.Trailer = http.Header{"X-Amz-Checksum-Crc32c": []string{""}}
+
+	req = StreamingUnsignedV4(req, "", dataLen, reqTime)
+
+	if gotEncoding := req.Header.Get("Content-Encoding"); gotEncoding != "aws-chunked" {
+		t.Errorf("Content-Encoding = %q, want %q", gotEncoding, "aws-chunked")
+	}
+	if err := req.Body.Close(); err != nil {
+		t.Errorf("Failed to close request body - %v", err)
+	}
+}
+
+func TestSignV4TrailerContentEncoding(t *testing.T) {
+	accessKeyID := "AKIAIOSFODNN7EXAMPLE"
+	secretAccessKeyID := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	trailer := http.Header{"X-Amz-Checksum-Crc32c": []string{""}}
+
+	dataLen := int64(payloadChunkSize)
+	body := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), int(dataLen))))
+	req := NewRequest(http.MethodPut, "/examplebucket/chunkObject.txt", body)
+	req.ContentLength = dataLen
+	req.Header.Set("Content-Encoding", "gzip")
+
+	req = SignV4Trailer(*req, accessKeyID, secretAccessKeyID, "", "us-east-1", trailer)
+
+	if gotEncoding := req.Header.Get("Content-Encoding"); gotEncoding != "aws-chunked,gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", gotEncoding, "aws-chunked,gzip")
+	}
+	if err := req.Body.Close(); err != nil {
+		t.Errorf("Failed to close request body - %v", err)
+	}
+}
+
+func TestUnsignedTrailerContentEncoding(t *testing.T) {
+	trailer := http.Header{"X-Amz-Checksum-Crc32c": []string{""}}
+
+	dataLen := int64(payloadChunkSize)
+	body := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), int(dataLen))))
+	req := NewRequest(http.MethodPut, "/examplebucket/chunkObject.txt", body)
+	req.ContentLength = dataLen
+	req.Header.Set("Content-Encoding", "gzip")
+
+	req = UnsignedTrailer(*req, trailer)
+
+	if gotEncoding := req.Header.Get("Content-Encoding"); gotEncoding != "aws-chunked,gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", gotEncoding, "aws-chunked,gzip")
+	}
+	if err := req.Body.Close(); err != nil {
+		t.Errorf("Failed to close request body - %v", err)
+	}
+}
+
+func TestSetAwsChunkedContentEncodingMultiValue(t *testing.T) {
+	req := NewRequest(http.MethodPut, "/examplebucket/chunkObject.txt", nil)
+	req.Header.Add("Content-Encoding", "gzip")
+	req.Header.Add("Content-Encoding", "br")
+
+	setAwsChunkedContentEncoding(req)
+
+	if gotEncoding := req.Header.Get("Content-Encoding"); gotEncoding != "aws-chunked,gzip,br" {
+		t.Errorf("Content-Encoding = %q, want %q", gotEncoding, "aws-chunked,gzip,br")
+	}
+
+	req = NewRequest(http.MethodPut, "/examplebucket/chunkObject.txt", nil)
+	req.Header.Add("Content-Encoding", "gzip")
+	req.Header.Add("Content-Encoding", "aws-chunked")
+
+	setAwsChunkedContentEncoding(req)
+
+	if got := req.Header.Values("Content-Encoding"); !slices.Equal(got, []string{"gzip", "aws-chunked"}) {
+		t.Errorf("Content-Encoding values = %v, want unchanged [gzip aws-chunked]", got)
+	}
 }

--- a/pkg/signer/request-signature-v4.go
+++ b/pkg/signer/request-signature-v4.go
@@ -331,7 +331,7 @@ func signV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, locati
 			req.Header.Add("X-Amz-Trailer", strings.ToLower(k))
 		}
 
-		req.Header.Set("Content-Encoding", "aws-chunked")
+		setAwsChunkedContentEncoding(&req)
 		req.Header.Set("x-amz-decoded-content-length", strconv.FormatInt(req.ContentLength, 10))
 	}
 
@@ -395,7 +395,7 @@ func UnsignedTrailer(req http.Request, trailer http.Header) *http.Request {
 		req.Header.Add("X-Amz-Trailer", strings.ToLower(k))
 	}
 
-	req.Header.Set("Content-Encoding", "aws-chunked")
+	setAwsChunkedContentEncoding(&req)
 	req.Header.Set("x-amz-decoded-content-length", strconv.FormatInt(req.ContentLength, 10))
 
 	// Use custom chunked encoding.

--- a/pkg/signer/utils.go
+++ b/pkg/signer/utils.go
@@ -22,6 +22,8 @@ import (
 	"crypto/sha256"
 	"net/http"
 	"strings"
+
+	"golang.org/x/net/http/httpguts"
 )
 
 // unsignedPayload - value to be set to X-Amz-Content-Sha256 header when
@@ -59,4 +61,27 @@ func signV4TrimAll(input string) string {
 	// Compress adjacent spaces (a space is determined by
 	// unicode.IsSpace() internally here) to one space and return
 	return strings.Join(strings.Fields(input), " ")
+}
+
+// awsChunkedEncoding is the content coding AWS SigV4 streaming uploads
+// declare on the Content-Encoding header.
+const awsChunkedEncoding = "aws-chunked"
+
+// setAwsChunkedContentEncoding marks the request payload as aws-chunked
+// encoded, keeping any content encoding the caller already set, for example
+// "aws-chunked,gzip". AWS SigV4 streaming uploads require this header.
+// Assigning "aws-chunked" to http.Request.TransferEncoding never reaches
+// the wire — net/http silently drops assigned values other than "chunked" —
+// so this header is the only signal that declares the aws-chunked framing.
+func setAwsChunkedContentEncoding(req *http.Request) {
+	encodings := req.Header.Values("Content-Encoding")
+	if httpguts.HeaderValuesContainsToken(encodings, awsChunkedEncoding) {
+		return
+	}
+	existing := strings.TrimSpace(strings.Join(encodings, ","))
+	if existing == "" {
+		req.Header.Set("Content-Encoding", awsChunkedEncoding)
+		return
+	}
+	req.Header.Set("Content-Encoding", awsChunkedEncoding+","+existing)
 }


### PR DESCRIPTION
RDMA failure fixed in https://github.com/minio/minio-go/pull/2276

## Description

Streaming SigV4 and unsigned-trailer uploads frame the request body as aws-chunked but never declare it. PR #1803 tried to declare it through `req.TransferEncoding = []string{"aws-chunked"}`, which Go's `net/http` silently drops (it only honors `"chunked"`), so nothing reached the wire and #1802 was reopened.

- Adds one idempotent helper, `setAwsChunkedContentEncoding`, used by all four production call sites: the shared signed-streaming preparer (`StreamingSignV4`/`Express`/`Outposts`), the unsigned-streaming preparer, and the two trailer paths in `request-signature-v4.go`.
- Sets `Content-Encoding: aws-chunked` before the seed signature is computed, so the header is signed. A caller-set encoding survives as `aws-chunked,gzip` (the two trailer paths previously clobbered it), multi-value headers are merged, and an already-present token (any case, with or without whitespace) is left unchanged.
- Removes the two dead `req.TransferEncoding = []string{"aws-chunked"}` writes.
- Updates two golden signatures (`content-encoding` now joins `SignedHeaders`). The AWS-docs-derived trailer golden is unchanged, which pins helper idempotence.
- Adds six tests: a 7-case table test asserting header value and `SignedHeaders` membership, an httptest wire round-trip, and one test per entry point (`StreamingUnsignedV4`, `SignV4Trailer`, `UnsignedTrailer`, multi-value header).

## Motivation and Context

Fixes #1802. Servers that do not sniff `x-amz-content-sha256` store the chunk framing as object data (see the issue thread and gitea#33638). The AWS SigV4 streaming spec lists `Content-Encoding` under the headers a chunked upload must include ("Set the value to `aws-chunked` ... For example: `Content-Encoding : aws-chunked,gzip`"), and its example request signs it.

Compatibility notes:

- minio-go already sends and signs this header on the trailing-checksum path (`request-signature-v4.go`), so this extends an existing wire shape to plain-HTTP streaming uploads rather than introducing a new one. Conformant verifiers recompute the signature from received headers, so signatures stay valid.
- AWS documents that S3 stores the object without the aws-chunked encoding, and MinIO server strips it in `trimAwsChunkedContentEncoding`. A server that stores `Content-Encoding` verbatim would now echo `aws-chunked` in object metadata for plain-HTTP streaming PUTs, as it already does for trailing-checksum PUTs.

## How to test this PR?

```
go test -race -count=1 ./pkg/signer/
```

Side-by-side results, master (`802bd60`) versus this PR:

| Check | master `802bd60` | this PR |
| --- | --- | --- |
| Wire capture through a real `net/http` round trip (httptest), all three streaming paths | server receives `Content-Encoding: ""`, `Transfer-Encoding: []` — the framing is never declared | server receives `Content-Encoding: aws-chunked` on all three paths |
| The added tests, run against each tree | FAIL: `Content-Encoding = "", want "aws-chunked"` and `content-encoding missing from SignedHeaders` | PASS: 26/26 under `-race`, repeated across 8 runs |
| Live server, plain-HTTP streaming signature (`quay.io/minio/minio:latest`): PutObject + GetObject + StatObject for plain, user-gzip, and no-trailing shapes | accepted only because MinIO sniffs `x-amz-content-sha256`; nothing declares the framing | all three accepted with the new signed header; GET round-trip byte-identical; stored `Content-Encoding` is `""`/`"gzip"` — `aws-chunked` stripped, user gzip preserved |
| Golden signatures | seed `38cab3af...` (content-encoding not signed) | `00748050...` — re-derived independently from first principles; the derivation reproduces the AWS-docs control `4f232c43...`, and the unchanged trailer golden `106e2a8a...` still passes byte-identically |
| Guard coverage | — | `TrimSpace` and `Header.Values` guards are mutation-verified: reverting either one fails the matching new test |
| Helper cost | — | 396-860 ns/op, ≤3 allocs/op per request (micro-benchmark) — noise against a network PUT |

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Cleanup/Maintenance (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS-chunked streaming uploads to preserve existing content encodings.
  * Prevented duplicate `aws-chunked` encoding values in request headers.
  * Updated signed and unsigned streaming requests for more consistent transfer handling.
* **Tests**
  * Added coverage for signed, unsigned, trailer-based, and multi-value content-encoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->