### PR TITLE
feat: support dualstack S3 Express endpoints

### DIFF
--- a/api.go
+++ b/api.go
@@ -1152,7 +1152,7 @@ func (c *Client) makeTargetURL(bucketName, objectName, bucketLocation string, is
 			if !s3utils.IsAmazonFIPSEndpoint(*c.endpointURL) && !s3utils.IsAmazonPrivateLinkEndpoint(*c.endpointURL) {
 				if s3utils.IsAmazonExpressRegionalEndpoint(*c.endpointURL) {
 					// Fetch new host based on the bucket location.
-					host = getS3ExpressEndpoint(bucketLocation, bucketName)
+					host = getS3ExpressEndpoint(bucketLocation, bucketName, c.s3DualstackEnabled)
 				} else {
 					// Fetch new host based on the bucket location.
 					host = getS3Endpoint(bucketLocation, c.s3DualstackEnabled)

--- a/create-session.go
+++ b/create-session.go
@@ -120,7 +120,7 @@ func (c *Client) createSessionRequest(ctx context.Context, bucketName string, se
 	targetURL := *c.endpointURL
 
 	// Fetch new host based on the bucket location.
-	host := getS3ExpressEndpoint(c.region, bucketName)
+	host := getS3ExpressEndpoint(c.region, bucketName, c.s3DualstackEnabled)
 
 	// as it works in makeTargetURL method from api.go file
 	if h, p, err := net.SplitHostPort(host); err == nil {

--- a/endpoints.go
+++ b/endpoints.go
@@ -223,15 +223,22 @@ var s3ExpressBucketAZID = regexp.MustCompile(`--([a-z0-9]+(?:-[a-z0-9]+)*-az[0-9
 // suffix ("--<zone-id>--x-s3"); the zonal endpoint is derived from it via
 // the regular "s3express-<zone-id>.<region>.amazonaws.com" pattern.
 // Non-S3 Express buckets (or no bucket) use the regional endpoint.
-// Unknown regions return "".
-func getS3ExpressEndpoint(region, bucketName string) (endpoint string) {
+// Unknown regions return "". dualstack selects the dualstack variants
+// (s3express-<zone-id>.dualstack.<region>.amazonaws.com and
+// s3express-control-dualstack.<region>.amazonaws.com).
+func getS3ExpressEndpoint(region, bucketName string, dualstack bool) (endpoint string) {
 	regionalEndpoint, ok := awsS3ExpressEndpointMap[region]
 	if !ok {
 		return ""
 	}
-	m := s3ExpressBucketAZID.FindStringSubmatch(bucketName)
-	if len(m) == 2 {
+	if m := s3ExpressBucketAZID.FindStringSubmatch(bucketName); len(m) == 2 {
+		if dualstack {
+			return "s3express-" + m[1] + ".dualstack." + region + ".amazonaws.com"
+		}
 		return "s3express-" + m[1] + "." + region + ".amazonaws.com"
+	}
+	if dualstack {
+		return "s3express-control-dualstack." + region + ".amazonaws.com"
 	}
 	return regionalEndpoint
 }

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -23,40 +23,47 @@ func TestGetS3ExpressEndpoint(t *testing.T) {
 	tests := []struct {
 		region     string
 		bucketName string
+		dualstack  bool
 		want       string
 	}{
 		// No bucket: regional (control) endpoint.
-		{"us-east-1", "", "s3express-control.us-east-1.amazonaws.com"},
+		{"us-east-1", "", false, "s3express-control.us-east-1.amazonaws.com"},
 		// Non S3 Express bucket: regional endpoint.
-		{"us-east-1", "regular-bucket", "s3express-control.us-east-1.amazonaws.com"},
+		{"us-east-1", "regular-bucket", false, "s3express-control.us-east-1.amazonaws.com"},
 		// S3 Express buckets: the AZ encoded in the bucket name selects
 		// the zonal endpoint.
-		{"us-east-1", "mybucket--use1-az4--x-s3", "s3express-use1-az4.us-east-1.amazonaws.com"},
-		{"us-east-1", "mybucket--use1-az5--x-s3", "s3express-use1-az5.us-east-1.amazonaws.com"},
-		{"eu-west-1", "mybucket--euw1-az3--x-s3", "s3express-euw1-az3.eu-west-1.amazonaws.com"},
-		{"eu-north-1", "mybucket--eun1-az2--x-s3", "s3express-eun1-az2.eu-north-1.amazonaws.com"},
+		{"us-east-1", "mybucket--use1-az4--x-s3", false, "s3express-use1-az4.us-east-1.amazonaws.com"},
+		{"us-east-1", "mybucket--use1-az5--x-s3", false, "s3express-use1-az5.us-east-1.amazonaws.com"},
+		{"eu-west-1", "mybucket--euw1-az3--x-s3", false, "s3express-euw1-az3.eu-west-1.amazonaws.com"},
+		{"eu-north-1", "mybucket--eun1-az2--x-s3", false, "s3express-eun1-az2.eu-north-1.amazonaws.com"},
 		// Frankfurt (eu-central-1): regional and zonal endpoints.
-		{"eu-central-1", "", "s3express-control.eu-central-1.amazonaws.com"},
-		{"eu-central-1", "mybucket--euc1-az2--x-s3", "s3express-euc1-az2.eu-central-1.amazonaws.com"},
+		{"eu-central-1", "", false, "s3express-control.eu-central-1.amazonaws.com"},
+		{"eu-central-1", "mybucket--euc1-az2--x-s3", false, "s3express-euc1-az2.eu-central-1.amazonaws.com"},
 		// Local Zone: the full zone ID (usw2-lax1-az1) selects the zonal
 		// endpoint of the parent region.
-		{"us-west-2", "bucket--usw2-lax1-az1--x-s3", "s3express-usw2-lax1-az1.us-west-2.amazonaws.com"},
+		{"us-west-2", "bucket--usw2-lax1-az1--x-s3", false, "s3express-usw2-lax1-az1.us-west-2.amazonaws.com"},
 		// AZ numbers are not capped at 6 (AWS has since added az7+).
-		{"us-west-2", "mybucket--usw2-az7--x-s3", "s3express-usw2-az7.us-west-2.amazonaws.com"},
+		{"us-west-2", "mybucket--usw2-az7--x-s3", false, "s3express-usw2-az7.us-west-2.amazonaws.com"},
 		// "--" runs in the base name must not confuse zone ID extraction:
 		// the last "-azN" segment wins.
-		{"us-east-1", "mybucket--foo-az1--use1-az4--x-s3", "s3express-use1-az4.us-east-1.amazonaws.com"},
+		{"us-east-1", "mybucket--foo-az1--use1-az4--x-s3", false, "s3express-use1-az4.us-east-1.amazonaws.com"},
 		// AZ not in the region's map: the endpoint is constructed from the
 		// regular "s3express-<az-id>.<region>.amazonaws.com" pattern.
-		{"us-east-1", "mybucket--use1-az6--x-s3", "s3express-use1-az6.us-east-1.amazonaws.com"},
-		{"us-east-1", "mybucket--use2-az1--x-s3", "s3express-use2-az1.us-east-1.amazonaws.com"},
+		{"us-east-1", "mybucket--use1-az6--x-s3", false, "s3express-use1-az6.us-east-1.amazonaws.com"},
+		{"us-east-1", "mybucket--use2-az1--x-s3", false, "s3express-use2-az1.us-east-1.amazonaws.com"},
+		// Dualstack variants, per
+		// https://docs.aws.amazon.com/AmazonS3/latest/userguide/endpoint-directory-buckets-AZ.html
+		{"us-east-1", "", true, "s3express-control-dualstack.us-east-1.amazonaws.com"},
+		{"us-east-1", "mybucket--use1-az4--x-s3", true, "s3express-use1-az4.dualstack.us-east-1.amazonaws.com"},
+		{"us-west-2", "bucket--usw2-lax1-az1--x-s3", true, "s3express-usw2-lax1-az1.dualstack.us-west-2.amazonaws.com"},
 		// Region not in the map: unknown, so no endpoint.
-		{"unknown-region", "mybucket--use1-az4--x-s3", ""},
-		{"unknown-region", "regular-bucket", ""},
+		{"unknown-region", "mybucket--use1-az4--x-s3", false, ""},
+		{"unknown-region", "regular-bucket", false, ""},
+		{"unknown-region", "mybucket--use1-az4--x-s3", true, ""},
 	}
 	for _, tt := range tests {
-		if got := getS3ExpressEndpoint(tt.region, tt.bucketName); got != tt.want {
-			t.Errorf("getS3ExpressEndpoint(%q, %q) = %q, want %q", tt.region, tt.bucketName, got, tt.want)
+		if got := getS3ExpressEndpoint(tt.region, tt.bucketName, tt.dualstack); got != tt.want {
+			t.Errorf("getS3ExpressEndpoint(%q, %q, %v) = %q, want %q", tt.region, tt.bucketName, tt.dualstack, got, tt.want)
 		}
 	}
 }

--- a/pkg/s3utils/utils.go
+++ b/pkg/s3utils/utils.go
@@ -96,11 +96,13 @@ var amazonS3HostFIPS = regexp.MustCompile(`^s3-fips.(.*?).amazonaws.com$`)
 var amazonS3HostFIPSDualStack = regexp.MustCompile(`^s3-fips.dualstack.(.*?).amazonaws.com$`)
 
 // amazonS3HostExpress - regular expression used to determine if an arg is S3 Express zonal endpoint.
-// The zone ID may be an Availability Zone (use1-az4) or a Local Zone (usw2-lax1-az1).
-var amazonS3HostExpress = regexp.MustCompile(`^s3express-[a-z0-9]+(?:-[a-z0-9]+)*-az[0-9]+\.([a-z0-9-]+)\.amazonaws\.com$`)
+// The zone ID may be an Availability Zone (use1-az4) or a Local Zone (usw2-lax1-az1),
+// and the dualstack variant (s3express-<zone-id>.dualstack.<region>.amazonaws.com) is matched as well.
+var amazonS3HostExpress = regexp.MustCompile(`^s3express-[a-z0-9]+(?:-[a-z0-9]+)*-az[0-9]+(?:\.dualstack)?\.([a-z0-9-]+)\.amazonaws\.com$`)
 
 // amazonS3HostExpressControl - regular expression used to determine if an arg is S3 express regional endpoint.
-var amazonS3HostExpressControl = regexp.MustCompile(`^s3express-control\.([a-z0-9-]+)\.amazonaws\.com$`)
+// The dualstack variant (s3express-control-dualstack.<region>.amazonaws.com) is matched as well.
+var amazonS3HostExpressControl = regexp.MustCompile(`^s3express-control(?:-dualstack)?\.([a-z0-9-]+)\.amazonaws\.com$`)
 
 // amazonS3HostDot - regular expression used to determine if an arg is s3 host in . style.
 var amazonS3HostDot = regexp.MustCompile(`^s3.(.*?).amazonaws.com$`)

--- a/pkg/s3utils/utils_test.go
+++ b/pkg/s3utils/utils_test.go
@@ -59,6 +59,10 @@ func TestGetRegionFromURL(t *testing.T) {
 		{u: "s3express-usgw1-az3.us-gov-west-1.amazonaws.com", expectedRegion: "us-gov-west-1"},
 		{u: "s3express-usw2-az7.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
 		{u: "s3express-usw2-lax1-az1.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
+		// Dualstack variants.
+		{u: "s3express-control-dualstack.us-east-1.amazonaws.com", expectedRegion: "us-east-1"},
+		{u: "s3express-use1-az4.dualstack.us-east-1.amazonaws.com", expectedRegion: "us-east-1"},
+		{u: "s3express-usw2-lax1-az1.dualstack.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
 		{u: "s3express-control.us-west-2.amazonaws.com", expectedRegion: "us-west-2"},
 		// S3 on Outposts.
 		{u: "test-access-point-000000000000.op-00000000000000000.s3-outposts.eu-central-1.amazonaws.com", expectedRegion: "eu-central-1"},
@@ -237,6 +241,8 @@ func TestIsAmazonEndpoint(t *testing.T) {
 		{"https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com", true},
 		{"https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com", true},
 		{"https://s3express-usw2-az1.us-west-2.amazonaws.com", true},
+		{"https://s3express-control-dualstack.us-east-1.amazonaws.com", true},
+		{"https://s3express-use1-az4.dualstack.us-east-1.amazonaws.com", true},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
Fixes #2296

AWS documents dualstack variants for every S3 Express endpoint ([Endpoint directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/endpoint-directory-buckets-AZ.html), [Networking for directory buckets in an AZ](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-az-networking.html)):

- Regional: `s3express-control-dualstack.<region>.amazonaws.com`
- Zonal: `s3express-<zone-id>.dualstack.<region>.amazonaws.com` (e.g. `s3express-use1-az4.dualstack.us-east-1.amazonaws.com`)

minio-go only produced the plain forms and ignored the dualstack flag on the S3 Express path, unlike the regular S3 path where `getS3Endpoint` honors `useDualstack` (enabled by default for Amazon S3).

Changes:

- `getS3ExpressEndpoint` now takes the dualstack flag and returns the dualstack variants for both the zonal and the regional endpoint, mirroring `getS3Endpoint`.
- `makeTargetURL` and `createSessionRequest` pass `c.s3DualstackEnabled`.
- The `pkg/s3utils` host-name regexes (`amazonS3HostExpress`, `amazonS3HostExpressControl`) recognize the dualstack forms, so `GetRegionFromURL` and `IsAmazonEndpoint` work on dualstack endpoints (previously they returned "" / false, making a dualstack endpoint unusable).

Tests added for zonal/regional dualstack endpoints (including a Local Zone) and region extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dual-stack endpoint support for Amazon S3 Express.
  - S3 Express now selects appropriate dual-stack endpoints for zonal, regional, and local-zone configurations.

- **Bug Fixes**
  - Improved recognition and validation of dual-stack S3 Express endpoints across supported regions.
  - Preserved existing behavior for standard endpoint configurations and unknown regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->