### PR TITLE
fix: swap Owner XML tags so DisplayName/ID parse correctly

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -122,8 +122,8 @@ func stringsCut(s, sep string) (before, after string, found bool) {
 // Owner name.
 type Owner struct {
 	XMLName     xml.Name `xml:"Owner" json:"owner"`
-	DisplayName string   `xml:"ID" json:"name"`
-	ID          string   `xml:"DisplayName" json:"id"`
+	DisplayName string   `xml:"DisplayName" json:"name"`
+	ID          string   `xml:"ID" json:"id"`
 }
 
 // UploadInfo contains information about the


### PR DESCRIPTION
The `Owner` struct in `api-datatypes.go` mapped Go field `DisplayName` to the XML `<ID>` element and `ID` to `<DisplayName>`:

```go
type Owner struct {
	XMLName     xml.Name `xml:"Owner" json:"owner"`
	DisplayName string   `xml:"ID" json:"name"`
	ID          string   `xml:"DisplayName" json:"id"`
}
```

S3 list responses carry `<ID>` (the canonical user id) and `<DisplayName>`. With the swapped tags, `ObjectInfo.Owner.DisplayName` ends up holding the canonical user ID and `ObjectInfo.Owner.ID` the display name in `ListObjects`, `ListObjectVersions` and `GetObjectACL`.

Swap the two `xml` tags so each field parses its own element. The `json` tags are left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected XML data mapping for owner display names and IDs, ensuring these values are read correctly from XML responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->