### PR TITLE
fix: honor the caller's TLS trust on the RDMA path

### DIFF
--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -31,11 +31,13 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: minio/minio-cpp
-        # Pinned: this job copies vendor/s3rdma out of the checkout, so a
-        # floating main makes the build race whatever landed there. It already
-        # did -- a run started before minio-cpp vendored libs3rdma and failed
-        # on the missing directory. Bump this when picking up a minio-cpp fix.
-        ref: v1.0.0 # first release carrying miniocpp_client_new_tls, as libminio
+        # Pinned to a commit, like vcpkg and the actions above: this job copies
+        # vendor/s3rdma out of the checkout and installs what it builds, so a
+        # floating ref makes the build race whatever landed there. It already
+        # did -- a run started before minio-cpp vendored libs3rdma and failed on
+        # the missing directory. A tag would still leave that open, since a tag
+        # can be moved after review. Bump this when picking up a minio-cpp fix.
+        ref: 78e1db407d97bf5fc643858d9f4f482bff069696 # tag v1.0.0, first release carrying miniocpp_client_new_tls as libminio
         persist-credentials: false
         path: "minio-cpp"
 

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -35,7 +35,7 @@ jobs:
         # floating main makes the build race whatever landed there. It already
         # did -- a run started before minio-cpp vendored libs3rdma and failed
         # on the missing directory. Bump this when picking up a minio-cpp fix.
-        ref: v0.7.0 # first release carrying the libs3rdma transport
+        ref: v1.0.0 # first release carrying miniocpp_client_new_tls, as libminio
         persist-credentials: false
         path: "minio-cpp"
 

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -52,7 +52,14 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        sudo apt-get -qy update
+        # The runner image ships third-party apt lists -- chrome, microsoft --
+        # that nothing here installs from, and whose indexes intermittently fail
+        # their hash check and take the job down with them. Drop those lists and
+        # retry once; the install below is the real gate, and still fails loudly
+        # if the index is genuinely unusable.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                   /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get -qy update || sudo apt-get -qy update || true
         sudo apt-get -qy install cmake libibverbs-dev
 
     - name: Build and install libminiocpp.so with RDMA

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -24,8 +24,14 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
+    # setup-go pins GOTOOLCHAIN=local, so `go install` can only use the matrix
+    # leg's toolchain -- and govulncheck's own module moves ahead of it. x/vuln
+    # v1.8.0 declares go 1.26.0, which failed the 1.25.x leg outright ("requires
+    # go >= 1.26.0"). Building the tool with GOTOOLCHAIN=auto lets it fetch what
+    # it needs, while the scan below still runs against the matrix leg. Scoped to
+    # this step so nothing else escapes the pinned toolchain.
     - name: Get govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      run: GOTOOLCHAIN=auto go install golang.org/x/vuln/cmd/govulncheck@latest
       shell: bash
     - name: Run govulncheck
       run: govulncheck ./...

--- a/rdma.go
+++ b/rdma.go
@@ -71,8 +71,19 @@ func newRDMAClient(c *Client) (*rdmaClientHandle, error) {
 		useHTTPS = 1
 	}
 
-	cptr := C.miniocpp_client_new(endpoint, region, accessKey, secretKey,
-		sessionToken, useHTTPS)
+	// Carry this client's trust decision across to libminiocpp, which makes the
+	// RDMA path's S3 requests itself and would otherwise verify against the
+	// system store regardless of what the caller configured here.
+	var skipCertCheck C.int
+	if rdmaSkipCertVerify(c.httpClient, c.secure) {
+		skipCertCheck = 1
+	}
+
+	// A CA bundle is left to SSL_CERT_FILE, which libminiocpp reads for every
+	// request: a *x509.CertPool cannot be turned back into the file path this
+	// argument wants.
+	cptr := C.miniocpp_client_new_tls(endpoint, region, accessKey, secretKey,
+		sessionToken, useHTTPS, skipCertCheck, nil)
 	if cptr == nil {
 		return nil, fmt.Errorf("RDMA: %s", lastRDMAError())
 	}

--- a/rdma.go
+++ b/rdma.go
@@ -12,7 +12,7 @@ package minio
 
 // #cgo CFLAGS: -DMINIO_CPP_RDMA
 // #cgo CXXFLAGS: --std=c++17 -DMINIO_CPP_RDMA
-// #cgo LDFLAGS: -lminiocpp
+// #cgo LDFLAGS: -lminio
 // #include <stdlib.h>
 // #include <miniocpp/c_api.h>
 import "C"

--- a/rdma_tls.go
+++ b/rdma_tls.go
@@ -1,0 +1,37 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2024-2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package minio
+
+import "net/http"
+
+// rdmaSkipCertVerify reports whether the RDMA control plane should skip server
+// certificate verification.
+//
+// RDMA transfers are driven by libminiocpp, which issues its own S3 requests
+// instead of going through this package's http.Client. A TLSClientConfig set
+// here therefore governs the HTTP path alone: the C++ client verifies against
+// the OpenSSL trust store and cannot see it. Left unbridged, RDMA fails against
+// exactly the self-signed and private-CA endpoints where the caller's plain S3
+// path succeeds, and no flag rescues it.
+//
+// Derived from the transport rather than configured separately, so a caller's
+// existing --insecure keeps working with no change at the call site. Only
+// *http.Transport can be inspected; a caller that wraps its transport in
+// another RoundTripper still gets verification. A private CA is named by
+// SSL_CERT_FILE in the environment, which libminiocpp reads per request.
+func rdmaSkipCertVerify(hc *http.Client, secure bool) bool {
+	if !secure || hc == nil {
+		return false
+	}
+	tr, ok := hc.Transport.(*http.Transport)
+	if !ok || tr.TLSClientConfig == nil {
+		return false
+	}
+	return tr.TLSClientConfig.InsecureSkipVerify
+}

--- a/rdma_tls_test.go
+++ b/rdma_tls_test.go
@@ -1,0 +1,91 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2024-2026 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package minio
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+type wrappedRoundTripper struct{ inner http.RoundTripper }
+
+func (w wrappedRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return w.inner.RoundTrip(r)
+}
+
+func TestRDMASkipCertVerify(t *testing.T) {
+	insecureTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // the case under test
+	}
+
+	tests := []struct {
+		name   string
+		client *http.Client
+		secure bool
+		want   bool
+	}{
+		// The case this exists for: a caller that opted out of verification
+		// must have that honored on the RDMA path too, or RDMA is the only
+		// thing that fails against a self-signed endpoint.
+		{
+			name:   "insecure transport over https",
+			client: &http.Client{Transport: insecureTransport},
+			secure: true,
+			want:   true,
+		},
+		{
+			name:   "verifying transport over https",
+			client: &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}},
+			secure: true,
+			want:   false,
+		},
+		// No TLS at all: there is nothing to verify, so never claim a skip.
+		{
+			name:   "insecure transport without https",
+			client: &http.Client{Transport: insecureTransport},
+			secure: false,
+			want:   false,
+		},
+		{
+			name:   "transport with no TLS config",
+			client: &http.Client{Transport: &http.Transport{}},
+			secure: true,
+			want:   false,
+		},
+		{
+			name:   "default transport",
+			client: &http.Client{},
+			secure: true,
+			want:   false,
+		},
+		{
+			name:   "nil client",
+			client: nil,
+			secure: true,
+			want:   false,
+		},
+		// A wrapped transport cannot be inspected, so it keeps verification
+		// rather than guessing its way into a weaker setting.
+		{
+			name:   "wrapped insecure transport is not inspectable",
+			client: &http.Client{Transport: wrappedRoundTripper{inner: insecureTransport}},
+			secure: true,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rdmaSkipCertVerify(tt.client, tt.secure); got != tt.want {
+				t.Errorf("rdmaSkipCertVerify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

RDMA transfers are driven by libminiocpp, which issues its own S3 requests rather than going through this package's `http.Client`. A
`TLSClientConfig` set on that client therefore governed the HTTP path alone: the C++ side verified against the OpenSSL trust store and
could not see it.

So an RDMA `PutObject`/`GetObject` failed against exactly the self-signed and private-CA endpoints where the same client's plain S3 calls
worked, and `--insecure` could not rescue it. There is no fallback to the HTTP data path once RDMA is selected
(`api-put-object.go:332`, `api-get-object.go:49` return the error), so the operation failed outright rather than degrading.

## How

The trust decision is carried across to libminiocpp via `miniocpp_client_new_tls`, released in
[minio-cpp v1.0.0](https://github.com/minio/minio-cpp/releases/tag/v1.0.0).

It is **derived from the transport** rather than exposed as a new option, so a caller's existing `--insecure` keeps working with no
call-site change. Only `*http.Transport` can be inspected; a caller that wraps its transport in another `RoundTripper` keeps verification
rather than having this guess its way into a weaker setting.

A private CA is still named by `SSL_CERT_FILE`, which libminiocpp reads per request — a `*x509.CertPool` cannot be turned back into the
file path that argument wants, so `nil` is passed for it.

## The other two commits

**`-lminio`.** minio-cpp 1.0.0 builds the library as `libminio` (with a stable `libminio.so.1` soname), so the link flag follows it. The
RDMA lane pins `v1.0.0`, which is also the first release carrying `miniocpp_client_new_tls` — `v0.7.0` has neither.

**apt hardening.** The lane's `apt-get update` fails the job when the runner image's third-party lists serve a bad index; this cost three
green lanes in minio-cpp within one minute on unrelated code. The lists nothing here installs from are dropped, the update retries once,
and `apt-get install` stays the gate.

## Test

`TestRDMASkipCertVerify` covers the derivation: insecure transport over https, a verifying transport, insecure without https (nothing to
skip), no `TLSClientConfig`, the default transport, a nil client, and a wrapped transport. Forcing the helper to return `false` fails the
insecure-over-https case, so the test guards the behaviour rather than restating it.

The helper is in an **untagged** file on purpose. `rdma_test.go` is `//go:build rdma` and only builds in the RDMA lane, which is why this
gap went unnoticed — the derivation is pure Go and now runs in the ordinary test lane. `go vet -tags rdma` also passes against the
minio-cpp 1.0.0 header, so the cgo call to the new symbol type-checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RDMA transfers now honor the client’s TLS certificate-verification settings.
  * Secure connections verify certificates by default, while explicitly configured insecure connections can skip verification as intended.
  * This aligns TLS behavior between regular and RDMA-based transfers.

* **Tests**
  * Added coverage for secure and insecure TLS configurations, missing or wrapped transports, and nil or default clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->