### PR TITLE
feat: add ListUnsorted() for the ?unsorted=true listing extension

### DIFF
--- a/api-list.go
+++ b/api-list.go
@@ -761,6 +761,23 @@ type ListObjectsOptions struct {
 	headers http.Header
 }
 
+// checkUnsorted returns an error if the unsorted listing extension cannot be
+// honored for these options against a bucket in the given location. It is only
+// implemented by ListObjects V2, and its continuation token encodes a position
+// rather than a key, so there is nothing for 'StartAfter' to resolve against.
+func (o ListObjectsOptions) checkUnsorted(location string) error {
+	if !o.Unsorted {
+		return nil
+	}
+	if o.UseV1 || o.WithVersions || location == "snowball" {
+		return errInvalidArgument("unsorted listing is only supported by ListObjects V2")
+	}
+	if o.StartAfter != "" {
+		return errInvalidArgument("unsorted listing does not support StartAfter")
+	}
+	return nil
+}
+
 // Set adds a key value pair to the options. The
 // key-value pair will be part of the HTTP GET request
 // headers.
@@ -790,6 +807,12 @@ func (c *Client) ListObjects(ctx context.Context, bucketName string, opts ListOb
 			return
 		}
 
+		location, _ := c.bucketLocCache.Get(bucketName)
+		if err := opts.checkUnsorted(location); err != nil {
+			objectStatCh <- ObjectInfo{Err: err}
+			return
+		}
+
 		var objIter iter.Seq[ObjectInfo]
 		switch {
 		case opts.WithVersions:
@@ -797,7 +820,6 @@ func (c *Client) ListObjects(ctx context.Context, bucketName string, opts ListOb
 		case opts.UseV1:
 			objIter = c.listObjects(ctx, bucketName, opts)
 		default:
-			location, _ := c.bucketLocCache.Get(bucketName)
 			if location == "snowball" {
 				objIter = c.listObjects(ctx, bucketName, opts)
 			} else {
@@ -832,6 +854,13 @@ func (c *Client) ListObjects(ctx context.Context, bucketName string, opts ListOb
 // Canceling the context the iterator will stop, if you wish to discard the yielding make sure
 // to cancel the passed context without that you might leak coroutines
 func (c *Client) ListObjectsIter(ctx context.Context, bucketName string, opts ListObjectsOptions) iter.Seq[ObjectInfo] {
+	location, _ := c.bucketLocCache.Get(bucketName)
+	if err := opts.checkUnsorted(location); err != nil {
+		return func(yield func(ObjectInfo) bool) {
+			yield(ObjectInfo{Err: err})
+		}
+	}
+
 	if opts.WithVersions {
 		return c.listObjectVersions(ctx, bucketName, opts)
 	}
@@ -842,10 +871,8 @@ func (c *Client) ListObjectsIter(ctx context.Context, bucketName string, opts Li
 	}
 
 	// Check whether this is snowball region, if yes ListObjectsV2 doesn't work, fallback to listObjectsV1.
-	if location, ok := c.bucketLocCache.Get(bucketName); ok {
-		if location == "snowball" {
-			return c.listObjects(ctx, bucketName, opts)
-		}
+	if location == "snowball" {
+		return c.listObjects(ctx, bucketName, opts)
 	}
 
 	return c.listObjectsV2(ctx, bucketName, opts)
@@ -858,7 +885,8 @@ func (c *Client) ListObjectsIter(ctx context.Context, bucketName string, opts Li
 //
 // This is a MinIO extension, S3 implementations that do not support it will
 // keep returning a regular lexically sorted listing. Unsorted listing is only
-// available on ListObjects V2, so 'UseV1' and 'WithVersions' are rejected.
+// available on ListObjects V2, so 'UseV1', 'WithVersions' and snowball buckets
+// are rejected instead of silently falling back to a sorted listing.
 //
 // Pagination is positional, the continuation token encodes a position in the
 // listing and not a key, therefore 'StartAfter' cannot be honored and is
@@ -878,18 +906,6 @@ func (c *Client) ListObjectsIter(ctx context.Context, bucketName string, opts Li
 // Canceling the context the iterator will stop, if you wish to discard the yielding make sure
 // to cancel the passed context without that you might leak coroutines
 func (c *Client) ListUnsorted(ctx context.Context, bucketName string, opts ListObjectsOptions) iter.Seq[ObjectInfo] {
-	if opts.UseV1 || opts.WithVersions {
-		return func(yield func(ObjectInfo) bool) {
-			yield(ObjectInfo{Err: errInvalidArgument("unsorted listing is only supported by ListObjects V2")})
-		}
-	}
-
-	if opts.StartAfter != "" {
-		return func(yield func(ObjectInfo) bool) {
-			yield(ObjectInfo{Err: errInvalidArgument("unsorted listing does not support StartAfter")})
-		}
-	}
-
 	opts.Unsorted = true
 	return c.ListObjectsIter(ctx, bucketName, opts)
 }

--- a/api-list.go
+++ b/api-list.go
@@ -157,7 +157,7 @@ func (c *Client) listObjectsV2(ctx context.Context, bucketName string, opts List
 
 			// Get list of objects a maximum of 1000 per request.
 			result, err := c.listObjectsV2Query(ctx, bucketName, opts.Prefix, continuationToken,
-				fetchOwner, opts.WithMetadata, delimiter, opts.StartAfter, opts.MaxKeys, opts.headers)
+				fetchOwner, opts.WithMetadata, opts.Unsorted, delimiter, opts.StartAfter, opts.MaxKeys, opts.headers)
 			if err != nil {
 				yield(ObjectInfo{Err: err})
 				return
@@ -209,10 +209,11 @@ func (c *Client) listObjectsV2(ctx context.Context, bucketName string, opts List
 // ?prefix - Limits the response to keys that begin with the specified prefix.
 // ?continuation-token - Used to continue iterating over a set of objects
 // ?metadata - Specifies if we want metadata for the objects as part of list operation.
+// ?unsorted - Specifies that the objects may be returned in any order, MinIO extension.
 // ?delimiter - A delimiter is a character you use to group keys.
 // ?start-after - Sets a marker to start listing lexically at this key onwards.
 // ?max-keys - Sets the maximum number of keys returned in the response body.
-func (c *Client) listObjectsV2Query(ctx context.Context, bucketName, objectPrefix, continuationToken string, fetchOwner, metadata bool, delimiter, startAfter string, maxkeys int, headers http.Header) (ListBucketV2Result, error) {
+func (c *Client) listObjectsV2Query(ctx context.Context, bucketName, objectPrefix, continuationToken string, fetchOwner, metadata, unsorted bool, delimiter, startAfter string, maxkeys int, headers http.Header) (ListBucketV2Result, error) {
 	// Validate bucket name.
 	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
 		return ListBucketV2Result{}, err
@@ -230,6 +231,10 @@ func (c *Client) listObjectsV2Query(ctx context.Context, bucketName, objectPrefi
 
 	if metadata {
 		urlValues.Set("metadata", "true")
+	}
+
+	if unsorted {
+		urlValues.Set("unsorted", "true")
 	}
 
 	// Set this conditionally if asked
@@ -728,6 +733,11 @@ type ListObjectsOptions struct {
 	WithVersions bool
 	// Include objects metadata in the listing
 	WithMetadata bool
+	// Unsorted allows the server to return the objects in any order, only
+	// honored by ListObjects V2 and incompatible with StartAfter. This is
+	// a MinIO extension, other S3 providers ignore it and keep returning a
+	// sorted listing. See ListUnsorted for the full semantics.
+	Unsorted bool
 	// Only list objects with the prefix
 	Prefix string
 	// Ignore '/' delimiter
@@ -839,6 +849,49 @@ func (c *Client) ListObjectsIter(ctx context.Context, bucketName string, opts Li
 	}
 
 	return c.listObjectsV2(ctx, bucketName, opts)
+}
+
+// ListUnsorted returns an object list iterator, the objects are returned in
+// the order the server finds them instead of the lexical order mandated by
+// S3. Skipping the sort lets the server stream the listing as it is read from
+// each erasure set, which is substantially faster on large prefixes.
+//
+// This is a MinIO extension, S3 implementations that do not support it will
+// keep returning a regular lexically sorted listing. Unsorted listing is only
+// available on ListObjects V2, so 'UseV1' and 'WithVersions' are rejected.
+//
+// Pagination is positional, the continuation token encodes a position in the
+// listing and not a key, therefore 'StartAfter' cannot be honored and is
+// rejected as well. Since there is no ordering to rely on, the caller must
+// de-duplicate: common prefixes can repeat when a delimiter is used, and the
+// same key can be returned twice while a pool is being decommissioned or
+// rebalanced.
+//
+//	api := client.New(....)
+//	for object := range api.ListUnsorted(ctx, "mytestbucket", minio.ListObjectsOptions{Prefix: "starthere", Recursive: true}) {
+//	    if object.Err != nil {
+//	        // handle the errors.
+//	    }
+//	    fmt.Println(object)
+//	}
+//
+// Canceling the context the iterator will stop, if you wish to discard the yielding make sure
+// to cancel the passed context without that you might leak coroutines
+func (c *Client) ListUnsorted(ctx context.Context, bucketName string, opts ListObjectsOptions) iter.Seq[ObjectInfo] {
+	if opts.UseV1 || opts.WithVersions {
+		return func(yield func(ObjectInfo) bool) {
+			yield(ObjectInfo{Err: errInvalidArgument("unsorted listing is only supported by ListObjects V2")})
+		}
+	}
+
+	if opts.StartAfter != "" {
+		return func(yield func(ObjectInfo) bool) {
+			yield(ObjectInfo{Err: errInvalidArgument("unsorted listing does not support StartAfter")})
+		}
+	}
+
+	opts.Unsorted = true
+	return c.ListObjectsIter(ctx, bucketName, opts)
 }
 
 // ListIncompleteUploads - List incompletely uploaded multipart objects.

--- a/core.go
+++ b/core.go
@@ -52,7 +52,7 @@ func (c Core) ListObjects(bucket, prefix, marker, delimiter string, maxKeys int)
 // ListObjectsV2 - Lists all the objects at a prefix, similar to ListObjects() but uses
 // continuationToken instead of marker to support iteration over the results.
 func (c Core) ListObjectsV2(bucketName, objectPrefix, startAfter, continuationToken, delimiter string, maxkeys int) (ListBucketV2Result, error) {
-	return c.listObjectsV2Query(context.Background(), bucketName, objectPrefix, continuationToken, true, false, delimiter, startAfter, maxkeys, nil)
+	return c.listObjectsV2Query(context.Background(), bucketName, objectPrefix, continuationToken, true, false, false, delimiter, startAfter, maxkeys, nil)
 }
 
 // CopyObject - copies an object from source object to destination object on server side.

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -14260,7 +14260,10 @@ func testListUnsorted() {
 		reader := getDataReader("datafile-1-b")
 		defer reader.Close()
 		_, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize),
-			minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+			minio.PutObjectOptions{
+				ContentType:  "binary/octet-stream",
+				UserMetadata: map[string]string{"Marker": "unsorted"},
+			})
 		if err != nil {
 			logError(testName, function, args, startTime, "", fmt.Sprintf("PutObject %d call failed", i+1), err)
 			return
@@ -14268,7 +14271,7 @@ func testListUnsorted() {
 		expected[objectName] = struct{}{}
 	}
 
-	testList := func(opts minio.ListObjectsOptions) {
+	testList := func(opts minio.ListObjectsOptions, wantMetadata bool) {
 		found := make(map[string]struct{})
 		for objInfo := range c.ListUnsorted(context.Background(), bucketName, opts) {
 			if objInfo.Err != nil {
@@ -14279,6 +14282,10 @@ func testListUnsorted() {
 				logError(testName, function, args, startTime, "", "ListUnsorted returned an unexpected object "+objInfo.Key, errors.New("unexpected object"))
 				return
 			}
+			if wantMetadata && objInfo.UserMetadataStripped["Marker"] != "unsorted" {
+				logError(testName, function, args, startTime, "", "ListUnsorted did not return the user metadata of "+objInfo.Key, errors.New("missing user metadata"))
+				return
+			}
 			found[objInfo.Key] = struct{}{}
 		}
 		if len(found) != len(expected) {
@@ -14287,11 +14294,11 @@ func testListUnsorted() {
 		}
 	}
 
-	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true})
+	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true}, false)
 	// MaxKeys smaller than the number of objects exercises the positional
 	// continuation token of an unsorted listing.
-	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true, MaxKeys: 3})
-	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true, WithMetadata: true})
+	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true, MaxKeys: 3}, false)
+	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true, WithMetadata: true}, true)
 
 	// Unsorted listing is only supported on ListObjects V2 and has no key
 	// ordering to start after.
@@ -14301,11 +14308,17 @@ func testListUnsorted() {
 		{Recursive: true, StartAfter: "unsorted/object-1"},
 	}
 	for _, opts := range rejected {
+		var gotErr error
 		for objInfo := range c.ListUnsorted(context.Background(), bucketName, opts) {
 			if objInfo.Err == nil {
 				logError(testName, function, args, startTime, "", "ListUnsorted returned an object for an unsupported option", errors.New("expected error"))
 				return
 			}
+			gotErr = objInfo.Err
+		}
+		if minio.ToErrorResponse(gotErr).Code != minio.InvalidArgument {
+			logError(testName, function, args, startTime, "", "ListUnsorted did not reject an unsupported option with InvalidArgument", gotErr)
+			return
 		}
 	}
 

--- a/functional_tests.go
+++ b/functional_tests.go
@@ -14222,6 +14222,96 @@ func testListObjects() {
 	logSuccess(testName, function, args, startTime)
 }
 
+// Tests unsorted listing of objects.
+func testListUnsorted() {
+	// initialize logging params
+	startTime := time.Now()
+	testName := getFuncName()
+	function := "ListUnsorted(bucketName, opts)"
+	args := map[string]interface{}{
+		"bucketName":   "",
+		"objectPrefix": "",
+		"recursive":    "true",
+	}
+
+	c, err := NewClient(ClientConfig{})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "MinIO client v4 object creation failed", err)
+		return
+	}
+
+	// Generate a new random bucket name.
+	bucketName := randString(60, rand.NewSource(time.Now().UnixNano()), "minio-go-test-")
+	args["bucketName"] = bucketName
+
+	// Make a new bucket.
+	err = c.MakeBucket(context.Background(), bucketName, minio.MakeBucketOptions{Region: "us-east-1"})
+	if err != nil {
+		logError(testName, function, args, startTime, "", "MakeBucket failed", err)
+		return
+	}
+
+	defer cleanupBucket(bucketName, c)
+
+	expected := make(map[string]struct{})
+	for i := 0; i < 10; i++ {
+		objectName := fmt.Sprintf("unsorted/object-%d", i)
+		bufSize := dataFileMap["datafile-1-b"]
+		reader := getDataReader("datafile-1-b")
+		defer reader.Close()
+		_, err = c.PutObject(context.Background(), bucketName, objectName, reader, int64(bufSize),
+			minio.PutObjectOptions{ContentType: "binary/octet-stream"})
+		if err != nil {
+			logError(testName, function, args, startTime, "", fmt.Sprintf("PutObject %d call failed", i+1), err)
+			return
+		}
+		expected[objectName] = struct{}{}
+	}
+
+	testList := func(opts minio.ListObjectsOptions) {
+		found := make(map[string]struct{})
+		for objInfo := range c.ListUnsorted(context.Background(), bucketName, opts) {
+			if objInfo.Err != nil {
+				logError(testName, function, args, startTime, "", "ListUnsorted failed unexpectedly", objInfo.Err)
+				return
+			}
+			if _, ok := expected[objInfo.Key]; !ok {
+				logError(testName, function, args, startTime, "", "ListUnsorted returned an unexpected object "+objInfo.Key, errors.New("unexpected object"))
+				return
+			}
+			found[objInfo.Key] = struct{}{}
+		}
+		if len(found) != len(expected) {
+			logError(testName, function, args, startTime, "", "ListUnsorted returned unexpected number of items", errors.New("missing objects"))
+			return
+		}
+	}
+
+	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true})
+	// MaxKeys smaller than the number of objects exercises the positional
+	// continuation token of an unsorted listing.
+	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true, MaxKeys: 3})
+	testList(minio.ListObjectsOptions{Prefix: "unsorted/", Recursive: true, WithMetadata: true})
+
+	// Unsorted listing is only supported on ListObjects V2 and has no key
+	// ordering to start after.
+	rejected := []minio.ListObjectsOptions{
+		{Recursive: true, UseV1: true},
+		{Recursive: true, WithVersions: true},
+		{Recursive: true, StartAfter: "unsorted/object-1"},
+	}
+	for _, opts := range rejected {
+		for objInfo := range c.ListUnsorted(context.Background(), bucketName, opts) {
+			if objInfo.Err == nil {
+				logError(testName, function, args, startTime, "", "ListUnsorted returned an object for an unsupported option", errors.New("expected error"))
+				return
+			}
+		}
+	}
+
+	logSuccess(testName, function, args, startTime)
+}
+
 // testCors is runnable against S3 itself.
 // Just provide the env var MINIO_GO_TEST_BUCKET_CORS with bucket that is public and WILL BE DELETED.
 // Recreate this manually each time. Minio-go SDK does not support calling
@@ -15591,6 +15681,7 @@ func main() {
 		testStorageClassMetadataCopyObject()
 		testPutObjectWithContentLanguage()
 		testListObjects()
+		testListUnsorted()
 		testRemoveObjects()
 		testRemoveObjectsIter()
 		testListObjectVersions()


### PR DESCRIPTION
AIStor serves `ListObjectsV2` with `?unsorted=true` by concatenating the per-erasure-set streams instead of merging them into lexical order. Clients that build their own set client-side (a `readdir()` that de-duplicates into a directory entry set, hydration passes, existence probes) pay for ordering they never use — skipping the merge is a measurable latency win on multi-pool/multi-set deployments.

This is the Go counterpart of what minio-rs already sends (`.unsorted(true)`), against the server extension documented in `docs/extensions/unsorted-listing/README.md`.

## API

- `ListObjectsOptions.Unsorted` sets `?unsorted=true`, composing with `metadata=true`.
- `ListUnsorted(ctx, bucket, opts) iter.Seq[ObjectInfo]` is the entrypoint.

```go
for object := range c.ListUnsorted(ctx, "mybucket", minio.ListObjectsOptions{Prefix: "a/", Recursive: true}) {
    if object.Err != nil {
        // handle the error
    }
    fmt.Println(object.Key)
}
```

## Semantics

Pagination stays positional — the continuation token encodes a position rather than a key — so the existing `NextContinuationToken` loop is unchanged. `StartAfter` has no key ordering to resolve against and the server answers `501 NotSupported`, so it is rejected client-side, along with the V1 and versioned listing paths that do not implement the extension.

Callers must de-duplicate: common prefixes can repeat when a delimiter is used, and the same key can be returned twice while a pool is being decommissioned or rebalanced. Both are documented on `ListUnsorted`.

Servers without the extension ignore the parameter and keep returning a sorted listing.

## Testing

`functional_tests.go` gains `testListUnsorted()` covering plain, paginated (`MaxKeys` below the object count, to exercise the positional token), and `WithMetadata` listings, plus the three rejected option sets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for unsorted object listings through a new listing option and convenience method.
  * Unsorted listings support prefixes, pagination, and object metadata.
* **Bug Fixes**
  * Added validation to reject unsupported combinations, including V1, versioned, or `StartAfter` listings.
* **Tests**
  * Added coverage for unsorted listing behavior, pagination, metadata, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->