### PR TITLE
fix: race on shared checksum hasher in parallel multipart upload

### DIFF
--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -488,10 +488,6 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 		}
 	}()
 
-	// Create checksums
-	// CRC32C is ~50% faster on AMD64 @ 30GB/s
-	crc := opts.AutoChecksum.Hasher()
-
 	// Total data read and written to server. should be equal to 'size' at the end of the call.
 	var totalUploadedSize int64
 
@@ -546,8 +542,9 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 			// Calculate md5sum.
 			customHeader := make(http.Header)
 			if opts.AutoChecksum.IsSet() {
-				// Add Checksum instead.
-				crc.Reset()
+				// Add Checksum instead. Per-goroutine hasher:
+				// hash.Hash is not safe for concurrent use.
+				crc := opts.AutoChecksum.Hasher()
 				crc.Write(buf[:length])
 				cSum := crc.Sum(nil)
 				customHeader.Set(opts.AutoChecksum.Key(), base64.StdEncoding.EncodeToString(cSum))


### PR DESCRIPTION
`putObjectMultipartStreamParallel` created a single `AutoChecksum` hasher before spawning the per-part upload goroutines, and every goroutine then called `Reset`/`Write`/`Sum` on that one hasher concurrently:

```go
crc := opts.AutoChecksum.Hasher()
...
go func(partNumber int) {
    ...
    crc.Reset()
    crc.Write(buf[:length])
    cSum := crc.Sum(nil)
```

`hash.Hash` (e.g. `crc32.NewIEEE()`) is not safe for concurrent use, so with `ConcurrentStreamParts` and `NumThreads > 1` the interleaved calls can compute a checksum over mixed data, which the server then rejects as a checksum mismatch.

Create a fresh hasher inside each goroutine, matching what `putObjectMultipartStreamFromReadAt` already does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of parallel multipart uploads by preventing concurrent checksum processing conflicts.
  * Ensured each uploaded part calculates its checksum independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->