### PR TITLE
Add AIStor Lifecycle Compression

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
           sudo apt install devscripts -y
           mkdir -p /tmp/certs-dir
           cp testcerts/* /tmp/certs-dir
-          # Test against the AIStor :edge image so the latest AIStor APIs
+          # Test against the AIStor :edge-daily image so the latest AIStor APIs
           # (object annotations) and checksum algorithms (xxhash3/xxhash128,
           # sha512, md5) are available to the functional tests.
           docker pull quay.io/minio/aistor/minio:edge-daily

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
           # Test against the AIStor :edge image so the latest AIStor APIs
           # (object annotations) and checksum algorithms (xxhash3/xxhash128,
           # sha512, md5) are available to the functional tests.
-          docker pull registry.k5.min.dev/aistor/minio:edge
+          docker pull quay.io/minio/aistor/minio:edge-daily
           # Free-tier AIStor license so the server allows writes (without a
           # license the server boots read-only). This is a public FREE-plan
           # license, not a secret.
@@ -64,7 +64,7 @@ jobs:
             -e MINIO_CI_CD=true \
             -e MINIO_KMS_SECRET_KEY="${MINIO_KMS_SECRET_KEY}" \
             -e MINIO_LICENSE="${MINIO_LICENSE}" \
-            registry.k5.min.dev/aistor/minio:edge \
+            quay.io/minio/aistor/minio:edge-daily \
             server --quiet --certs-dir /certs /data/{1...4}
           for _ in $(seq 1 60); do
             if curl -sf --cacert /tmp/certs-dir/public.crt https://localhost:9000/minio/health/ready >/dev/null; then

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -209,6 +209,58 @@ func (t Transition) MarshalXML(en *xml.Encoder, startElement xml.StartElement) e
 	return en.EncodeElement(transitionWrapper(t), startElement)
 }
 
+// Compression is a MinIO AIStor extension with no S3 equivalent: it compresses
+// matching current object versions in place. Presence of the element enables the
+// action, so Rule carries it as a pointer — unlike Transition, there is no
+// StorageClass to key presence off and Days: 0 legitimately means "immediately".
+//
+// HighCompression selects the strongest level the server offers; without it the
+// rule writes the level ingest uses and only compresses objects stored
+// uncompressed.
+//
+// Unlike Transition and Expiration there is no absolute Date trigger — a one-off
+// sweep is what the compress batch job is for. That also means no custom
+// MarshalJSON: with no embedded time.Time to suppress, every field honors
+// omitempty, and a zero element still marshals as {} because Rule holds it as a
+// pointer and its presence alone enables the action.
+type Compression struct {
+	XMLName          xml.Name       `xml:"Compression" json:"-"`
+	Days             ExpirationDays `xml:"Days,omitempty" json:"Days,omitempty"`
+	HighCompression  bool           `xml:"HighCompression,omitempty" json:"HighCompression,omitempty"`
+	SkipCompressed   bool           `xml:"SkipCompressed,omitempty" json:"SkipCompressed,omitempty"`
+	IncludeEncrypted bool           `xml:"IncludeEncrypted,omitempty" json:"IncludeEncrypted,omitempty"`
+}
+
+// IsDaysNull returns true if days field is null
+func (c *Compression) IsDaysNull() bool {
+	return c == nil || c.Days == ExpirationDays(0)
+}
+
+// IsNull returns true if the element is absent.
+func (c *Compression) IsNull() bool {
+	return c == nil
+}
+
+// NoncurrentVersionCompression is the Compression counterpart for noncurrent
+// object versions. See Compression for why Rule holds it as a pointer.
+type NoncurrentVersionCompression struct {
+	XMLName          xml.Name       `xml:"NoncurrentVersionCompression" json:"-"`
+	NoncurrentDays   ExpirationDays `xml:"NoncurrentDays,omitempty" json:"NoncurrentDays,omitempty"`
+	HighCompression  bool           `xml:"HighCompression,omitempty" json:"HighCompression,omitempty"`
+	SkipCompressed   bool           `xml:"SkipCompressed,omitempty" json:"SkipCompressed,omitempty"`
+	IncludeEncrypted bool           `xml:"IncludeEncrypted,omitempty" json:"IncludeEncrypted,omitempty"`
+}
+
+// IsDaysNull returns true if noncurrent days field is null
+func (n *NoncurrentVersionCompression) IsDaysNull() bool {
+	return n == nil || n.NoncurrentDays == ExpirationDays(0)
+}
+
+// IsNull returns true if the element is absent.
+func (n *NoncurrentVersionCompression) IsNull() bool {
+	return n == nil
+}
+
 // And And Rule for LifecycleTag, to be used in LifecycleRuleFilter
 type And struct {
 	XMLName               xml.Name `xml:"And" json:"-"`
@@ -472,6 +524,8 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 		Prefix                         string                          `json:"Prefix,omitempty"`
 		Status                         string                          `json:"Status"`
 		Transition                     *Transition                     `json:"Transition,omitempty"`
+		Compression                    *Compression                    `json:"Compression,omitempty"`
+		NoncurrentVersionCompression   *NoncurrentVersionCompression   `json:"NoncurrentVersionCompression,omitempty"`
 	}
 	newr := rule{
 		Prefix: r.Prefix,
@@ -503,6 +557,8 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 	if !r.AllVersionsExpiration.IsNull() {
 		newr.AllVersionsExpiration = &r.AllVersionsExpiration
 	}
+	newr.Compression = r.Compression
+	newr.NoncurrentVersionCompression = r.NoncurrentVersionCompression
 
 	return json.Marshal(newr)
 }
@@ -554,6 +610,8 @@ type Rule struct {
 	Prefix                         string                         `xml:"Prefix,omitempty" json:"Prefix,omitempty"`
 	Status                         string                         `xml:"Status" json:"Status"`
 	Transition                     Transition                     `xml:"Transition,omitempty" json:"Transition,omitempty"`
+	Compression                    *Compression                   `xml:"Compression,omitempty" json:"Compression,omitempty"`
+	NoncurrentVersionCompression   *NoncurrentVersionCompression  `xml:"NoncurrentVersionCompression,omitempty" json:"NoncurrentVersionCompression,omitempty"`
 }
 
 // Configuration is a collection of Rule objects.

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -297,6 +297,24 @@ func TestLifecycleJSONRoundtrip(t *testing.T) {
 				ID:     "rule-10",
 				Status: "Enabled",
 			},
+			{
+				Compression: &Compression{
+					Days:           ExpirationDays(30),
+					SkipCompressed: true,
+				},
+				NoncurrentVersionCompression: &NoncurrentVersionCompression{
+					NoncurrentDays:   ExpirationDays(45),
+					IncludeEncrypted: true,
+				},
+				ID:     "rule-11",
+				Status: "Enabled",
+			},
+			{
+				Compression:                  &Compression{},
+				NoncurrentVersionCompression: &NoncurrentVersionCompression{},
+				ID:                           "rule-12",
+				Status:                       "Enabled",
+			},
 		},
 	}
 
@@ -331,6 +349,41 @@ func TestLifecycleJSONRoundtrip(t *testing.T) {
 		if !lc.Rules[i].AllVersionsExpiration.equals(got.Rules[i].AllVersionsExpiration) {
 			t.Fatalf("expected %#v got %#v", lc.Rules[i].AllVersionsExpiration, got.Rules[i].AllVersionsExpiration)
 		}
+		if !lc.Rules[i].Compression.equals(got.Rules[i].Compression) {
+			t.Fatalf("expected %#v got %#v", lc.Rules[i].Compression, got.Rules[i].Compression)
+		}
+		if !lc.Rules[i].NoncurrentVersionCompression.equals(got.Rules[i].NoncurrentVersionCompression) {
+			t.Fatalf("expected %#v got %#v", lc.Rules[i].NoncurrentVersionCompression, got.Rules[i].NoncurrentVersionCompression)
+		}
+	}
+}
+
+// TestCompressionJSON pins the wire shape of the AIStor compression elements,
+// including that an all-default element survives as an empty object rather
+// than being dropped — its presence alone enables the action.
+func TestCompressionJSON(t *testing.T) {
+	expected := []byte(`{"Rules":[{"ID":"compress","Status":"Enabled","Compression":{"Days":30,"HighCompression":true,"SkipCompressed":true},"NoncurrentVersionCompression":{}}]}`)
+	lc := Configuration{
+		Rules: []Rule{
+			{
+				ID:     "compress",
+				Status: "Enabled",
+				Compression: &Compression{
+					Days:            ExpirationDays(30),
+					HighCompression: true,
+					SkipCompressed:  true,
+				},
+				NoncurrentVersionCompression: &NoncurrentVersionCompression{},
+			},
+		},
+	}
+
+	got, err := json.Marshal(lc)
+	if err != nil {
+		t.Fatalf("Failed to marshal due to %v", err)
+	}
+	if !bytes.Equal(expected, got) {
+		t.Fatalf("Expected %s but got %s", expected, got)
 	}
 }
 
@@ -404,6 +457,36 @@ func TestLifecycleXMLRoundtrip(t *testing.T) {
 					},
 				},
 			},
+			{
+				ID:          "immediate-compression",
+				Status:      "Enabled",
+				Compression: &Compression{},
+			},
+			{
+				ID:     "compression",
+				Status: "Enabled",
+				Compression: &Compression{
+					Days:             ExpirationDays(30),
+					HighCompression:  true,
+					SkipCompressed:   true,
+					IncludeEncrypted: true,
+				},
+			},
+			{
+				ID:                           "immediate-noncurrent-compression",
+				Status:                       "Enabled",
+				NoncurrentVersionCompression: &NoncurrentVersionCompression{},
+			},
+			{
+				ID:     "noncurrent-compression",
+				Status: "Enabled",
+				NoncurrentVersionCompression: &NoncurrentVersionCompression{
+					NoncurrentDays:   ExpirationDays(45),
+					HighCompression:  true,
+					SkipCompressed:   true,
+					IncludeEncrypted: true,
+				},
+			},
 		},
 	}
 
@@ -438,7 +521,31 @@ func TestLifecycleXMLRoundtrip(t *testing.T) {
 		if !lc.Rules[i].AllVersionsExpiration.equals(got.Rules[i].AllVersionsExpiration) {
 			t.Fatalf("%d: expected %#v got %#v", i+1, lc.Rules[i].AllVersionsExpiration, got.Rules[i].AllVersionsExpiration)
 		}
+
+		if !lc.Rules[i].Compression.equals(got.Rules[i].Compression) {
+			t.Fatalf("%d: expected %#v got %#v", i+1, lc.Rules[i].Compression, got.Rules[i].Compression)
+		}
+
+		if !lc.Rules[i].NoncurrentVersionCompression.equals(got.Rules[i].NoncurrentVersionCompression) {
+			t.Fatalf("%d: expected %#v got %#v", i+1, lc.Rules[i].NoncurrentVersionCompression, got.Rules[i].NoncurrentVersionCompression)
+		}
 	}
+}
+
+func (c *Compression) equals(d *Compression) bool {
+	if c == nil || d == nil {
+		return c == d
+	}
+	return c.Days == d.Days && c.HighCompression == d.HighCompression &&
+		c.SkipCompressed == d.SkipCompressed && c.IncludeEncrypted == d.IncludeEncrypted
+}
+
+func (n *NoncurrentVersionCompression) equals(m *NoncurrentVersionCompression) bool {
+	if n == nil || m == nil {
+		return n == m
+	}
+	return n.NoncurrentDays == m.NoncurrentDays && n.HighCompression == m.HighCompression &&
+		n.SkipCompressed == m.SkipCompressed && n.IncludeEncrypted == m.IncludeEncrypted
 }
 
 func (n NoncurrentVersionTransition) equals(m NoncurrentVersionTransition) bool {
@@ -690,6 +797,9 @@ func fillNonZero(t *testing.T, v reflect.Value) {
 		v.SetBool(true)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v.SetInt(1)
+	case reflect.Pointer:
+		v.Set(reflect.New(v.Type().Elem()))
+		fillNonZero(t, v.Elem())
 	case reflect.Struct:
 		switch v.Type() {
 		case reflect.TypeOf(time.Time{}):

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -387,6 +387,39 @@ func TestCompressionJSON(t *testing.T) {
 	}
 }
 
+// TestRuleMarshalJSONCopyCompleteness fills every Rule field and requires each
+// one to reach the JSON output. MarshalJSON copies Rule into a mirror struct
+// field by field, so a field added to Rule and to the mirror but never assigned
+// is dropped by omitempty with every other test still passing. RuleFilter is
+// skipped for the same reason as in TestRuleWrapperCopyCompleteness.
+func TestRuleMarshalJSONCopyCompleteness(t *testing.T) {
+	skip := func(name string) bool { return name == "XMLName" || name == "RuleFilter" }
+
+	var r Rule
+	rv := reflect.ValueOf(&r).Elem()
+	for i := range rv.NumField() {
+		if skip(rv.Type().Field(i).Name) {
+			continue
+		}
+		fillNonZero(t, rv.Field(i))
+	}
+
+	got, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("could not marshal a filled Rule: %v", err)
+	}
+	for i := range rv.NumField() {
+		f := rv.Type().Field(i)
+		if skip(f.Name) {
+			continue
+		}
+		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		if !bytes.Contains(got, []byte(`"`+name+`":`)) {
+			t.Fatalf("Rule.%s (JSON %q) is missing from MarshalJSON output: %s", f.Name, name, got)
+		}
+	}
+}
+
 func TestLifecycleXMLRoundtrip(t *testing.T) {
 	lc := Configuration{
 		Rules: []Rule{


### PR DESCRIPTION
Allow setting compression as a lifecycle for current and non-current versions. All lifecycle filters apply.

Will link AIStor/mc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added lifecycle rule support for compressing current and noncurrent object versions.
  - Compression settings can specify immediate or delayed actions based on configured days.
  - Compression options are supported consistently in JSON and XML configurations.
  - Optional compression settings distinguish between an omitted action and an action configured with zero days.
  - Compression settings are preserved during configuration conversion and round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->