### PR TITLE
fix: typos in S3 Express endpoint and randString alphabet

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -33,7 +33,7 @@ var awsS3ExpressEndpointMap = map[string]awsS3ExpressEndpoint{
 		[]string{
 			"s3express-use1-az4.us-east-1.amazonaws.com",
 			"s3express-use1-az5.us-east-1.amazonaws.com",
-			"3express-use1-az6.us-east-1.amazonaws.com",
+			"s3express-use1-az6.us-east-1.amazonaws.com",
 		},
 	},
 	"us-east-2": {

--- a/utils.go
+++ b/utils.go
@@ -673,7 +673,7 @@ func (m *hashWrapper) Close() {
 	m.Hash = nil
 }
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyz01234569"
+const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits


### PR DESCRIPTION
Two small typos:

1. `endpoints.go`: `"3express-use1-az6.us-east-1.amazonaws.com"` was missing the leading `s` (should be `s3express-...`). This was also pointed out as an unrelated note in #2282.
2. `utils.go`: `letterBytes` was `"...01234569"`, missing `7` and `8`, so names generated by `randString` never contained those digits.

Ref: #2282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the S3 Express endpoint for the `us-east-1` region.
  - Updated random string generation to include the digit `8` in its character set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->