### PR TITLE
signer: fix streaming signer to include Content-Type in SignedHeaders (fixes #2300)

### DIFF
--- a/pkg/signer/request-signature-streaming.go
+++ b/pkg/signer/request-signature-streaming.go
@@ -48,10 +48,14 @@ const (
 
 // Request headers to be ignored while calculating seed signature for
 // a request.
+//
+// Per AWS SigV4 specification:
+//   "If the Content-Type header is present in the request, you must add it
+//   to the CanonicalHeaders list."
+//   https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
 var ignoredStreamingHeaders = map[string]bool{
 	"Authorization": true,
 	"User-Agent":    true,
-	"Content-Type":  true,
 }
 
 // getSignedChunkLength - calculates the length of chunk metadata

--- a/pkg/signer/request-signature-streaming.go
+++ b/pkg/signer/request-signature-streaming.go
@@ -50,9 +50,10 @@ const (
 // a request.
 //
 // Per AWS SigV4 specification:
-//   "If the Content-Type header is present in the request, you must add it
-//   to the CanonicalHeaders list."
-//   https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
+//
+//	"If the Content-Type header is present in the request, you must add it
+//	to the CanonicalHeaders list."
+//	https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
 var ignoredStreamingHeaders = map[string]bool{
 	"Authorization": true,
 	"User-Agent":    true,


### PR DESCRIPTION
## Summary
Fixes #2300

The streaming SigV4 signer (`StreamingSignV4`) was unconditionally excluding `Content-Type` from `SignedHeaders` via `ignoredStreamingHeaders`, even when `Content-Type` was present on the request. This violates the AWS SigV4 specification.

## Root Cause
```go
// Before (incorrect)
var ignoredStreamingHeaders = map[string]bool{
    "Authorization": true,
    "User-Agent":    true,
    "Content-Type":  true,  // ❌ Wrong: hardcoded exclusion
}
```

## AWS SigV4 Specification
> **"If the Content-Type header is present in the request, you must add it to the CanonicalHeaders list."**
> — https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html

The non-streaming signer (`v4IgnoredHeaders`) correctly does **not** ignore `Content-Type`.

## Evidence
| Source | Finding | Link |
|--------|---------|------|
| **AWS SigV4 Spec** | Spec explicitly requires signing Content-Type when present in request | [docs.aws.amazon.com](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html) |
| **Non-streaming signer** | `v4IgnoredHeaders` omits Content-Type → it gets signed when present | [request-signature-v4.go](https://github.com/minio/minio-go/blob/master/pkg/signer/request-signature-v4.go#L61-L65) |
| **AWS SDK for .NET** | Fixed identical bug in streaming signer | [aws/aws-sdk-net#678](https://github.com/aws/aws-sdk-net/issues/678) |
| **Ceph RGW CVE-2026-54330** | Patched versions (20.2.4+, 19.2.6+) now reject requests with present-but-unsigned headers | [docs.ceph.com](https://docs.ceph.com/en/latest/security/CVE-2026-54330/) |
| **AWS CLI behavior** | Real streaming requests include `content-type` in `SignedHeaders` | [seaweedfs/seaweedfs#6713](https://github.com/seaweedfs/seaweedfs/issues/6713) |
| **StackOverflow** | Community confirms spec requires Content-Type in signature when present | [stackoverflow.com](https://stackoverflow.com/questions/79754009) |

## Impact
- Fixes streaming/chunked uploads to Ceph RGW (Tentacle 20.2.4+, Squid 19.2.6+)
- Fixes compatibility with any S3-compatible backend enforcing SigV4 strictly
- Aligns streaming signer with non-streaming signer behavior

## Testing
- All existing signer tests pass
- Verified `Content-Type` now appears in `SignedHeaders` when present on request