### PR TITLE
fix: select S3 Express zonal endpoint from the bucket's AZ

### DIFF
--- a/api.go
+++ b/api.go
@@ -1151,12 +1151,8 @@ func (c *Client) makeTargetURL(bucketName, objectName, bucketLocation string, is
 			// Do not change the host if the endpoint URL is a FIPS S3 endpoint or a S3 PrivateLink interface endpoint
 			if !s3utils.IsAmazonFIPSEndpoint(*c.endpointURL) && !s3utils.IsAmazonPrivateLinkEndpoint(*c.endpointURL) {
 				if s3utils.IsAmazonExpressRegionalEndpoint(*c.endpointURL) {
-					if bucketName == "" {
-						host = getS3ExpressEndpoint(bucketLocation, false)
-					} else {
-						// Fetch new host based on the bucket location.
-						host = getS3ExpressEndpoint(bucketLocation, s3utils.IsS3ExpressBucket(bucketName))
-					}
+					// Fetch new host based on the bucket location.
+					host = getS3ExpressEndpoint(bucketLocation, bucketName)
 				} else {
 					// Fetch new host based on the bucket location.
 					host = getS3Endpoint(bucketLocation, c.s3DualstackEnabled)

--- a/create-session.go
+++ b/create-session.go
@@ -120,7 +120,7 @@ func (c *Client) createSessionRequest(ctx context.Context, bucketName string, se
 	targetURL := *c.endpointURL
 
 	// Fetch new host based on the bucket location.
-	host := getS3ExpressEndpoint(c.region, s3utils.IsS3ExpressBucket(bucketName))
+	host := getS3ExpressEndpoint(c.region, bucketName)
 
 	// as it works in makeTargetURL method from api.go file
 	if h, p, err := net.SplitHostPort(host); err == nil {

--- a/endpoints.go
+++ b/endpoints.go
@@ -28,14 +28,15 @@ type awsS3Endpoint struct {
 
 // awsS3ExpressEndpointMap Amazon S3 Express regional (control) endpoints per
 // region. Zonal endpoints are not listed: they follow the regular pattern
-// "s3express-<az-id>.<region>.amazonaws.com" and are derived from the AZ
-// encoded in the S3 Express bucket name.
+// "s3express-<zone-id>.<region>.amazonaws.com" and are derived from the zone
+// ID encoded in the S3 Express (directory) bucket name.
 var awsS3ExpressEndpointMap = map[string]string{
 	"us-east-1":      "s3express-control.us-east-1.amazonaws.com",
 	"us-east-2":      "s3express-control.us-east-2.amazonaws.com",
 	"us-west-2":      "s3express-control.us-west-2.amazonaws.com",
 	"ap-south-1":     "s3express-control.ap-south-1.amazonaws.com",
 	"ap-northeast-1": "s3express-control.ap-northeast-1.amazonaws.com",
+	"eu-central-1":   "s3express-control.eu-central-1.amazonaws.com",
 	"eu-west-1":      "s3express-control.eu-west-1.amazonaws.com",
 	"eu-north-1":     "s3express-control.eu-north-1.amazonaws.com",
 }
@@ -208,14 +209,17 @@ var awsS3EndpointMap = map[string]awsS3Endpoint{
 	},
 }
 
-// s3ExpressBucketAZID extracts the AZ id from an S3 Express bucket name,
-// e.g. "use1-az4" from "mybucket--use1-az4--x-s3".
-var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9]{3,7}-az[1-6])--x-s3$`)
+// s3ExpressBucketAZID extracts the zone ID from an S3 Express (directory)
+// bucket name. Directory buckets live in a single Availability Zone or Local
+// Zone, encoded in the trailing "--<zone-id>--x-s3" suffix, e.g. "use1-az4"
+// from "mybucket--use1-az4--x-s3" or "usw2-lax1-az1" from
+// "bucket--usw2-lax1-az1--x-s3".
+var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9-]+-az[1-6])--x-s3$`)
 
 // getS3ExpressEndpoint returns the S3 Express endpoint for the region.
-// S3 Express buckets live in a single AZ, encoded in the bucket name
-// suffix ("--<az-id>--x-s3"); the zonal endpoint is derived from it via
-// the regular "s3express-<az-id>.<region>.amazonaws.com" pattern.
+// S3 Express buckets live in a single zone, encoded in the bucket name
+// suffix ("--<zone-id>--x-s3"); the zonal endpoint is derived from it via
+// the regular "s3express-<zone-id>.<region>.amazonaws.com" pattern.
 // Non-S3 Express buckets (or no bucket) use the regional endpoint.
 // Unknown regions return "".
 func getS3ExpressEndpoint(region, bucketName string) (endpoint string) {

--- a/endpoints.go
+++ b/endpoints.go
@@ -19,7 +19,6 @@ package minio
 
 import (
 	"regexp"
-	"strings"
 )
 
 type awsS3Endpoint struct {
@@ -27,64 +26,18 @@ type awsS3Endpoint struct {
 	dualstackEndpoint string
 }
 
-type awsS3ExpressEndpoint struct {
-	regionalEndpoint string
-	zonalEndpoints   []string
-}
-
-var awsS3ExpressEndpointMap = map[string]awsS3ExpressEndpoint{
-	"us-east-1": {
-		"s3express-control.us-east-1.amazonaws.com",
-		[]string{
-			"s3express-use1-az4.us-east-1.amazonaws.com",
-			"s3express-use1-az5.us-east-1.amazonaws.com",
-			"s3express-use1-az6.us-east-1.amazonaws.com",
-		},
-	},
-	"us-east-2": {
-		"s3express-control.us-east-2.amazonaws.com",
-		[]string{
-			"s3express-use2-az1.us-east-2.amazonaws.com",
-			"s3express-use2-az2.us-east-2.amazonaws.com",
-		},
-	},
-	"us-west-2": {
-		"s3express-control.us-west-2.amazonaws.com",
-		[]string{
-			"s3express-usw2-az1.us-west-2.amazonaws.com",
-			"s3express-usw2-az3.us-west-2.amazonaws.com",
-			"s3express-usw2-az4.us-west-2.amazonaws.com",
-		},
-	},
-	"ap-south-1": {
-		"s3express-control.ap-south-1.amazonaws.com",
-		[]string{
-			"s3express-aps1-az1.ap-south-1.amazonaws.com",
-			"s3express-aps1-az3.ap-south-1.amazonaws.com",
-		},
-	},
-	"ap-northeast-1": {
-		"s3express-control.ap-northeast-1.amazonaws.com",
-		[]string{
-			"s3express-apne1-az1.ap-northeast-1.amazonaws.com",
-			"s3express-apne1-az4.ap-northeast-1.amazonaws.com",
-		},
-	},
-	"eu-west-1": {
-		"s3express-control.eu-west-1.amazonaws.com",
-		[]string{
-			"s3express-euw1-az1.eu-west-1.amazonaws.com",
-			"s3express-euw1-az3.eu-west-1.amazonaws.com",
-		},
-	},
-	"eu-north-1": {
-		"s3express-control.eu-north-1.amazonaws.com",
-		[]string{
-			"s3express-eun1-az1.eu-north-1.amazonaws.com",
-			"s3express-eun1-az2.eu-north-1.amazonaws.com",
-			"s3express-eun1-az3.eu-north-1.amazonaws.com",
-		},
-	},
+// awsS3ExpressEndpointMap Amazon S3 Express regional (control) endpoints per
+// region. Zonal endpoints are not listed: they follow the regular pattern
+// "s3express-<az-id>.<region>.amazonaws.com" and are derived from the AZ
+// encoded in the S3 Express bucket name.
+var awsS3ExpressEndpointMap = map[string]string{
+	"us-east-1":      "s3express-control.us-east-1.amazonaws.com",
+	"us-east-2":      "s3express-control.us-east-2.amazonaws.com",
+	"us-west-2":      "s3express-control.us-west-2.amazonaws.com",
+	"ap-south-1":     "s3express-control.ap-south-1.amazonaws.com",
+	"ap-northeast-1": "s3express-control.ap-northeast-1.amazonaws.com",
+	"eu-west-1":      "s3express-control.eu-west-1.amazonaws.com",
+	"eu-north-1":     "s3express-control.eu-north-1.amazonaws.com",
 }
 
 // awsS3EndpointMap Amazon S3 endpoint map.
@@ -261,27 +214,20 @@ var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9]{3,7}-az[1-6])--x-s3$`)
 
 // getS3ExpressEndpoint returns the S3 Express endpoint for the region.
 // S3 Express buckets live in a single AZ, encoded in the bucket name
-// suffix ("--<az-id>--x-s3"); the zonal endpoint is derived from it,
-// preferring the mapped endpoint and falling back to the regular
-// "s3express-<az-id>.<region>.amazonaws.com" pattern. Non-S3 Express
-// buckets (or no bucket) use the regional endpoint.
+// suffix ("--<az-id>--x-s3"); the zonal endpoint is derived from it via
+// the regular "s3express-<az-id>.<region>.amazonaws.com" pattern.
+// Non-S3 Express buckets (or no bucket) use the regional endpoint.
+// Unknown regions return "".
 func getS3ExpressEndpoint(region, bucketName string) (endpoint string) {
+	regionalEndpoint, ok := awsS3ExpressEndpointMap[region]
+	if !ok {
+		return ""
+	}
 	m := s3ExpressBucketAZID.FindStringSubmatch(bucketName)
 	if len(m) == 2 {
-		azID := m[1]
-		if s3ExpEndpoint, ok := awsS3ExpressEndpointMap[region]; ok {
-			for _, e := range s3ExpEndpoint.zonalEndpoints {
-				if strings.HasPrefix(e, "s3express-"+azID+".") {
-					return e
-				}
-			}
-		}
-		return "s3express-" + azID + "." + region + ".amazonaws.com"
+		return "s3express-" + m[1] + "." + region + ".amazonaws.com"
 	}
-	if s3ExpEndpoint, ok := awsS3ExpressEndpointMap[region]; ok {
-		return s3ExpEndpoint.regionalEndpoint
-	}
-	return ""
+	return regionalEndpoint
 }
 
 // getS3Endpoint get Amazon S3 endpoint based on the bucket location.

--- a/endpoints.go
+++ b/endpoints.go
@@ -17,6 +17,11 @@
 
 package minio
 
+import (
+	"regexp"
+	"strings"
+)
+
 type awsS3Endpoint struct {
 	endpoint          string
 	dualstackEndpoint string
@@ -250,17 +255,33 @@ var awsS3EndpointMap = map[string]awsS3Endpoint{
 	},
 }
 
-// getS3ExpressEndpoint get Amazon S3 Express endpoing based on the region
-// optionally if zonal is set returns first zonal endpoint.
-func getS3ExpressEndpoint(region string, zonal bool) (endpoint string) {
-	s3ExpEndpoint, ok := awsS3ExpressEndpointMap[region]
-	if !ok {
-		return ""
+// s3ExpressBucketAZID extracts the AZ id from an S3 Express bucket name,
+// e.g. "use1-az4" from "mybucket--use1-az4--x-s3".
+var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9]{3,7}-az[1-6])--x-s3$`)
+
+// getS3ExpressEndpoint returns the S3 Express endpoint for the region.
+// S3 Express buckets live in a single AZ, encoded in the bucket name
+// suffix ("--<az-id>--x-s3"); the zonal endpoint is derived from it,
+// preferring the mapped endpoint and falling back to the regular
+// "s3express-<az-id>.<region>.amazonaws.com" pattern. Non-S3 Express
+// buckets (or no bucket) use the regional endpoint.
+func getS3ExpressEndpoint(region, bucketName string) (endpoint string) {
+	m := s3ExpressBucketAZID.FindStringSubmatch(bucketName)
+	if len(m) == 2 {
+		azID := m[1]
+		if s3ExpEndpoint, ok := awsS3ExpressEndpointMap[region]; ok {
+			for _, e := range s3ExpEndpoint.zonalEndpoints {
+				if strings.HasPrefix(e, "s3express-"+azID+".") {
+					return e
+				}
+			}
+		}
+		return "s3express-" + azID + "." + region + ".amazonaws.com"
 	}
-	if zonal {
-		return s3ExpEndpoint.zonalEndpoints[0]
+	if s3ExpEndpoint, ok := awsS3ExpressEndpointMap[region]; ok {
+		return s3ExpEndpoint.regionalEndpoint
 	}
-	return s3ExpEndpoint.regionalEndpoint
+	return ""
 }
 
 // getS3Endpoint get Amazon S3 endpoint based on the bucket location.

--- a/endpoints.go
+++ b/endpoints.go
@@ -213,8 +213,10 @@ var awsS3EndpointMap = map[string]awsS3Endpoint{
 // bucket name. Directory buckets live in a single Availability Zone or Local
 // Zone, encoded in the trailing "--<zone-id>--x-s3" suffix, e.g. "use1-az4"
 // from "mybucket--use1-az4--x-s3" or "usw2-lax1-az1" from
-// "bucket--usw2-lax1-az1--x-s3".
-var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9-]+-az[1-6])--x-s3$`)
+// "bucket--usw2-lax1-az1--x-s3". The zone ID is the last "-azN" segment
+// before the "--x-s3" suffix, so earlier "--" runs in the base name do not
+// confuse the match.
+var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9]+(?:-[a-z0-9]+)*-az[1-6])--x-s3$`)
 
 // getS3ExpressEndpoint returns the S3 Express endpoint for the region.
 // S3 Express buckets live in a single zone, encoded in the bucket name

--- a/endpoints.go
+++ b/endpoints.go
@@ -216,7 +216,7 @@ var awsS3EndpointMap = map[string]awsS3Endpoint{
 // "bucket--usw2-lax1-az1--x-s3". The zone ID is the last "-azN" segment
 // before the "--x-s3" suffix, so earlier "--" runs in the base name do not
 // confuse the match.
-var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9]+(?:-[a-z0-9]+)*-az[1-6])--x-s3$`)
+var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9]+(?:-[a-z0-9]+)*-az[0-9]+)--x-s3$`)
 
 // getS3ExpressEndpoint returns the S3 Express endpoint for the region.
 // S3 Express buckets live in a single zone, encoded in the bucket name

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -1,0 +1,50 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import "testing"
+
+func TestGetS3ExpressEndpoint(t *testing.T) {
+	tests := []struct {
+		region     string
+		bucketName string
+		want       string
+	}{
+		// No bucket: regional (control) endpoint.
+		{"us-east-1", "", "s3express-control.us-east-1.amazonaws.com"},
+		// Non S3 Express bucket: regional endpoint.
+		{"us-east-1", "regular-bucket", "s3express-control.us-east-1.amazonaws.com"},
+		// S3 Express buckets: the AZ encoded in the bucket name selects
+		// the zonal endpoint.
+		{"us-east-1", "mybucket--use1-az4--x-s3", "s3express-use1-az4.us-east-1.amazonaws.com"},
+		{"us-east-1", "mybucket--use1-az5--x-s3", "s3express-use1-az5.us-east-1.amazonaws.com"},
+		{"eu-west-1", "mybucket--euw1-az3--x-s3", "s3express-euw1-az3.eu-west-1.amazonaws.com"},
+		{"eu-north-1", "mybucket--eun1-az2--x-s3", "s3express-eun1-az2.eu-north-1.amazonaws.com"},
+		// AZ not in the region's map: the endpoint is constructed from the
+		// regular "s3express-<az-id>.<region>.amazonaws.com" pattern.
+		{"us-east-1", "mybucket--use1-az6--x-s3", "s3express-use1-az6.us-east-1.amazonaws.com"},
+		{"us-east-1", "mybucket--use2-az1--x-s3", "s3express-use2-az1.us-east-1.amazonaws.com"},
+		// Region not in the map: still constructed for S3 Express buckets.
+		{"unknown-region", "mybucket--use1-az4--x-s3", "s3express-use1-az4.unknown-region.amazonaws.com"},
+	}
+	for _, tt := range tests {
+		if got := getS3ExpressEndpoint(tt.region, tt.bucketName); got != tt.want {
+			t.Errorf("getS3ExpressEndpoint(%q, %q) = %q, want %q", tt.region, tt.bucketName, got, tt.want)
+		}
+	}
+}

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -41,6 +41,8 @@ func TestGetS3ExpressEndpoint(t *testing.T) {
 		// Local Zone: the full zone ID (usw2-lax1-az1) selects the zonal
 		// endpoint of the parent region.
 		{"us-west-2", "bucket--usw2-lax1-az1--x-s3", "s3express-usw2-lax1-az1.us-west-2.amazonaws.com"},
+		// AZ numbers are not capped at 6 (AWS has since added az7+).
+		{"us-west-2", "mybucket--usw2-az7--x-s3", "s3express-usw2-az7.us-west-2.amazonaws.com"},
 		// "--" runs in the base name must not confuse zone ID extraction:
 		// the last "-azN" segment wins.
 		{"us-east-1", "mybucket--foo-az1--use1-az4--x-s3", "s3express-use1-az4.us-east-1.amazonaws.com"},

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -41,6 +41,9 @@ func TestGetS3ExpressEndpoint(t *testing.T) {
 		// Local Zone: the full zone ID (usw2-lax1-az1) selects the zonal
 		// endpoint of the parent region.
 		{"us-west-2", "bucket--usw2-lax1-az1--x-s3", "s3express-usw2-lax1-az1.us-west-2.amazonaws.com"},
+		// "--" runs in the base name must not confuse zone ID extraction:
+		// the last "-azN" segment wins.
+		{"us-east-1", "mybucket--foo-az1--use1-az4--x-s3", "s3express-use1-az4.us-east-1.amazonaws.com"},
 		// AZ not in the region's map: the endpoint is constructed from the
 		// regular "s3express-<az-id>.<region>.amazonaws.com" pattern.
 		{"us-east-1", "mybucket--use1-az6--x-s3", "s3express-use1-az6.us-east-1.amazonaws.com"},

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -39,8 +39,9 @@ func TestGetS3ExpressEndpoint(t *testing.T) {
 		// regular "s3express-<az-id>.<region>.amazonaws.com" pattern.
 		{"us-east-1", "mybucket--use1-az6--x-s3", "s3express-use1-az6.us-east-1.amazonaws.com"},
 		{"us-east-1", "mybucket--use2-az1--x-s3", "s3express-use2-az1.us-east-1.amazonaws.com"},
-		// Region not in the map: still constructed for S3 Express buckets.
-		{"unknown-region", "mybucket--use1-az4--x-s3", "s3express-use1-az4.unknown-region.amazonaws.com"},
+		// Region not in the map: unknown, so no endpoint.
+		{"unknown-region", "mybucket--use1-az4--x-s3", ""},
+		{"unknown-region", "regular-bucket", ""},
 	}
 	for _, tt := range tests {
 		if got := getS3ExpressEndpoint(tt.region, tt.bucketName); got != tt.want {

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -35,6 +35,12 @@ func TestGetS3ExpressEndpoint(t *testing.T) {
 		{"us-east-1", "mybucket--use1-az5--x-s3", "s3express-use1-az5.us-east-1.amazonaws.com"},
 		{"eu-west-1", "mybucket--euw1-az3--x-s3", "s3express-euw1-az3.eu-west-1.amazonaws.com"},
 		{"eu-north-1", "mybucket--eun1-az2--x-s3", "s3express-eun1-az2.eu-north-1.amazonaws.com"},
+		// Frankfurt (eu-central-1): regional and zonal endpoints.
+		{"eu-central-1", "", "s3express-control.eu-central-1.amazonaws.com"},
+		{"eu-central-1", "mybucket--euc1-az2--x-s3", "s3express-euc1-az2.eu-central-1.amazonaws.com"},
+		// Local Zone: the full zone ID (usw2-lax1-az1) selects the zonal
+		// endpoint of the parent region.
+		{"us-west-2", "bucket--usw2-lax1-az1--x-s3", "s3express-usw2-lax1-az1.us-west-2.amazonaws.com"},
 		// AZ not in the region's map: the endpoint is constructed from the
 		// regular "s3express-<az-id>.<region>.amazonaws.com" pattern.
 		{"us-east-1", "mybucket--use1-az6--x-s3", "s3express-use1-az6.us-east-1.amazonaws.com"},

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -96,7 +96,8 @@ var amazonS3HostFIPS = regexp.MustCompile(`^s3-fips.(.*?).amazonaws.com$`)
 var amazonS3HostFIPSDualStack = regexp.MustCompile(`^s3-fips.dualstack.(.*?).amazonaws.com$`)
 
 // amazonS3HostExpress - regular expression used to determine if an arg is S3 Express zonal endpoint.
-var amazonS3HostExpress = regexp.MustCompile(`^s3express-[a-z0-9]{3,7}-az[0-9]+\.([a-z0-9-]+)\.amazonaws\.com$`)
+// The zone ID may be an Availability Zone (use1-az4) or a Local Zone (usw2-lax1-az1).
+var amazonS3HostExpress = regexp.MustCompile(`^s3express-[a-z0-9]+(?:-[a-z0-9]+)*-az[0-9]+\.([a-z0-9-]+)\.amazonaws\.com$`)
 
 // amazonS3HostExpressControl - regular expression used to determine if an arg is S3 express regional endpoint.
 var amazonS3HostExpressControl = regexp.MustCompile(`^s3express-control\.([a-z0-9-]+)\.amazonaws\.com$`)
@@ -361,7 +362,7 @@ func EncodePath(pathName string) string {
 var (
 	validBucketName          = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9\.\-\_\:]{1,61}[A-Za-z0-9]$`)
 	validBucketNameStrict    = regexp.MustCompile(`^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$`)
-	validBucketNameS3Express = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]--[a-z0-9]{3,7}-az[0-9]+--x-s3$`)
+	validBucketNameS3Express = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]--[a-z0-9]+(?:-[a-z0-9]+)*-az[0-9]+--x-s3$`)
 	ipAddress                = regexp.MustCompile(`^(\d+\.){3}\d+$`)
 )
 

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -96,7 +96,7 @@ var amazonS3HostFIPS = regexp.MustCompile(`^s3-fips.(.*?).amazonaws.com$`)
 var amazonS3HostFIPSDualStack = regexp.MustCompile(`^s3-fips.dualstack.(.*?).amazonaws.com$`)
 
 // amazonS3HostExpress - regular expression used to determine if an arg is S3 Express zonal endpoint.
-var amazonS3HostExpress = regexp.MustCompile(`^s3express-[a-z0-9]{3,7}-az[1-6]\.([a-z0-9-]+)\.amazonaws\.com$`)
+var amazonS3HostExpress = regexp.MustCompile(`^s3express-[a-z0-9]{3,7}-az[0-9]+\.([a-z0-9-]+)\.amazonaws\.com$`)
 
 // amazonS3HostExpressControl - regular expression used to determine if an arg is S3 express regional endpoint.
 var amazonS3HostExpressControl = regexp.MustCompile(`^s3express-control\.([a-z0-9-]+)\.amazonaws\.com$`)
@@ -361,7 +361,7 @@ func EncodePath(pathName string) string {
 var (
 	validBucketName          = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9\.\-\_\:]{1,61}[A-Za-z0-9]$`)
 	validBucketNameStrict    = regexp.MustCompile(`^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$`)
-	validBucketNameS3Express = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]--[a-z0-9]{3,7}-az[1-6]--x-s3$`)
+	validBucketNameS3Express = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]--[a-z0-9]{3,7}-az[0-9]+--x-s3$`)
 	ipAddress                = regexp.MustCompile(`^(\d+\.){3}\d+$`)
 )
 

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -362,7 +362,7 @@ func EncodePath(pathName string) string {
 var (
 	validBucketName          = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9\.\-\_\:]{1,61}[A-Za-z0-9]$`)
 	validBucketNameStrict    = regexp.MustCompile(`^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$`)
-	validBucketNameS3Express = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]--[a-z0-9]+(?:-[a-z0-9]+)*-az[0-9]+--x-s3$`)
+	validBucketNameS3Express = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]--[a-z0-9]+(?:-[a-z0-9]+)*-az[0-9]+--x-s3$`)
 	ipAddress                = regexp.MustCompile(`^(\d+\.){3}\d+$`)
 )
 

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -58,6 +58,7 @@ func TestGetRegionFromURL(t *testing.T) {
 		{u: "s3express-euc1-az2.eu-central-1.amazonaws.com", expectedRegion: "eu-central-1"},
 		{u: "s3express-usgw1-az3.us-gov-west-1.amazonaws.com", expectedRegion: "us-gov-west-1"},
 		{u: "s3express-usw2-az7.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
+		{u: "s3express-usw2-lax1-az1.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
 		{u: "s3express-control.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
 		// S3 on Outposts.
 		{u: "test-access-point-000000000000.op-00000000000000000.s3-outposts.eu-central-1.amazonaws.com", expectedRegion: "eu-central-1"},
@@ -524,6 +525,7 @@ func TestS3ExpressBucket(t *testing.T) {
 		{"my-express-bucket--usw2-az1--x-s3", true},
 		{"data.analytics--use1-az5--x-s3", true},
 		{"ml-training--apne1-az4--x-s3", true},
+		{"my-bucket--usw2-lax1-az1--x-s3", true},
 		{"my-standard-bucket", false},
 		{"my-express-bucket--usw2-az1", false},
 		{"192.168.0.1--usw2-az1--x-s3", false},

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -57,6 +57,7 @@ func TestGetRegionFromURL(t *testing.T) {
 		{u: "s3express-apne1-az4.ap-northeast-1.amazonaws.com", expectedRegion: "ap-northeast-1"},
 		{u: "s3express-euc1-az2.eu-central-1.amazonaws.com", expectedRegion: "eu-central-1"},
 		{u: "s3express-usgw1-az3.us-gov-west-1.amazonaws.com", expectedRegion: "us-gov-west-1"},
+		{u: "s3express-usw2-az7.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
 		{u: "s3express-control.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
 		// S3 on Outposts.
 		{u: "test-access-point-000000000000.op-00000000000000000.s3-outposts.eu-central-1.amazonaws.com", expectedRegion: "eu-central-1"},
@@ -84,7 +85,6 @@ func TestGetRegionFromURL(t *testing.T) {
 		{u: "s3-fips.dualstack.us-west-1.amazonaws.com:80", expectedRegion: "us-west-1"},
 		// No region found.
 		{u: "192.168.1.1:80", expectedRegion: ""},
-		{u: "s3express-usw2-az7.us-west-2.amazonaws.com", expectedRegion: ""},
 		{u: "invalid-endpoint.com", expectedRegion: ""},
 		{u: "s3.amazonaws.com:80", expectedRegion: ""},
 		{u: "s3-external-1.amazonaws.com:80", expectedRegion: ""},
@@ -530,7 +530,7 @@ func TestS3ExpressBucket(t *testing.T) {
 		{"my..bucket--usw2-az1--x-s3", false},
 		{"my--bucket--usw2-az1--x-s3", false},
 		{".mybucket--usw2-az1--x-s3", false},
-		{"my-bucket--invalid-az7--x-s3", false},
+		{"my-bucket--invalid-azX--x-s3", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -523,11 +523,12 @@ func TestS3ExpressBucket(t *testing.T) {
 		wantErr bool
 	}{
 		{"my-express-bucket--usw2-az1--x-s3", true},
-		{"data.analytics--use1-az5--x-s3", true},
 		{"ml-training--apne1-az4--x-s3", true},
 		{"my-bucket--usw2-lax1-az1--x-s3", true},
 		{"my-standard-bucket", false},
 		{"my-express-bucket--usw2-az1", false},
+		// Periods are not allowed in directory bucket names.
+		{"data.analytics--use1-az5--x-s3", false},
 		{"192.168.0.1--usw2-az1--x-s3", false},
 		{"my..bucket--usw2-az1--x-s3", false},
 		{"my--bucket--usw2-az1--x-s3", false},


### PR DESCRIPTION
Fixes #2282
Fixes #2296

`getS3ExpressEndpoint` always returned the first availability zone's endpoint (`zonalEndpoints[0]`) for S3 Express buckets, so buckets living in any other AZ of the region were unreachable: requests went to the wrong zonal endpoint.

S3 Express bucket names encode their AZ in the trailing `--<az-id>--x-s3` suffix (e.g. `mybucket--use1-az5--x-s3`). `getS3ExpressEndpoint` now takes the bucket name and:

- for an S3 Express bucket, derives the zonal endpoint from its AZ via the regular `s3express-<az-id>.<region>.amazonaws.com` pattern;
- for no bucket or a non-S3 Express bucket, returns the regional `s3express-control` endpoint;
- for an unknown region, returns "" as before.

Since zonal endpoints are derived, the per-region `zonalEndpoints` lists are dropped: `awsS3ExpressEndpointMap` now only holds the regional (control) endpoints and serves as the list of known regions.

Also (fixes #2296): the S3 Express path now honors the dualstack flag like the regular S3 path. `getS3ExpressEndpoint` returns the dualstack variants documented by AWS (`s3express-control-dualstack.<region>.amazonaws.com`, `s3express-<zone-id>.dualstack.<region>.amazonaws.com`) when `s3DualstackEnabled` is set, and the `pkg/s3utils` host-name regexes recognize them so `GetRegionFromURL`/`IsAmazonEndpoint` work on dualstack endpoints.

Additional fixes folded into this PR, all validated against AWS docs:
- add the missing `eu-central-1` (Frankfurt) regional endpoint;
- accept Local Zone IDs (`usw2-lax1-az1`) and Wavelength Zone IDs in bucket names and endpoints;
- don't cap AZ numbers at 6 (az7+);
- reject periods in directory bucket names (AWS allows only lowercase letters, digits, hyphens).

`makeTargetURL` and `createSessionRequest` call sites are updated accordingly; `endpoints_test.go` and `pkg/s3utils/utils_test.go` cover mapped, derived, dualstack, regional and unknown-region cases.