### PR TITLE
fix: keep opts.Internal on CompleteMultipartUpload

### DIFF
--- a/api-put-object-multipart.go
+++ b/api-put-object-multipart.go
@@ -202,10 +202,7 @@ func (c *Client) putObjectMultipartNoStream(ctx context.Context, bucketName, obj
 
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
-	opts = PutObjectOptions{
-		ServerSideEncryption: opts.ServerSideEncryption,
-		AutoChecksum:         opts.AutoChecksum,
-	}
+	opts = completeUploadOpts(opts)
 	applyAutoChecksum(&opts, allParts)
 
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
@@ -369,6 +366,22 @@ func (c *Client) uploadPart(ctx context.Context, p uploadPartParams) (ObjectPart
 	// Trim off the odd double quotes from ETag in the beginning and end.
 	objPart.ETag = trimEtag(h.Get("ETag"))
 	return objPart, nil
+}
+
+// completeUploadOpts returns the options to send on CompleteMultipartUpload.
+// Everything that applies to the upload as a whole was already sent with
+// NewMultipartUpload or with the individual parts, so most of the caller's
+// options are deliberately dropped here. Three things must survive: the SSE-C
+// key, which has to be repeated on every request touching the object, the
+// auto-checksum, which is computed from the completed parts, and opts.Internal,
+// because MinIO reads x-minio-source-mtime and
+// x-minio-source-replication-request from this request and nowhere else.
+func completeUploadOpts(opts PutObjectOptions) PutObjectOptions {
+	return PutObjectOptions{
+		ServerSideEncryption: opts.ServerSideEncryption,
+		AutoChecksum:         opts.AutoChecksum,
+		Internal:             opts.Internal,
+	}
 }
 
 // completeMultipartUpload - Completes a multipart upload by assembling previously uploaded parts.

--- a/api-put-object-streaming.go
+++ b/api-put-object-streaming.go
@@ -276,10 +276,7 @@ func (c *Client) putObjectMultipartStreamFromReadAt(ctx context.Context, bucketN
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
 
-	opts = PutObjectOptions{
-		ServerSideEncryption: opts.ServerSideEncryption,
-		AutoChecksum:         opts.AutoChecksum,
-	}
+	opts = completeUploadOpts(opts)
 	if withChecksum {
 		applyAutoChecksum(&opts, allParts)
 	}
@@ -434,10 +431,7 @@ func (c *Client) putObjectMultipartStreamOptionalChecksum(ctx context.Context, b
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
 
-	opts = PutObjectOptions{
-		ServerSideEncryption: opts.ServerSideEncryption,
-		AutoChecksum:         opts.AutoChecksum,
-	}
+	opts = completeUploadOpts(opts)
 	applyAutoChecksum(&opts, allParts)
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)
 	if err != nil {
@@ -635,10 +629,7 @@ func (c *Client) putObjectMultipartStreamParallel(ctx context.Context, bucketNam
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
 
-	opts = PutObjectOptions{
-		ServerSideEncryption: opts.ServerSideEncryption,
-		AutoChecksum:         opts.AutoChecksum,
-	}
+	opts = completeUploadOpts(opts)
 	applyAutoChecksum(&opts, allParts)
 
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)

--- a/api-put-object.go
+++ b/api-put-object.go
@@ -531,10 +531,7 @@ func (c *Client) putObjectMultipartStreamNoLength(ctx context.Context, bucketNam
 	// Sort all completed parts.
 	sort.Sort(completedParts(complMultipartUpload.Parts))
 
-	opts = PutObjectOptions{
-		ServerSideEncryption: opts.ServerSideEncryption,
-		AutoChecksum:         opts.AutoChecksum,
-	}
+	opts = completeUploadOpts(opts)
 	applyAutoChecksum(&opts, allParts)
 
 	uploadInfo, err := c.completeMultipartUpload(ctx, bucketName, objectName, uploadID, complMultipartUpload, opts)

--- a/api-put-object_test.go
+++ b/api-put-object_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 )
@@ -164,5 +165,63 @@ func Test_SSEHeaders(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCompleteUploadOpts checks that the options sent on
+// CompleteMultipartUpload keep opts.Internal. MinIO reads
+// x-minio-source-mtime and x-minio-source-replication-request from the
+// complete request and from nowhere else, so dropping Internal silently
+// discards a preserved modification time on every multipart upload.
+func TestCompleteUploadOpts(t *testing.T) {
+	mtime := time.Date(2026, 8, 21, 15, 42, 50, 543000000, time.UTC)
+	sse, err := encrypt.NewSSEC(make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := PutObjectOptions{
+		ContentType:          "text/plain",
+		StorageClass:         "REDUCED_REDUNDANCY",
+		UserMetadata:         map[string]string{"Key": "value"},
+		ServerSideEncryption: sse,
+		AutoChecksum:         ChecksumCRC32C,
+	}
+	opts.Internal.SourceMTime = mtime
+	opts.Internal.SourceETag = "0d2e0d0e0f0a0b0c"
+	opts.Internal.ReplicationRequest = true
+
+	got := completeUploadOpts(opts)
+
+	if !got.Internal.SourceMTime.Equal(mtime) {
+		t.Errorf("SourceMTime = %v, want %v", got.Internal.SourceMTime, mtime)
+	}
+	if got.Internal.SourceETag != opts.Internal.SourceETag {
+		t.Errorf("SourceETag = %q, want %q", got.Internal.SourceETag, opts.Internal.SourceETag)
+	}
+	if !got.Internal.ReplicationRequest {
+		t.Error("ReplicationRequest = false, want true")
+	}
+	if got.ServerSideEncryption != sse {
+		t.Error("ServerSideEncryption was dropped")
+	}
+	if got.AutoChecksum != opts.AutoChecksum {
+		t.Errorf("AutoChecksum = %v, want %v", got.AutoChecksum, opts.AutoChecksum)
+	}
+
+	// Options that already applied at NewMultipartUpload must not be repeated.
+	if got.ContentType != "" || got.StorageClass != "" || got.UserMetadata != nil {
+		t.Errorf("upload-wide options leaked into the complete request: %+v", got)
+	}
+
+	header := got.Header()
+	if v := header.Get(minIOBucketSourceMTime); v != mtime.Format(time.RFC3339Nano) {
+		t.Errorf("%s header = %q, want %q", minIOBucketSourceMTime, v, mtime.Format(time.RFC3339Nano))
+	}
+	if v := header.Get(minIOBucketReplicationRequest); v != "true" {
+		t.Errorf("%s header = %q, want %q", minIOBucketReplicationRequest, v, "true")
+	}
+	if v := header.Get(amzStorageClass); v != "" {
+		t.Errorf("%s header = %q, want it absent", amzStorageClass, v)
 	}
 }


### PR DESCRIPTION
## Problem

`Internal.SourceMTime` is silently ignored for any object large enough to go multipart.

The header is sent on `POST ?uploads=`, where the server does not look for it, and stripped from `POST ?uploadId=`, where it does. Captured from a real upload:

```
POST /mpart/o32?uploads= HTTP/1.1
X-Minio-Source-Mtime: 2026-08-24T18:06:13.989Z          <- present

POST /mpart/o32?uploadId=ZTU3... HTTP/1.1
Content-Type / X-Amz-Content-Sha256 / X-Amz-Date        <- header gone
```

Five call sites rebuild `PutObjectOptions` from scratch immediately before completing, keeping only two fields:

```go
opts = PutObjectOptions{
    ServerSideEncryption: opts.ServerSideEncryption,
    AutoChecksum:         opts.AutoChecksum,
}
```

`api-put-object.go:534`, `api-put-object-streaming.go:279,437,638`, `api-put-object-multipart.go:205`. `Header()` has the `!opts.Internal.SourceMTime.IsZero()` branch and would emit it — the struct is simply blank by the time it runs.

MinIO reads two `Internal`-derived headers from the complete request: `X-Minio-Source-Mtime` and `X-Minio-Source-Replication-Request` (the latter also carrying the reserved actual-object-size metadata). The server's own replication code documents the contract explicitly, clearing the mtime at initiation because it belongs on completion:

```go
opts.Internal.SourceMTime = time.Time{} // this value is saved properly in CompleteMultipartUpload()
```

It goes through `Core.CompleteMultipartUpload`, which passes `opts` through untouched, so server-side replication is unaffected. It is the high-level `PutObject` paths — the ones every client uses — that drop it.

## Effect

A caller preserving source modification times gets them honored below the multipart threshold and quietly replaced with the server's clock above it. Found via `mc mirror --preserve`, where objects up to 16 MiB kept their source mtime and everything larger did not.

## Fix

Carry `opts.Internal` through, and collapse the five copies of the reset into `completeUploadOpts()` so the set of options that survive completion is stated once rather than in five places that have to stay in sync.

## Testing

`TestCompleteUploadOpts` asserts `Internal` survives and reaches the wire via `Header()`, and that upload-wide options (content type, storage class, user metadata) still do not get repeated on the complete request. It fails without the fix:

```
SourceMTime = 0001-01-01 00:00:00 +0000 UTC, want 2026-08-21 15:42:50.543 +0000 UTC
X-Minio-Source-Mtime header = "", want "2026-08-21T15:42:50.543Z"
X-Minio-Source-Replication-Request header = "", want "true"
```

Full unit suite and `go vet` pass.

End-to-end against a live 4-drive MinIO server, driving the same change through `mc mirror --preserve` (applied to the v7.2.1 line that `mc` currently vendors, since master and that line differ in unrelated ways):

| object size | before | after |
| --- | --- | --- |
| 1 / 8 / 16 MiB | preserved | preserved |
| 32 / 64 / 65 / 128 MiB | stamped with server clock | **preserved, exact** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart uploads now consistently preserve applicable encryption, checksum, and metadata settings when completed.
  * Prevented upload options already applied during initiation from being incorrectly reapplied during completion.

* **Tests**
  * Added coverage validating multipart completion settings and generated request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->