### PR TITLE
fix(rdma): report the transferred size from Stat on an RDMA GET

### DIFF
--- a/api-get-object.go
+++ b/api-get-object.go
@@ -51,15 +51,7 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string, o
 		if err != nil {
 			return nil, err
 		}
-		return &Object{
-			mutex:    &sync.Mutex{},
-			isClosed: true,
-			objectInfo: ObjectInfo{
-				Key:  objectName,
-				Size: n,
-			},
-			objectInfoSet: true,
-		}, nil
+		return newRDMAObject(objectName, n), nil
 	}
 
 	gctx, cancel := context.WithCancel(ctx)
@@ -499,6 +491,25 @@ func (o *Object) Read(b []byte) (n int, err error) {
 
 	// Return the response.
 	return response.Size, err
+}
+
+// newRDMAObject returns the Object handed back by the RDMA GET path, whose
+// payload of n bytes has already been delivered out-of-band into the caller's
+// registered buffer. The object is closed on arrival: there is nothing left to
+// read from it, only its info to report. totalSize must carry n as well as
+// objectInfo.Size, because Stat recomputes Size as totalSize-currOffset for
+// any object whose info is already set.
+func newRDMAObject(objectName string, n int64) *Object {
+	return &Object{
+		mutex:    &sync.Mutex{},
+		isClosed: true,
+		objectInfo: ObjectInfo{
+			Key:  objectName,
+			Size: n,
+		},
+		objectInfoSet: true,
+		totalSize:     n,
+	}
 }
 
 // Stat returns the ObjectInfo structure describing Object.

--- a/api-get-object_test.go
+++ b/api-get-object_test.go
@@ -623,3 +623,23 @@ func TestObjectSeekWithSetRange(t *testing.T) {
 		t.Fatalf("expected to read %q, got %q (%d bytes)", "456", string(buf[:rn]), rn)
 	}
 }
+
+// TestRDMAGetObjectStatReportsTransferredSize verifies that Stat on the object
+// returned by the RDMA GET path reports the transferred length. The payload
+// arrives out-of-band, so the object is created closed with its info already
+// set; Stat recomputes Size as totalSize-currOffset for any such object, which
+// reports 0 unless the RDMA path populates totalSize too.
+func TestRDMAGetObjectStatReportsTransferredSize(t *testing.T) {
+	for _, size := range []int64{1, 1 << 20, 64 << 20} {
+		info, err := newRDMAObject("obj", size).Stat()
+		if err != nil {
+			t.Fatalf("Stat on an RDMA-delivered object of %d bytes failed: %v", size, err)
+		}
+		if info.Size != size {
+			t.Fatalf("expected Stat to report %d bytes, got %d", size, info.Size)
+		}
+		if info.Key != "obj" {
+			t.Fatalf("expected key %q, got %q", "obj", info.Key)
+		}
+	}
+}


### PR DESCRIPTION
## Description

`GetObject`'s RDMA branch builds its `Object` with `objectInfo.Size` set but leaves `totalSize` at zero. `Stat` recomputes `Size` as `totalSize - currOffset` for any object whose info is already set, so it clobbers the real length:

```go
if o.objectInfoSet {
    if o.currOffset <= o.totalSize {
        o.objectInfo.Size = o.totalSize - o.currOffset   // 0 - 0 = 0
    }
    return o.objectInfo, nil
}
```

Every RDMA GET therefore reports `Size: 0`, and callers treat it as a short read even though the payload landed correctly.

Found while benchmarking S3-over-RDMA against a 4-node cluster: `warp get --rdma=cpu` failed every request with `unexpected download size. want:67108864, got:0`, while the server-side counters showed the bytes had actually been delivered (`rdma_read_ops x 64MiB == rdma_read_bytes`, exactly).

## Motivation

RDMA GET is unusable through any caller that checks the returned size. The transfer itself was always correct — only the reported length was wrong — so this presents as data loss that isn't.

## How to test

`go test -run TestRDMAGetObjectStatReportsTransferredSize ./...`

The test calls the extracted `newRDMAObject` constructor and asserts `Stat` reports the transferred length at 1 B / 1 MiB / 64 MiB. Removing the `totalSize: n` line fails it (`expected Stat to report 1 bytes, got 0`).

Verified end to end against a live cluster: errors went from ~50k per run to zero, with throughput unchanged (6434 -> 6372 MiB/s), confirming only the accounting was broken. A separate byte-for-byte round-trip check (`PutObject` + `GetObject` with `RDMABuffer`, `bytes.Equal`) passes 40/40 across 1/5/16/64/200 MiB.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Fixes a regression / defect in existing behaviour
- [x] Unit test added, and it fails without the fix
- [x] Full package test suite passes
- [x] `go vet` and `gofumpt` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected object metadata reporting for RDMA-delivered objects.
  * Object statistics now accurately show the transferred size and object key across different object sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->