### PR TITLE
fix(s3utils): reject path-shaped bucket names explicitly

### DIFF
--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -365,10 +365,31 @@ var (
 	ipAddress                = regexp.MustCompile(`^(\d+\.){3}\d+$`)
 )
 
+// A bucket name is a single path element, so it can never carry a path
+// separator nor be a relative path element. Callers that hand a raw request
+// path to CheckValidBucketName/CheckValidBucketNameStrict - because the path
+// hid the bucket behind a leading "//" - rely on this: "//bucket", "../",
+// "/.." and friends have to be rejected as path-shaped input rather than pass
+// on a length or character technicality.
+func checkBucketNamePathShaped(bucketName string) error {
+	if strings.ContainsAny(bucketName, `/\`) {
+		return errors.New("Bucket name cannot contain path separators")
+	}
+	if bucketName == "." || bucketName == ".." {
+		return errors.New("Bucket name cannot be a relative path element")
+	}
+	return nil
+}
+
 // Common checker for both stricter and basic validation.
 func checkBucketNameCommon(bucketName string, strict bool) (err error) {
 	if strings.TrimSpace(bucketName) == "" {
 		return errors.New("Bucket name cannot be empty")
+	}
+	// Checked ahead of the length limits so that path-shaped input is
+	// diagnosed as such whatever its length.
+	if err := checkBucketNamePathShaped(bucketName); err != nil {
+		return err
 	}
 	if len(bucketName) < 3 {
 		return errors.New("Bucket name cannot be shorter than 3 characters")
@@ -408,6 +429,10 @@ func IsS3ExpressBucket(bucketName string) bool {
 func CheckValidBucketNameS3Express(bucketName string) (err error) {
 	if strings.TrimSpace(bucketName) == "" {
 		return errors.New("Bucket name cannot be empty for S3 Express")
+	}
+
+	if err := checkBucketNamePathShaped(bucketName); err != nil {
+		return err
 	}
 
 	if len(bucketName) < 3 {

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -20,6 +20,7 @@ package s3utils
 import (
 	"errors"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -383,6 +384,9 @@ func TestIsValidBucketName(t *testing.T) {
 		{"192.168.1.168", errors.New("Bucket name cannot be an ip address"), false},
 		{":bucketname", errors.New("Bucket name contains invalid characters"), false},
 		{"_bucketName", errors.New("Bucket name contains invalid characters"), false},
+		{"/mybucket", errors.New("Bucket name cannot contain path separators"), false},
+		{"mybucket/myobject", errors.New("Bucket name cannot contain path separators"), false},
+		{"..", errors.New("Bucket name cannot be a relative path element"), false},
 		{"my.bucket.com", nil, true},
 		{"my-bucket", nil, true},
 		{"123my-bucket", nil, true},
@@ -428,6 +432,24 @@ func TestIsValidBucketNameStrict(t *testing.T) {
 		{"my-.bucket", errors.New("Bucket name contains invalid characters"), false},
 		{"192.168.1.168", errors.New("Bucket name cannot be an ip address"), false},
 		{"Mybucket", errors.New("Bucket name contains invalid characters"), false},
+		// Request paths that hid the bucket behind a leading "//" reach here
+		// verbatim, so every path-shaped spelling has to be rejected as a path.
+		{"/mybucket", errors.New("Bucket name cannot contain path separators"), false},
+		{"//mybucket", errors.New("Bucket name cannot contain path separators"), false},
+		{"mybucket/myobject", errors.New("Bucket name cannot contain path separators"), false},
+		{"//", errors.New("Bucket name cannot contain path separators"), false},
+		{"/", errors.New("Bucket name cannot contain path separators"), false},
+		{"../", errors.New("Bucket name cannot contain path separators"), false},
+		{"/..", errors.New("Bucket name cannot contain path separators"), false},
+		{"/.", errors.New("Bucket name cannot contain path separators"), false},
+		{"./mybucket", errors.New("Bucket name cannot contain path separators"), false},
+		{"mybucket/", errors.New("Bucket name cannot contain path separators"), false},
+		{`\mybucket`, errors.New("Bucket name cannot contain path separators"), false},
+		{".", errors.New("Bucket name cannot be a relative path element"), false},
+		{"..", errors.New("Bucket name cannot be a relative path element"), false},
+		// A path-shaped name is diagnosed as a path even when it also busts
+		// the length limit - the oversized scanner probe that motivated this.
+		{"//" + strings.Repeat("a", 300), errors.New("Bucket name cannot contain path separators"), false},
 		{"my.bucket.com", nil, true},
 		{"my-bucket", nil, true},
 		{"123my-bucket", nil, true},


### PR DESCRIPTION
## Summary

`CheckValidBucketNameStrict` already rejected path-shaped input such as `//bucket`, `/bucket`, `../`, `/..` and
`bucket/object`, but only as a side effect of `/` falling outside the character class of `validBucketNameStrict`, and it
misreported what was wrong:

| input | before | after |
| --- | --- | --- |
| `//` | `Bucket name cannot be shorter than 3 characters` | `Bucket name cannot contain path separators` |
| `//` + 300 chars | `Bucket name cannot be longer than 63 characters` | `Bucket name cannot contain path separators` |
| `..` | `Bucket name cannot be shorter than 3 characters` | `Bucket name cannot be a relative path element` |

Both of those messages hide the fact that the input is a path.

This matters for callers that hand a raw request path to the validator. A server that derives the bucket from the
request path gets an empty bucket name when the path begins with `//` (the empty leading segment consumes the
separator), so validating the path itself as a bucket name is the natural fallback — and that fallback wants an explicit
rule, not an accident of a regex that a later loosening of the character class could silently undo. `validBucketName`
already permits `_` and `:`, so the character class is not frozen.

## Change

A single `checkBucketNamePathShaped` helper, applied by `checkBucketNameCommon` (so both `CheckValidBucketName` and
`CheckValidBucketNameStrict`) and by `CheckValidBucketNameS3Express`:

```go
func checkBucketNamePathShaped(bucketName string) error {
	if strings.ContainsAny(bucketName, `/\`) {
		return errors.New("Bucket name cannot contain path separators")
	}
	if bucketName == "." || bucketName == ".." {
		return errors.New("Bucket name cannot be a relative path element")
	}
	return nil
}
```

Two deliberate choices:

- It runs **ahead of the length limits**, so path-shaped input is diagnosed as a path whatever its length.
- It rejects the **separator itself** rather than enumerating `//`, `../`, `/..`, which covers every spelling instead of
  playing whack-a-mole. Embedded `..` (`a..b`) stays with the pre-existing `strings.Contains` check.

## The accepted set is unchanged

This only re-diagnoses names that were already rejected; it cannot narrow what is accepted. Verified differentially
against the pre-change implementation, comparing the accept/reject decision (not the error text):

| corpus | names | decision differences |
| --- | --- | --- |
| exhaustive, len 0–4 over `a z 0 9 A . - _ : / \ % SP \n é` | 54,241 | 0 |
| randomised, len 1–70 across 13 shapes (bare, `/x`, `//x`, `x/`, `../x`, S3 Express, dotted, hyphenated) | 400,000 | 0 |

× 3 validators each. Also checked against the MinIO server's own authoritative valid-name table
(`cmd/object-api-utils_test.go`): `lol`, `123`, `a.b`, `ab.a.bc`, `this.works.too.1`, `s3-eu-west-1.amazonaws.com` and
friends all still pass, as do S3 Express directory buckets (`bucket--usw2-az1--x-s3`) and the names MinIO permits only
under the relaxed validator (`My_bucket`, `My:bucket`).

MinIO's internal slash-bearing pseudo-buckets (`.minio.sys/config`, `.minio.sys/buckets`) were already rejected here
before this change — the server exempts them via `isMinioMetaBucketName` before calling s3utils, and
`isReservedOrInvalidBucket` trims a trailing slash before validating. Verified by decision-parity assertion.

## Tests

13 cases added to the strict table and 3 to the basic table, covering each path-shaped spelling, `.`/`..`, a backslash,
and `"//" + strings.Repeat("a", 300)` as the guard that the separator check wins over the length check.

Live-server check against MinIO with `mc`: 29 operations pass (`mb`/`cp`/`ls`/`stat`/`cat`/`pipe`/`mirror`/`find`/`du`/`rm`/`rb`),
7 valid bucket names accepted and 7 invalid ones rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket-name validation to reject names containing path separators.
  * Rejects relative path-like names such as `.` and `..`, including variants with repeated or backslash separators.
  * Applies consistent validation across standard, strict, and S3 Express bucket-name checks.
  * Provides path-specific validation errors before length checks for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->